### PR TITLE
fix: enable selection-to-conversation popup in the markdown editor

### DIFF
--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -141,11 +141,11 @@ export function TextEditor(props: FileViewerProps) {
           ...defaultKeymap,
           ...historyKeymap,
         ]),
-        // Selection popup (the catch-all code viewer only): a non-empty
+        // Selection popup (the code and markdown editors): a non-empty
         // selection anchors the floating "add to conversation" button above
         // its head. Scrolling (geometry/viewport change) or losing focus
         // hides it; typing collapses the selection and hides it too.
-        ...(viewerId === 'code' ? [
+        ...(viewerId === 'code' || viewerId === 'markdown' ? [
           CodeMirrorView.updateListener.of((update) => {
             if (update.geometryChanged || update.viewportChanged) {
               hidePopup()


### PR DESCRIPTION
## 问题

在 markdown 文件的**编辑态**（CodeMirror）里选中文字，不会出现「添加到对话」浮动按钮；只有**预览态**（渲染后 DOM 选区）能插入。原因：编辑器选区弹窗只在 `viewerId === 'code'`（通用代码查看器）时注册，markdown 编辑态被排除。

## 改动

`src/client/TextEditor.tsx` 中把选区弹窗的注册条件放宽：

```diff
- ...(viewerId === 'code' ? [
+ ...(viewerId === 'code' || viewerId === 'markdown' ? [
```

markdown 编辑态由此获得与代码查看器一致的「选中 → 添加到对话」体验，且行号来自编辑器选区（精确），插入格式为 `\`\`\`相对路径:起止行 + 选中文本\`\`\``（>500 字符时仅插 `路径:起止行` 引用），与 `selection-payload.ts` 现有约定一致。

## 验证

- `pnpm typecheck` ✅
- `pnpm test`：382 passed / 22 failed —— 22 个失败全部是 `agent-pty.spec.ts` / `smoke.spec.ts` 的 node-pty `posix_spawnp failed`（沙箱环境无法 spawn PTY，基线分支同样失败，与本次改动无关）；客户端组件测试（selection-payload、markdown-copy-labels、sandbox-views 等）全部通过
- `pnpm build`（tsdown）后 `lib/client-editor.js` 已包含新条件
- 已在本机安装包中同步打补丁，重启 DSH 后人工验证 markdown 编辑态选区弹窗生效