### PR TITLE
fix: install.ps1 兼容 PowerShell 5.1（node -e 引号被吞 + UTF-8 BOM）

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-# =============================================================================
+﻿# =============================================================================
 # dsh-better-sidebar 一键安装脚本（官方 CLI 方式，Windows PowerShell 5.1+ / pwsh）
 #
 # 通过 DSH 官方插件命令安装 npm 包并自动挂载：
@@ -118,7 +118,7 @@ if ($DryRun) {
 # 步骤 1：预写 workspace 设置（幂等），保证 pnpm 不拦截构建、放行本插件新版本
 $wsScript = @'
 const fs = require("fs");
-const p = process.argv[1];
+const p = process.argv[2];
 let t = fs.readFileSync(p, "utf8");
 const before = t;
 t = t.replace(/^(\s*)(node-pty|protobufjs):.*$/gm, "$1$2: true");
@@ -141,8 +141,14 @@ if (!/^\s*-\s+dsh-better-sidebar\s*$/m.test(t)) {
 if (t !== before) fs.writeFileSync(p, t);
 console.log(t === before ? "unchanged" : "updated");
 '@
-$wsOut = node -e $wsScript "$WS_YML" 2>&1
+# PowerShell 5.1 把含内嵌双引号的多行 JS 作为参数传给 `node -e` 时，引号会被
+# Windows 命令行解析吞掉，导致 JS 语法错误（Expected ',', got ':'）。
+# 改用临时文件方式，兼容 PS 5.1 与 pwsh 7。
+$wsJs = Join-Path $env:TEMP ("dshbs-ws-" + [guid]::NewGuid().ToString("N") + ".js")
+Set-Content -LiteralPath $wsJs -Value $wsScript -Encoding UTF8
+$wsOut = node $wsJs "$WS_YML" 2>&1
 $wsCode = $LASTEXITCODE
+Remove-Item -LiteralPath $wsJs -Force -ErrorAction SilentlyContinue
 $wsResult = (($wsOut | Out-String)).Trim()
 if ($wsCode -ne 0) { Die "处理 $WS_YML 失败（node 退出码 $wsCode）：$wsResult" }
 if ($wsResult -eq 'updated') {
@@ -181,7 +187,7 @@ Say "bundle 已注册：dsh.profile.bundles 包含 $PKG（下次启动自动挂�
 # 步骤 4：幂等移除旧的 manual 挂载行（避免与 bundle 双挂载）
 $mountScript = @'
 const fs = require("fs");
-const p = process.argv[1];
+const p = process.argv[2];
 const lines = fs.readFileSync(p, "utf8").split("\n");
 const out = [];
 let i = 0;
@@ -213,8 +219,11 @@ if (!removed) {
   console.log("removed");
 }
 '@
-$mountOut = node -e $mountScript "$PATCH_YML" 2>&1
+$mountJs = Join-Path $env:TEMP ("dshbs-mount-" + [guid]::NewGuid().ToString("N") + ".js")
+Set-Content -LiteralPath $mountJs -Value $mountScript -Encoding UTF8
+$mountOut = node $mountJs "$PATCH_YML" 2>&1
 $mountCode = $LASTEXITCODE
+Remove-Item -LiteralPath $mountJs -Force -ErrorAction SilentlyContinue
 $mountResult = (($mountOut | Out-String)).Trim()
 if ($mountCode -ne 0) { Die "处理 $PATCH_YML 失败（node 退出码 $mountCode）：$mountResult" }
 if ($mountResult -eq 'removed') {


### PR DESCRIPTION
## 问题

`irm ... | iex` 一键安装在 **Windows 默认的 PowerShell 5.1** 下必挂，报错：

```
t = t.replace(/^(\s*)(node-pty|protobufjs):.*$/gm, $1$2:
                                                   ^^^^
Expected ',', got ':'
```

原因有两层：

1. **`node -e` 传参被 PS 5.1 吞引号**：第 144/216 行用 `node -e $wsScript "$WS_YML"` 把多行 JS（内含大量 `"`）作为参数传给 node。PowerShell 5.1（及 7.0–7.2）给原生命令传参时**不转义参数内的双引号**，Windows 命令行解析（CommandLineToArgvW）把 JS 里的 `"` 当分隔符吃掉，node 收到残缺的 JS（如 `"$1$2: true"` 变成 `$1$2: true`）→ 语法错误。该缺陷在 PowerShell 7.3+ 才修复（PSNativeCommandArgumentPassing）。
2. **文件无 BOM**：README 文档化了 `powershell -File install.ps1` 的用法，但文件是无 BOM 的 UTF-8，PS 5.1 从磁盘加载时按 ANSI/GBK 解码 → 中文乱码、脚本解析失败。`irm | iex` 走内存解码所以没暴露。

## 修复

- 两处 `node -e $script` 改为：写临时 `.js` 文件 → `node file.js` → 删除，彻底绕开 PS 5.1 的原生参数引号缺陷；对应 `process.argv[1]` → `process.argv[2]`；
- 文件补 **UTF-8 BOM**，PS 5.1 `-File` 直跑时正确识别编码。

## 验证

- PowerShell 5.1（5.1.26100）本机实测：`-DryRun` 与完整安装均跑通（幂等重跑：workspace 设置已就绪 / bundle 已注册 / 无旧挂载行）；
- 与原行为的差异仅限上述两处，JS 逻辑、幂等性不变；
- `irm | iex` 与 `powershell -File` 两种用法现在都兼容 PS 5.1 与 pwsh 7。
