### PR TITLE
fix: install.sh 变量加花括号（$WS_YML：→ ${WS_YML}），修复 macOS bash 3.2 unbound variable（#23）

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,7 +164,7 @@ if (t !== before) fs.writeFileSync(p, t);
 console.log(t === before ? "unchanged" : "updated");
 ' "$WS_YML")"
 [ "$WS_RESULT" = "updated" ] \
-  && say "已确保 $WS_YML：allowBuilds（node-pty/protobufjs: true）+ minimumReleaseAgeExclude（${PKG}）" \
+  && say "已确保 ${WS_YML}：allowBuilds（node-pty/protobufjs: true）+ minimumReleaseAgeExclude（${PKG}）" \
   || say "workspace 设置已就绪，跳过"
 
 # 步骤 2：官方 CLI 安装 + bundle 自动注册（含挂载）


### PR DESCRIPTION
## 修复内容

[#23](https://github.com/omdsh-dev/DSH-better-sidebar/issues/23)：一键安装脚本在 macOS 报 `bash: line 167: WS_YML�: unbound variable`。

### 根因

`scripts/install.sh` 第 167 行 `say "已确保 $WS_YML：..."` 的 `$WS_YML` 后紧跟全角冒号且未加花括号。macOS 默认 bash 3.2 的解析器会把全角冒号（U+FF1A）**并入变量名**，脚本头部 `set -euo pipefail` 触发 nounset 致命错误。

### 改动

- `$WS_YML：` → `${WS_YML}：`（花括号显式划定变量名边界，一行改动）

### 验证

- 已在 macOS 默认 bash 3.2 复现：旧写法 `set -u` 下报 `WS_YML�: unbound variable`（与 issue 报告一致）；新写法正常输出。
- `bash -n` 语法检查通过；已确认全脚本仅此一处该模式（install.ps1 的 PowerShell 语义不同且无 nounset 致命错误，不受影响）。