### PR TITLE
ci: add GitHub Actions workflow (tests + type/build checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Test
+        run: pnpm test
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Tests run git log against this repository and need the full history.
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
           version: 11
@@ -18,6 +21,13 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      # The plugin's git revert/cherry-pick spawn git without setting an
+      # identity (deliberate, see tests/smoke.spec.ts) and rely on ambient
+      # config; the runner has none by default.
+      - name: Configure git identity for tests
+        run: |
+          git config --global user.name "dsh-better-sidebar-ci"
+          git config --global user.email "ci@dsh.invalid"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Tests run git log against this repository and need the full history.
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/README.md
+++ b/README.md
@@ -250,3 +250,4 @@ Windows / Linux / macOS 三平台适配（macOS 日常验证；其余经单元�
 ## 🔗 友情链接
 
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui)：DeepSeek Harness 交互式终端 UI 插件（渲染核心由自研 harness agent Tianshu-Tui 演进而来），在官方基础上增加 TDD 与证据门等工作流
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI)：Claude Code 风格全屏交互终端插件——像素鲸鱼顶栏、实时工作状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表，npm 一键安装

--- a/README.md
+++ b/README.md
@@ -251,3 +251,4 @@ Windows / Linux / macOS 三平台适配（macOS 日常验证；其余经单元�
 
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui)：DeepSeek Harness 交互式终端 UI 插件（渲染核心由自研 harness agent Tianshu-Tui 演进而来），在官方基础上增加 TDD 与证据门等工作流
 - [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI)：Claude Code 风格全屏交互终端插件——像素鲸鱼顶栏、实时工作状态行、思考流式展开、双击 Esc 回滚、上下文进度条 + TPS 仪表，npm 一键安装
+- [dshfind 插件超市](https://dshfind.com/zh/plugins)：三方插件市场——GitHub topic `dsh-plugin` 下的公开仓库清单，每日同步 star、贡献者与增长数据

--- a/README_EN.md
+++ b/README_EN.md
@@ -252,3 +252,4 @@ Windows / Linux / macOS (macOS validated daily; the rest covered by unit tests);
 
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui): an interactive terminal UI plugin for DeepSeek Harness (its rendering core evolved from the self-developed harness agent Tianshu-Tui), adding TDD and evidence-gate workflows on top of the official harness
 - [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI): a Claude Code-style fullscreen interactive TUI plugin — pixel-whale top bar, live working-status row, streaming thought expansion, double-Esc rollback, context progress bar + TPS meter; one-command npm install
+- [dshfind Plugin Market](https://dshfind.com/zh/plugins): a third-party plugin marketplace — a listing of public repos under the GitHub topic `dsh-plugin`, with stars, contributors and growth data synced daily

--- a/README_EN.md
+++ b/README_EN.md
@@ -251,3 +251,4 @@ Windows / Linux / macOS (macOS validated daily; the rest covered by unit tests);
 ## 🔗 Friends
 
 - [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui): an interactive terminal UI plugin for DeepSeek Harness (its rendering core evolved from the self-developed harness agent Tianshu-Tui), adding TDD and evidence-gate workflows on top of the official harness
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI): a Claude Code-style fullscreen interactive TUI plugin — pixel-whale top bar, live working-status row, streaming thought expansion, double-Esc rollback, context progress bar + TPS meter; one-command npm install

--- a/tests/unit.spec.ts
+++ b/tests/unit.spec.ts
@@ -861,8 +861,10 @@ describe('pty helpers', () => {
   })
 
   it('restores the spawn-helper executable bit idempotently', () => {
-    // On non-Windows the helper must exist and be executable after the fix.
-    if (process.platform === 'win32') return
+    // node-pty's spawn-helper is a macOS-only artifact: binding.gyp builds
+    // the executable only for OS=="mac", and no other platform ships one to
+    // restore (linux uses forkpty directly). Skip elsewhere.
+    if (process.platform !== 'darwin') return
     ensureSpawnHelper()
     ensureSpawnHelper()
     const { existsSync, statSync } = require('node:fs') as typeof import('node:fs')
@@ -870,9 +872,8 @@ describe('pty helpers', () => {
     const { createRequire } = require('node:module') as typeof import('node:module')
     const entry = createRequire(import.meta.url).resolve('node-pty')
     const root = dirname(dirname(entry))
-    // node-pty ships a prebuilt spawn-helper for darwin/win32; on other
-    // platforms (linux) node-gyp compiles it into build/Release. Mirror
-    // ensureSpawnHelper's candidate list: either location is acceptable.
+    // Prebuilt (tarball) or node-gyp-compiled (build/Release): mirror
+    // ensureSpawnHelper's candidate list — either location is acceptable.
     const candidates = [
       join(root, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper'),
       join(root, 'build', 'Release', 'spawn-helper'),

--- a/tests/unit.spec.ts
+++ b/tests/unit.spec.ts
@@ -865,15 +865,21 @@ describe('pty helpers', () => {
     if (process.platform === 'win32') return
     ensureSpawnHelper()
     ensureSpawnHelper()
-    const { existsSync } = require('node:fs') as typeof import('node:fs')
+    const { existsSync, statSync } = require('node:fs') as typeof import('node:fs')
     const { dirname, join } = require('node:path') as typeof import('node:path')
     const { createRequire } = require('node:module') as typeof import('node:module')
     const entry = createRequire(import.meta.url).resolve('node-pty')
     const root = dirname(dirname(entry))
-    const helper = join(root, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')
-    expect(existsSync(helper)).toBe(true)
-    const { statSync } = require('node:fs') as typeof import('node:fs')
-    expect((statSync(helper).mode & 0o111) !== 0).toBe(true)
+    // node-pty ships a prebuilt spawn-helper for darwin/win32; on other
+    // platforms (linux) node-gyp compiles it into build/Release. Mirror
+    // ensureSpawnHelper's candidate list: either location is acceptable.
+    const candidates = [
+      join(root, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper'),
+      join(root, 'build', 'Release', 'spawn-helper'),
+    ]
+    const helper = candidates.find(existsSync)
+    expect(helper).toBeTruthy()
+    expect((statSync(helper!).mode & 0o111) !== 0).toBe(true)
   })
 })
 


### PR DESCRIPTION
## 变更

新增 `.github/workflows/ci.yml`：对 push 到 main 与所有 PR 自动运行

1. `pnpm install --frozen-lockfile`（lockfile 漂移即失败）
2. `pnpm typecheck`（tsc --noEmit，代码质量检查）
3. `pnpm test`（vitest，32 文件 / 422 用例）
4. `pnpm build`（tsc + tsdown 构建门禁）

## 设计要点

- 复用仓库现有 scripts，**零新增依赖**，不引入 lint 工具
- checkout@v7（`fetch-depth: 0` 完整历史）+ pnpm/action-setup@v6（pnpm 11）+ setup-node@v7（Node 22 LTS）+ pnpm store 缓存
- 无 secrets；测试已 stub fetch，无网络依赖
- node-pty/protobufjs 构建脚本由 `pnpm-workspace.yaml` 的 `allowBuilds` 放行

## 附带修复（CI 首跑暴露的 Linux runner 环境问题）

- **浅克隆**：checkout 默认 depth 1，`git log` 分页测试需要 ≥5 条历史 → `fetch-depth: 0`
- **git 身份**：`src/git.ts` 有意不设身份（测试注释明示），revert/cherry-pick 依赖环境全局配置；runner 默认无 → workflow 增加 `git config --global` 步骤
- **spawn-helper 测试**：node-pty@1.1.0 的 npm tarball 只带 darwin/win32 预编译产物（已从官方 registry 下载 tarball 验证；GitHub release v1.1.0 也无 assets；参考 deepseek-ai/deepseek-harness#605 同款问题），且 binding.gyp 仅在 `OS=="mac"` 构建 spawn-helper → 测试断言改为仅限 macOS（helper 唯一存在平台），与 `ensureSpawnHelper` 候选路径一致

## 本地已验证

- `pnpm typecheck` ✅ / `pnpm test` ✅（32 files / 422 tests）/ `pnpm build` ✅
- CI 全绿（run 31785885137，54s）；升级 action 后重新验证中