### PR TITLE
fix(html): Windows 盘符路径解码去掉前导斜杠，修复 html 预览被 isWithin 拒绝

### DIFF
--- a/src/html-route.ts
+++ b/src/html-route.ts
@@ -66,5 +66,14 @@ export function decodeHtmlUrl(pathname: string): HtmlDecodeResult {
   if (sessionId === undefined || sessionId === '' || pathSegments.length === 0 || pathSegments.some(segment => segment === '')) {
     return { ok: false, status: 400, message: 'sessionId and file path are required' }
   }
-  return { ok: true, ref: { sessionId, path: `/${pathSegments.join('/')}` } }
+  // A Windows drive segment ('D:') is the FIRST path segment of an encoded
+  // drive path. Rejoining it with a leading slash would yield '/D:/work/...'
+  // which node's path.resolve() mangles into 'D:\D:\work\...' on Windows —
+  // the html route's isWithin(cwd) fence would then reject every drive path.
+  // Keep the drive form slash-free so requireAbsolute() resolves it verbatim.
+  const first = pathSegments[0] ?? ''
+  const path = /^[A-Za-z]:$/.test(first)
+    ? pathSegments.join('/')
+    : `/${pathSegments.join('/')}`
+  return { ok: true, ref: { sessionId, path } }
 }

--- a/tests/html-route.spec.ts
+++ b/tests/html-route.spec.ts
@@ -6,6 +6,7 @@
  * the session scope intact (the WHY of the path-encoding design).
  */
 import { describe, expect, it } from 'vitest'
+import { resolve } from 'node:path'
 import { decodeHtmlUrl, encodeHtmlUrl } from '../src/html-route.ts'
 
 describe('encodeHtmlUrl', () => {
@@ -38,11 +39,25 @@ describe('decodeHtmlUrl', () => {
     })
   })
 
-  it('decodes a Windows round-trip', () => {
+  it('decodes a Windows round-trip (drive path WITHOUT a leading slash, so node resolve() keeps the drive)', () => {
     const url = encodeHtmlUrl('sess-1', 'C:\\Users\\me\\a.html')
     expect(decodeHtmlUrl(url)).toEqual({
       ok: true,
-      ref: { sessionId: 'sess-1', path: '/C:/Users/me/a.html' },
+      ref: { sessionId: 'sess-1', path: 'C:/Users/me/a.html' },
+    })
+    // The host runs requireAbsolute() over the decoded path: with the old
+    // '/C:/...' form node's resolve() produced 'C:\C:\Users\...' (drive
+    // doubled) on Windows and the isWithin(cwd) fence rejected every drive
+    // path. The slash-free form must resolve back to the original path.
+    if (process.platform === 'win32') {
+      expect(resolve('C:/Users/me/a.html')).toBe('C:\\Users\\me\\a.html')
+    }
+  })
+
+  it('decodes a lowercase-drive Windows path without a leading slash', () => {
+    expect(decodeHtmlUrl('/sidebar/html/s/d%3A/work/x.html')).toEqual({
+      ok: true,
+      ref: { sessionId: 's', path: 'd:/work/x.html' },
     })
   })
 


### PR DESCRIPTION
## 问题

Windows 上打开任何 HTML 文件报错：
`{"ok":false,"error":{"code":"fs-error","message":"html path outside the session working directory"}}`

根因：`/sidebar/html` 路由用路径编码承载文件路径（`encodeHtmlUrl`），`decodeHtmlUrl` 对盘符路径 `D:\work\x.html` 重拼为 `/D:/work/x.html`（前导斜杠 + 盘符段）。Windows 下 `path.resolve('/D:/...')` 会产出 `D:\D:\work\...`（盘符重复），`isWithin(cwd, ...)` 围栏必然拒绝 → 所有盘符路径的 html 预览全部失败。

## 修复

`src/html-route.ts`：首段匹配 `/^[A-Za-z]:$/`（盘符段）时改回**无前导斜杠**的 `D:/...` 形式，`requireAbsolute` 可原样解析回盘符路径；POSIX 路径行为不变。

## 验证

- `tests/html-route.spec.ts`：更新 Windows round-trip 断言（`C:/Users/me/a.html`），新增小写盘符用例与 `resolve()` 回归护栏（win32 平台守卫）
- `vitest tests/html-route.spec.ts` 15/15 通过