### PR TITLE
fix(installer): 修复 PowerShell 远程入口 BOM 解析与 pnpm 版本校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ curl -fsSL https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/s
 **Windows（PowerShell 5.1+ / pwsh）**：
 
 ```powershell
-irm https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1 | iex
+$script = (
+  irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'
+).TrimStart([char]0xFEFF)
+& ([scriptblock]::Create($script))
 ```
 
 装完**硬刷新浏览器**（Cmd/Ctrl+Shift+R）即可看到侧边栏（DSH 对 client 改动热加载，无需重启；仅 host 半更新时需要重启）。
@@ -65,7 +68,10 @@ irm https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/
 curl -fsSL https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.sh | bash -s 0.10.3 --restart
 
 # Windows PowerShell
-& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'))) -Version 0.10.3 -Restart
+$script = (
+  irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'
+).TrimStart([char]0xFEFF)
+& ([scriptblock]::Create($script)) -Version 0.10.3 -Restart
 ```
 
 不确定的话，可先加 `--dry-run`（PowerShell 用 `-DryRun`）预览步骤再执行。
@@ -122,7 +128,7 @@ npx -y --package @deepseek-ai/dsh dsh plugin --profile web add dsh-better-sideba
 3. 执行 `dsh plugin --profile web add dsh-better-sidebar`：登记依赖 → 识别包内 `dsh.bundle.patch` → 自动注册进 `dsh.profile.bundles` 挂载；
 4. 清理旧版残留的手动挂载行，避免「双挂载」（页面出现两个侧边栏）。
 
-`curl | bash` / `irm | iex` 会执行远程代码——脚本已随仓库开源（`scripts/install.sh` / `scripts/install.ps1`），可先下载审阅。插件以 npm 包 `dsh-better-sidebar@0.10.3` 发布，通过 `dsh.bundle.patch`（随包的 `cordis.patch.yml`）由官方 CLI 自动挂载，**不修改 DSH 源码**。
+上述一键命令会下载并执行远程代码——脚本已随仓库开源（`scripts/install.sh` / `scripts/install.ps1`），可先下载审阅。PowerShell 入口会先移除 UTF-8 BOM，再创建 ScriptBlock，以确保参数在 PowerShell 5.1 和 pwsh 中都能正确绑定。插件以 npm 包 `dsh-better-sidebar@0.10.3` 发布，通过 `dsh.bundle.patch`（随包的 `cordis.patch.yml`）由官方 CLI 自动挂载，**不修改 DSH 源码**。
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,7 +53,10 @@ curl -fsSL https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/s
 **Windows (PowerShell 5.1+ / pwsh)**:
 
 ```powershell
-irm https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1 | iex
+$script = (
+  irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'
+).TrimStart([char]0xFEFF)
+& ([scriptblock]::Create($script))
 ```
 
 Then **hard-refresh the browser** (Cmd/Ctrl+Shift+R) to see the sidebar (DSH hot-reloads client changes; only host-half updates need a restart).
@@ -66,7 +69,10 @@ Then **hard-refresh the browser** (Cmd/Ctrl+Shift+R) to see the sidebar (DSH hot
 curl -fsSL https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.sh | bash -s 0.10.3 --restart
 
 # Windows PowerShell
-& ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'))) -Version 0.10.3 -Restart
+$script = (
+  irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'
+).TrimStart([char]0xFEFF)
+& ([scriptblock]::Create($script)) -Version 0.10.3 -Restart
 ```
 
 Not sure? Add `--dry-run` (`-DryRun` in PowerShell) to preview before running.
@@ -123,7 +129,7 @@ The one-click script does four things, all idempotent (safe to re-run):
 3. Runs `dsh plugin --profile web add dsh-better-sidebar`: registers the dependency → detects `dsh.bundle.patch` → auto-appends the plugin to `dsh.profile.bundles`;
 4. Removes any leftover hand-written mount line to avoid double-mounting (two sidebars on the page).
 
-`curl | bash` / `irm | iex` executes remote code — the scripts are open source in the repo (`scripts/install.sh` / `scripts/install.ps1`); download and review them first if you prefer. The plugin ships as npm package `dsh-better-sidebar@0.10.3` and mounts via `dsh.bundle.patch` (the shipped `cordis.patch.yml`), so the DSH source is never modified.
+The one-click commands above download and execute remote code. The scripts are open source in the repo (`scripts/install.sh` / `scripts/install.ps1`), so you can download and review them first. The PowerShell entry point removes the UTF-8 BOM before creating the ScriptBlock, which keeps parameter binding correct in both Windows PowerShell 5.1 and pwsh. The plugin ships as npm package `dsh-better-sidebar@0.10.3` and mounts via `dsh.bundle.patch` (the shipped `cordis.patch.yml`), so the DSH source is never modified.
 
 </details>
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,9 +11,11 @@
 #
 # 用法（任选其一）：
 #   # 默认最新版
-#   irm https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1 | iex
+#   $script = (irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1').TrimStart([char]0xFEFF)
+#   & ([scriptblock]::Create($script))
 #   # 指定版本 / 装完重启
-#   & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'))) -Version 0.10.2 -Restart
+#   $script = (irm 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1').TrimStart([char]0xFEFF)
+#   & ([scriptblock]::Create($script)) -Version 0.10.2 -Restart
 #   # 本地保存后运行
 #   powershell -ExecutionPolicy Bypass -File install.ps1 -Version 0.10.2 -DryRun
 #
@@ -91,6 +93,21 @@ function Get-DshCli {
 # 前置校验
 if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
   Die '未找到 node（DSH 运行需要 Node.js >= 20），请先安装 Node.js 并加入 PATH。'
+}
+if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+  Die '未找到 pnpm；安装脚本需要 pnpm >= 10。请先安装或升级 pnpm 并加入 PATH。'
+}
+$pnpmVersion = (& pnpm --version 2>$null | Select-Object -Last 1)
+if ($LASTEXITCODE -ne 0 -or -not $pnpmVersion) {
+  Die '无法读取 pnpm 版本；安装脚本需要 pnpm >= 10。'
+}
+$pnpmVersionText = ([string]$pnpmVersion).Trim()
+$pnpmMajor = 0
+if (-not [int]::TryParse(($pnpmVersionText -split '\.')[0], [ref]$pnpmMajor)) {
+  Die "无法解析 pnpm 版本（输出：$pnpmVersionText）；安装脚本需要 pnpm >= 10。"
+}
+if ($pnpmMajor -lt 10) {
+  Die "安装脚本需要 pnpm >= 10；当前版本为 $pnpmVersionText。请升级 pnpm 后重试。"
 }
 if (-not (Test-Path $PROFILE_DIR)) {
   Die "找不到 profile 目录：$PROFILE_DIR（请先安装并运行过一次 dsh web）"

--- a/tests/install-powershell.spec.ts
+++ b/tests/install-powershell.spec.ts
@@ -1,0 +1,130 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const INSTALLER = resolve(ROOT, 'scripts/install.ps1')
+const INSTALLER_URL = 'https://raw.githubusercontent.com/omdsh-dev/DSH-better-sidebar/main/scripts/install.ps1'
+const tempDirs: string[] = []
+const hasPwsh = process.platform === 'win32'
+  && spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-Command', 'exit 0'], { stdio: 'ignore' }).status === 0
+
+interface InstallerFixture {
+  home: string
+  path: string
+  workspace: string
+}
+
+function createFixture(pnpmVersion: string): InstallerFixture {
+  const root = mkdtempSync(join(tmpdir(), 'dshbs-install-'))
+  tempDirs.push(root)
+  const home = join(root, 'home')
+  const profile = join(home, 'profiles', 'web')
+  const bin = join(root, 'bin')
+  mkdirSync(profile, { recursive: true })
+  mkdirSync(bin)
+  const workspace = 'packages:\n  - .\n'
+  writeFileSync(join(profile, 'pnpm-workspace.yaml'), workspace)
+  writeFileSync(join(bin, 'pnpm.cmd'), `@echo off\r\necho ${pnpmVersion}\r\n`)
+  return {
+    home,
+    workspace,
+    path: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+  }
+}
+
+function runPowerShell(executable: string, args: string[], fixture: InstallerFixture) {
+  return spawnSync(executable, ['-NoLogo', '-NoProfile', ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DSH_CMD: 'dsh',
+      DSH_HOME: fixture.home,
+      INSTALLER_PATH: INSTALLER,
+      PATH: fixture.path,
+    },
+  })
+}
+
+function assertInMemoryInvocation(executable: string): void {
+  const fixture = createFixture('10.34.5')
+  const command = [
+    '$bytes = [IO.File]::ReadAllBytes($env:INSTALLER_PATH)',
+    '$script = [Text.Encoding]::UTF8.GetString($bytes).TrimStart([char]0xFEFF)',
+    '& ([scriptblock]::Create($script)) -Version 0.11.0 -DryRun',
+  ].join('; ')
+  const result = runPowerShell(executable, ['-Command', command], fixture)
+  const output = `${result.stdout}\n${result.stderr}`
+
+  expect(result.status, output).toBe(0)
+  expect(output).toContain('dsh-better-sidebar@0.11.0')
+  expect(output).toContain('[dry-run]')
+  expect(output).not.toContain('False False')
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('PowerShell installer entry points', () => {
+  it('keeps the UTF-8 BOM required by Windows PowerShell 5.1 -File decoding', () => {
+    expect(readFileSync(INSTALLER).subarray(0, 3)).toEqual(Buffer.from([0xef, 0xbb, 0xbf]))
+  })
+
+  it('documents only BOM-safe in-memory invocation', () => {
+    for (const file of ['README.md', 'README_EN.md', 'scripts/install.ps1']) {
+      const source = readFileSync(resolve(ROOT, file), 'utf8')
+      expect(source, file).not.toMatch(new RegExp(`irm [^\\r\\n]*${INSTALLER_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\r\\n]*\\|\\s*iex`, 'i'))
+      expect(source, file).not.toMatch(/\[scriptblock\]::Create\(\(irm\b/i)
+      expect(source.match(/\.TrimStart\(\[char\]0xFEFF\)/g)?.length, file).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('keeps the versioned installer usage example self-contained', () => {
+    const source = readFileSync(INSTALLER, 'utf8')
+    const versionedExample = source.slice(
+      source.indexOf('#   # 指定版本 / 装完重启'),
+      source.indexOf('#   # 本地保存后运行'),
+    )
+
+    expect(versionedExample).toContain(INSTALLER_URL)
+    expect(versionedExample).toContain('.TrimStart([char]0xFEFF)')
+    expect(versionedExample).toContain('-Version 0.10.2 -Restart')
+  })
+
+  it.runIf(process.platform === 'win32')('binds parameters when loaded into memory by Windows PowerShell 5.1', () => {
+    assertInMemoryInvocation('powershell.exe')
+  })
+
+  it.runIf(hasPwsh)('binds parameters when loaded into memory by pwsh, when available', () => {
+    assertInMemoryInvocation('pwsh')
+  })
+
+  it.runIf(process.platform === 'win32')('retains the Windows PowerShell 5.1 -File entry point', () => {
+    const fixture = createFixture('10.34.5')
+    const result = runPowerShell('powershell.exe', [
+      '-ExecutionPolicy', 'Bypass', '-File', INSTALLER, '-Version', '0.11.0', '-DryRun',
+    ], fixture)
+    const output = `${result.stdout}\n${result.stderr}`
+
+    expect(result.status, output).toBe(0)
+    expect(output).toContain('dsh-better-sidebar@0.11.0')
+    expect(output).toContain('[dry-run]')
+  })
+
+  it.runIf(process.platform === 'win32')('rejects pnpm 8 before changing the profile', () => {
+    const fixture = createFixture('8.15.9')
+    const workspacePath = join(fixture.home, 'profiles', 'web', 'pnpm-workspace.yaml')
+    const result = runPowerShell('powershell.exe', [
+      '-ExecutionPolicy', 'Bypass', '-File', INSTALLER, '-Version', '0.11.0', '-DryRun',
+    ], fixture)
+    const output = `${result.stdout}\n${result.stderr}`
+
+    expect(result.status, output).toBe(1)
+    expect(output).toContain('pnpm >= 10')
+    expect(readFileSync(workspacePath, 'utf8')).toBe(fixture.workspace)
+  })
+})


### PR DESCRIPTION
## 问题

Windows PowerShell 安装入口存在两类问题：

1. `scripts/install.ps1` 为兼容 Windows PowerShell 5.1 的 `-File` 模式带有 UTF-8 BOM，但 README 和脚本注释中的远程执行命令直接把下载结果交给 `iex` 或 `ScriptBlock.Create`。BOM 会被解析成 `﻿#` 命令，并导致 `param(...)` 不再位于脚本起点，出现命令报错或 `-Version`、`-DryRun` 等参数失效。
2. README 声明需要 pnpm >= 10，但脚本此前只检查 pnpm 是否存在。使用 pnpm 8 时，会在安装阶段才出现 `ERR_PNPM_ADDING_TO_ROOT`，且脚本已经开始处理 profile 配置。

## 修复

- PowerShell 远程入口统一调整为：
  1. 使用 `irm` 下载脚本文本；
  2. 调用 `.TrimStart([char]0xFEFF)` 移除 BOM；
  3. 通过 `ScriptBlock.Create` 执行。
- 保留脚本的 UTF-8 BOM，继续兼容 Windows PowerShell 5.1 的 `-File` 入口。
- 默认安装与指定版本示例均可独立复制执行。
- 在版本解析、profile 写入和安装前检查 `pnpm --version`：
  - 未安装、版本读取失败或无法解析时给出明确错误；
  - 主版本低于 10 时提示升级并以退出码 1 结束。
- 同步更新中英文 README。
- 新增 PowerShell 安装入口回归测试。

## 验证

- `pnpm vitest run tests/install-powershell.spec.ts`：7/7 通过
  - UTF-8 BOM 保留
  - Windows PowerShell 5.1 `-File` 执行
  - Windows PowerShell 5.1 内存执行及参数绑定
  - 安装了 pwsh 时额外验证 pwsh 内存执行
  - pnpm 8 在修改 profile 前被拒绝
  - 文档入口均执行 BOM 清理
  - 指定版本示例保持自包含
- `pnpm typecheck`：通过
- `git diff --check`：通过
- 原问题 Windows 机器实测：
  - 正确识别 `dsh-better-sidebar@0.11.0`
  - `-DryRun` 正常执行
  - 退出码为 0

## 关联

Related to #44
