### PR TITLE
fix: 终端 Tab 使用账户 login shell 并以 login 模式启动

### DIFF
--- a/src/agent-pty.ts
+++ b/src/agent-pty.ts
@@ -13,7 +13,7 @@
  */
 import { randomUUID } from 'node:crypto'
 import * as nodePty from 'node-pty'
-import { ensureSpawnHelper } from './pty-manager.ts'
+import { ensureSpawnHelper, shellSpawnArgs } from './pty-manager.ts'
 import { SidebarError } from './wire.ts'
 
 /** Per-agent-terminal transcript bound (bytes kept for replay and reads). */
@@ -211,7 +211,7 @@ export class AgentPtyRegistry {
   ): string {
     const uuid = randomUUID()
     const dims = clampDims(cols, rows)
-    const pty = nodePty.spawn(this.shell, [], {
+    const pty = nodePty.spawn(this.shell, shellSpawnArgs(), {
       name: 'xterm-256color',
       cols: dims.cols,
       rows: dims.rows,

--- a/src/pty-manager.ts
+++ b/src/pty-manager.ts
@@ -9,6 +9,7 @@
 import { chmodSync, existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
+import { userInfo } from 'node:os'
 import * as nodePty from 'node-pty'
 import { SidebarError } from './wire.ts'
 
@@ -118,7 +119,7 @@ export class PtyManager {
       sessionId,
       tabId,
       cwd,
-      pty: nodePty.spawn(this.shell, [], {
+      pty: nodePty.spawn(this.shell, shellSpawnArgs(), {
         name: 'xterm-256color',
         cols: Math.max(2, Math.floor(cols)),
         rows: Math.max(2, Math.floor(rows)),
@@ -191,9 +192,35 @@ export class PtyManager {
   }
 }
 
-/** The interactive shell for this platform (empty SHELL falls back). */
+/**
+ * The interactive shell for this platform, resolved like a terminal
+ * emulator: an explicit `$SHELL` on the dsh process wins (deployment
+ * override), then the account's login shell from passwd, then `/bin/bash`.
+ * The passwd step matters because service managers and container inits
+ * often start dsh without `SHELL`, and the tab should still open the
+ * user's login shell (e.g. zsh) instead of silently degrading to bash.
+ * Windows short-circuits to `powershell.exe` before any resolution.
+ */
 export function defaultShell(): string {
   if (process.platform === 'win32') return 'powershell.exe'
-  const shell = process.env.SHELL
-  return shell !== undefined && shell.trim() !== '' ? shell : '/bin/bash'
+  const envShell = process.env.SHELL
+  if (envShell !== undefined && envShell.trim() !== '') return envShell
+  // userInfo() throws when the uid has no passwd entry (rare chroots);
+  // without a login shell there is nothing better than the bash default.
+  try {
+    const loginShell = userInfo().shell
+    if (typeof loginShell === 'string' && loginShell.trim() !== '') return loginShell
+  } catch {
+    // no passwd entry: fall through to /bin/bash
+  }
+  return '/bin/bash'
+}
+
+/**
+ * Spawn arguments that make the shell behave like a terminal-emulator tab:
+ * POSIX shells start as login shells (`-l`) so they read the profile files
+ * (`~/.profile`, `~/.zprofile`); Windows PowerShell takes no login flag.
+ */
+export function shellSpawnArgs(): string[] {
+  return process.platform === 'win32' ? [] : ['-l']
 }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -188,6 +188,34 @@ describe('host plugin smoke', () => {
     }
   })
 
+  it.skipIf(process.platform === 'win32')('spawns the shell as a login shell (loads ~/.profile)', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-sidebar-login-'))
+    const previousHome = process.env.HOME
+    try {
+      // A login bash reads ~/.profile (a non-login interactive bash reads
+      // ~/.bashrc instead), so this marker proves the spawn used a login
+      // argv — the terminal-emulator behavior the tab should match.
+      writeFileSync(join(home, '.profile'), 'export DSH_LOGIN_MARKER=loaded-from-profile\n')
+      process.env.HOME = home
+      const manager = new PtyManager('/bin/bash', 3)
+      try {
+        const handle = manager.open('s5', 't1', process.cwd(), 80, 24)
+        handle.pty.write('echo $DSH_LOGIN_MARKER\r')
+        const deadline = Date.now() + 5000
+        while (!handle.transcript.includes('loaded-from-profile') && Date.now() < deadline) {
+          await new Promise(resolve => setTimeout(resolve, 50))
+        }
+        expect(handle.transcript).toContain('loaded-from-profile')
+      } finally {
+        manager.disposeAll()
+      }
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME
+      else process.env.HOME = previousHome
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
   it('lists the repository root level', async () => {
     const listing = await listDirectory(process.cwd(), 1000)
     expect(listing.entries.some(entry => entry.name === 'src' && entry.isDir)).toBe(true)

--- a/tests/unit.spec.ts
+++ b/tests/unit.spec.ts
@@ -1,4 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Pin the passwd login shell to a non-bash value for the pty helpers tests:
+// the CI runner's own login shell is /bin/bash, which the old hardcoded
+// fallback would have satisfied by coincidence, so the fallback chain needs
+// a mock passwd to be genuinely discriminating. No other test in this file
+// reads os.userInfo.
+vi.mock('node:os', async (importOriginal) => {
+  const os = await importOriginal<typeof import('node:os')>()
+  return {
+    ...os,
+    userInfo: () => ({ ...os.userInfo(), shell: '/usr/bin/zsh' }),
+  }
+})
 import { compareEntries, isWithin, parentOf, rootLabel, requireAbsolute } from '../src/fs-tree.ts'
 import { parseLogLines, parsePorcelainZ } from '../src/git.ts'
 import { parseUnifiedDiff } from '../src/client/DiffView.tsx'
@@ -846,13 +859,21 @@ describe('agent terminal reconciliation', () => {
 })
 
 describe('pty helpers', () => {
-  it('falls back from an empty SHELL to a usable shell', () => {
+  it('prefers an explicit SHELL, then falls back to the account login shell', () => {
+    if (process.platform === 'win32') {
+      // defaultShell() short-circuits to powershell.exe before env/passwd
+      // resolution on Windows; the POSIX fallback chain is asserted below.
+      expect(defaultShell()).toBe('powershell.exe')
+      return
+    }
     const previous = process.env.SHELL
     try {
-      process.env.SHELL = ''
-      expect(defaultShell()).toBe('/bin/bash')
+      process.env.SHELL = '/explicit/zsh'
+      expect(defaultShell()).toBe('/explicit/zsh')
+      process.env.SHELL = '   '
+      expect(defaultShell()).toBe('/usr/bin/zsh')
       delete process.env.SHELL
-      expect(defaultShell()).toBe('/bin/bash')
+      expect(defaultShell()).toBe('/usr/bin/zsh')
     } finally {
       if (previous === undefined) delete process.env.SHELL
       else process.env.SHELL = previous


### PR DESCRIPTION
## 关联

Fixes #68

## 改什么

终端 Tab（UI tab 与 agent 终端 `terminal_create`）的 shell 解析与启动方式：

1. `defaultShell()`：解析顺序改为 `$SHELL` → 账户 login shell（`os.userInfo().shell`，passwd）→ `/bin/bash`。dsh 由 systemd / supervisord / 容器 init 启动时进程环境通常没有 `SHELL`，旧实现直接回退硬编码 bash，忽略了用户的 login shell（如 zsh）。
2. 两个 registry（`PtyManager.open()`、`AgentPtyRegistry.create()`）的 node-pty spawn 参数从空数组改为 POSIX `['-l']`（共享 `shellSpawnArgs()`），终端以 **login shell** 启动，按终端模拟器惯例加载 `~/.profile` / `~/.zprofile`；Windows 维持 `powershell.exe` 无参不变。

## 为什么

见 #68：服务化管理启动的 dsh 进程没有 `SHELL` 环境变量时，终端固定退化为 bash；即使解析到 zsh 也是非 login 模式，`.zprofile` 不加载。

## 影响面

- bash 用户：login bash 读 `.bash_profile`/`.profile` 而非 `.bashrc`（Debian/Ubuntu 默认骨架里 `.profile` 会 source `.bashrc`，一般无感）。这正是对齐终端模拟器的目标行为。
- agent 终端（`terminal_create`）与 UI tab 共享同一解析/spawn helper，行为一致变化。
- Windows 无变化。

## 测试

- `tests/unit.spec.ts`：解析顺序单测，`vi.mock('node:os')` 钉死 passwd shell 为非 bash 值，保证 CI（runner 登录 shell 恰为 bash）上真能区分新旧实现；已实测旧实现下该测试失败。
- `tests/smoke.spec.ts`：真实 pty 验证 login 加载——临时 HOME 写 `.profile` marker，断言 marker 出现在终端输出；已实测旧实现下该测试失败。
- 本地门禁：typecheck、489 项测试、build、consumer-types 全过（全量中 1 个既有 ETag 偶发失败与本次改动无关，已在未改动分支上复现）。
- 端到端：隔离实例以 `env -u SHELL` 启动 dsh web，浏览器打开终端 Tab：`echo $0` → `/usr/bin/zsh`；`[[ -o login ]]` 为真（输出 LOGIN_OK）；`.zshrc` 主题提示符与 nvm 初始化输出均出现。