### PR TITLE
fix: 侧边栏面板开关按钮避开桌面端原生标题带

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -6,11 +6,12 @@
  * bottom panel squeezes ONLY the center column (the agent output area): it
  * spans from the app shell's own left sidebar to the right panel's left
  * edge, so neither sidebar gives up any position (the right panel keeps its
- * full height). A persistent two-button cluster at the top-right corner
- * toggles each panel; the right panel's width drags from its left edge, the
- * bottom panel's height from its top edge, and the shared corner drags both
- * at once. The whole layout lives in the per-session store, so switching
- * conversations swaps the sidebar.
+ * full height). The right panel owns a dedicated control row below the
+ * native caption band; the closed state keeps a matching fallback affordance.
+ * The right panel's width drags from its left edge, the bottom panel's height
+ * from its top edge, and the shared corner drags both at once. The whole
+ * layout lives in the per-session store, so switching conversations swaps
+ * the sidebar.
  *
  * The shell binds the workbench actions to the store and dispatches tab
  * content to the views. New tabs come from the + menu (explorer / git /
@@ -674,6 +675,33 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     return <span className={css.tabBadge}>{text}</span>
   }
 
+  /** The panel controls live after the + button while the right panel is
+   * open. A fixed fallback below is kept only for the closed state. */
+  const panelToggleActions = (
+    <>
+      <Tooltip label={state.bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')} side="bottom" delayMs={500}>
+        <button
+          type="button"
+          className={css.toggleButton}
+          aria-label={state.bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')}
+          onClick={() => { store.reduce(toggleBottomPanel) }}
+        >
+          <IconPanelBottomOutline16 />
+        </button>
+      </Tooltip>
+      <Tooltip label={state.panelOpen ? t('collapse') : t('expand')} side="bottom" delayMs={500}>
+        <button
+          type="button"
+          className={css.toggleButton}
+          aria-label={state.panelOpen ? t('collapse') : t('expand')}
+          onClick={() => { store.reduce(togglePanel) }}
+        >
+          <IconPanelRightOutline16 />
+        </button>
+      </Tooltip>
+    </>
+  )
+
   /**
    * Render one tab's content. `active` (from the workbench) tells whether
    * this tab is the active one in its pane; combined with the panel's
@@ -699,42 +727,11 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
 
   return (
     <>
-      {/*
-        The persistent toggle cluster at the top-right corner: the bottom
-        panel's button (bottom glyph) LEFT of the right panel's (side glyph).
-        Always pinned to the viewport corner — inside the right panel's
-        top-right while it is open, sitting flush in the tab strip whose
-        right end it really squeezes (the strip reserves its width via CSS),
-        so the tabs genuinely yield space to it.
-      */}
-      <div className={css.toggleCluster}>
-        {/*
-          Narrow viewports merge the two workbenches into the one drawer —
-          there is no bottom panel, so its toggle button is not offered.
-        */}
-        {!narrow && (
-          <Tooltip label={state.bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')} side="bottom" delayMs={500}>
-            <button
-              type="button"
-              className={css.toggleButton}
-              aria-label={state.bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')}
-              onClick={() => { store.reduce(toggleBottomPanel) }}
-            >
-              <IconPanelBottomOutline16 />
-            </button>
-          </Tooltip>
-        )}
-        <Tooltip label={state.panelOpen ? t('collapse') : t('expand')} side="bottom" delayMs={500}>
-          <button
-            type="button"
-            className={css.toggleButton}
-            aria-label={state.panelOpen ? t('collapse') : t('expand')}
-            onClick={() => { store.reduce(togglePanel) }}
-          >
-            <IconPanelRightOutline16 />
-          </button>
-        </Tooltip>
-      </div>
+      {/* When the right panel is closed its tab strip is hidden, so retain a
+          small fallback affordance for reopening it. */}
+      {!state.panelOpen && (
+        <div className={css.toggleCluster}>{panelToggleActions}</div>
+      )}
       {/*
         The right panel stays mounted while collapsed (hidden off-screen) so
         the slide in/out can animate; visibility hides it after the slide
@@ -776,6 +773,11 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
               }}
             />
           )}
+        <div className={css.panelTopbar}>
+          <div className={css.panelControls}>
+            {state.panelOpen ? panelToggleActions : null}
+          </div>
+        </div>
         <div className={css.panelBody}>
           <Workbench
             state={state}

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -10,11 +10,8 @@
 
 /* ── Shell ─────────────────────────────────────────────────────────────── */
 
-/* The persistent expand/collapse cluster at the top-right corner: two rail
-   controls side by side (bottom panel's glyph LEFT of the right panel's).
-   Always pinned to the viewport corner — inside the right panel's top-right
-   while it is open, sitting flush in the 34px tab strip (28px buttons at
-   top: 3) whose right end it really squeezes. */
+/* The fallback expand/collapse cluster used only while the right panel is
+   closed (when its tab strip is not mounted on screen). */
 .toggleCluster {
   position: fixed;
   top: 3px;
@@ -25,11 +22,11 @@
   gap: 4px;
 }
 
-/* The tab strip of the OPEN right panel reserves the cluster's width at its
-   right end, so the tabs and the + menu genuinely yield space to the cluster
-   (never hiding under it). */
-.panel:not(.panelHidden) .tabBar {
-  padding-right: 72px;
+/* Electron's native caption buttons occupy the first title-bar band. Keep
+   the closed-state fallback below that band instead of competing for the
+   same hit targets. */
+:global(html[data-dsh-desktop='true']) .toggleCluster {
+  top: var(--dsh-desktop-titlebar-inset, 40px);
 }
 
 /* The closed-state affordance is the native rail icon control: a plain
@@ -112,6 +109,35 @@
 
 .panelResizeActive {
   background: var(--dsw-alias-interactive-bg-hover-accent);
+}
+
+/* A dedicated control row keeps the two panel toggles available regardless
+   of which tab is active. On desktop it starts below the native caption band;
+   the workbench begins after it, so neither expanded content nor tabs can
+   cover the hit targets. */
+.panelTopbar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  height: 34px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--dsw-alias-border-l1);
+  background: var(--dsw-alias-bg-layer-1);
+  box-sizing: border-box;
+}
+
+.panelControls {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+:global(html[data-dsh-desktop='true']) .panelTopbar {
+  height: calc(var(--dsh-desktop-titlebar-inset, 40px) + 34px);
+  padding-top: var(--dsh-desktop-titlebar-inset, 40px);
+  align-items: flex-end;
 }
 
 .panelBody {
@@ -1787,14 +1813,6 @@
    switches (which panels render, the migration) are JS-driven via
    useNarrowViewport; this block only adapts the pure style details. */
 @media (max-width: 767px) {
-  /* The toggle cluster holds a single button on narrow viewports (the
-     bottom panel button is not rendered), so the open panel's tab strip
-     reserves 40px instead of the desktop 72px — the tabs and + menu still
-     yield space to the one remaining control. */
-  .panel:not(.panelHidden) .tabBar {
-    padding-right: 40px;
-  }
-
   /* Narrower tabs: a phone-width drawer fits more open tabs before the
      strip scrolls. */
   .tab {


### PR DESCRIPTION
## 问题描述
桌面端（Electron）右面板右上角常驻的「展开/收起」双按钮（position: fixed; top: 3px）与窗口原生标题栏按钮重叠，点击目标被标题带遮挡，面板开关不好点。

## 修改内容
- src/client/Sidebar.tsx：把两个面板开关按钮抽成 panelToggleActions；
  - 右面板**打开**时，按钮放入面板顶部新增的 .panelTopbar 控制行（原生标题带下方，不随 tab 切换变化）
  - 右面板**关闭**时，保留 .toggleCluster 兜底入口（否则无法重新打开面板）
- src/client/sidebar.module.css：
  - 新增 .panelTopbar / .panelControls（34px 控制行、右对齐）
  - 删除 .panel:not(.panelHidden) .tabBar { padding-right: 72px }（tab 条不再为角落按钮预留空间）
  - 桌面端兜底 cluster 下移：html[data-dsh-desktop='true'] .toggleCluster { top: var(--dsh-desktop-titlebar-inset, 40px) }

## 验证
在 DSH 桌面端实测：右面板打开/关闭、底部面板展开/收起均正常，按钮不再与原生标题带重叠。
