### PR TITLE
fix: 面板开关注入 session header utilities，与 Session log 同行对齐

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -6,11 +6,12 @@
  * bottom panel squeezes ONLY the center column (the agent output area): it
  * spans from the app shell's own left sidebar to the right panel's left
  * edge, so neither sidebar gives up any position (the right panel keeps its
- * full height). A persistent two-button cluster at the top-right corner
- * toggles each panel; the right panel's width drags from its left edge, the
- * bottom panel's height from its top edge, and the shared corner drags both
- * at once. The whole layout lives in the per-session store, so switching
- * conversations swaps the sidebar.
+ * full height). A two-button cluster toggles each panel — in the session
+ * header's utilities row while a session is painted, pinned to the viewport
+ * corner only on the blank hero. The right panel's width drags from its
+ * left edge, the bottom panel's height from its top edge, and the shared
+ * corner drags both at once. The whole layout lives in the per-session
+ * store, so switching conversations swaps the sidebar.
  *
  * The shell binds the workbench actions to the store and dispatches tab
  * content to the views. New tabs come from the + menu (explorer / git /
@@ -37,7 +38,7 @@ import {
   resizeSplitIn, setBottomHeight, setWidth, toggleBottomPanel, toggleExpanded, togglePanel,
   type DropZone, type SidebarState, type SidebarStore, type SidebarTab, type SplitNode,
 } from './state.ts'
-import { IconPanelBottomOutline16, IconPanelRightOutline16 } from './icons.tsx'
+import { ToggleCluster } from './ToggleCluster.tsx'
 import { Workbench, type WorkbenchActions } from './split-pane.tsx'
 import { useNarrowViewport } from './breakpoints.ts'
 import type { NewTabOption } from './TabBar.tsx'
@@ -154,18 +155,6 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   const state = snapshot.state
   const sessionId = snapshot.sessionId
   const summaryCwd = sessionId === undefined ? undefined : sessionList.byId[sessionId]?.cwd
-
-  // The collapsed toggle cluster reclaims the top-right corner, so the DSH
-  // session header's right-aligned utilities (the "Session log" download
-  // capsule) must yield. layout.css keys off this body attribute to push the
-  // header's right padding out past the cluster. Only the CLOSED panel needs
-  // it — an open panel already squeezes `#root` left, moving the header clear.
-  const collapsed = state === undefined || !state.panelOpen
-  useEffect(() => {
-    if (collapsed) document.body.setAttribute('data-dsh-sidebar-collapsed', '')
-    else document.body.removeAttribute('data-dsh-sidebar-collapsed')
-    return () => { document.body.removeAttribute('data-dsh-sidebar-collapsed') }
-  }, [collapsed])
 
   /**
    * Bottom-panel merge on narrow viewports: whenever a session is current
@@ -613,22 +602,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   }, [ctx, sessionId, cwd])
 
   if (state === undefined || sessionId === undefined) {
-    return (
-      <div className={css.toggleCluster}>
-        {!narrow && (
-          <Tooltip label={t('noSession')} side="bottom" delayMs={500}>
-            <button type="button" className={css.toggleButton} disabled aria-label={t('noSession')}>
-              <IconPanelBottomOutline16 />
-            </button>
-          </Tooltip>
-        )}
-        <Tooltip label={t('noSession')} side="bottom" delayMs={500}>
-          <button type="button" className={css.toggleButton} disabled aria-label={t('noSession')}>
-            <IconPanelRightOutline16 />
-          </button>
-        </Tooltip>
-      </div>
-    )
+    return <ToggleCluster state={undefined} store={store} narrow={narrow} variant="fixed" />
   }
 
   const onNewTab = (optionId: string): void => {
@@ -700,41 +674,12 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   return (
     <>
       {/*
-        The persistent toggle cluster at the top-right corner: the bottom
-        panel's button (bottom glyph) LEFT of the right panel's (side glyph).
-        Always pinned to the viewport corner — inside the right panel's
-        top-right while it is open, sitting flush in the tab strip whose
-        right end it really squeezes (the strip reserves its width via CSS),
-        so the tabs genuinely yield space to it.
+        Floating fallback: pinned to the viewport corner while the session
+        header is hidden (blank hero). Once HeaderToggleCluster mounts into
+        the header utilities row it sets data-dsh-sidebar-in-header and CSS
+        hides this copy so the two never stack.
       */}
-      <div className={css.toggleCluster}>
-        {/*
-          Narrow viewports merge the two workbenches into the one drawer —
-          there is no bottom panel, so its toggle button is not offered.
-        */}
-        {!narrow && (
-          <Tooltip label={state.bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')} side="bottom" delayMs={500}>
-            <button
-              type="button"
-              className={css.toggleButton}
-              aria-label={state.bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')}
-              onClick={() => { store.reduce(toggleBottomPanel) }}
-            >
-              <IconPanelBottomOutline16 />
-            </button>
-          </Tooltip>
-        )}
-        <Tooltip label={state.panelOpen ? t('collapse') : t('expand')} side="bottom" delayMs={500}>
-          <button
-            type="button"
-            className={css.toggleButton}
-            aria-label={state.panelOpen ? t('collapse') : t('expand')}
-            onClick={() => { store.reduce(togglePanel) }}
-          >
-            <IconPanelRightOutline16 />
-          </button>
-        </Tooltip>
-      </div>
+      <ToggleCluster state={state} store={store} narrow={narrow} variant="fixed" />
       {/*
         The right panel stays mounted while collapsed (hidden off-screen) so
         the slide in/out can animate; visibility hides it after the slide

--- a/src/client/ToggleCluster.tsx
+++ b/src/client/ToggleCluster.tsx
@@ -1,0 +1,128 @@
+/**
+ * The expand/collapse cluster: bottom-panel glyph LEFT of the right-panel
+ * glyph. Two homes share this tree:
+ *
+ *  - Inline, in `conversation.session.header.utilities` (same row as
+ *    Session log) while a session header is painted. That is the official
+ *    additive seat; the host flex-aligns us with the title row so we never
+ *    sit on a different baseline than the shipped utilities.
+ *  - Fixed, at the viewport's top-right, only while the header is hidden
+ *    (blank hero / no session). The header entry unmounts in those states,
+ *    so the body attribute this file sets drops and the floating cluster
+ *    becomes the only affordance.
+ *
+ * The header seat is a CHILD slot of `conversation.session.header`, so
+ * registration goes through `slots.inject` (same race as turn-tail).
+ */
+import { useCallback, useEffect, type ReactNode } from 'react'
+import { useSyncExternalStore } from 'react'
+import { Tooltip } from '@deepseek-ai/dsh-client-ui-primitives'
+import type {} from '@deepseek-ai/dsh-client-ui-conversation/client'
+import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
+import clsx from 'clsx'
+import type { Context } from '../context-types.ts'
+import { useNarrowViewport } from './breakpoints.ts'
+import { IconPanelBottomOutline16, IconPanelRightOutline16 } from './icons.tsx'
+import { t } from './locales.ts'
+import {
+  toggleBottomPanel, togglePanel,
+  type SidebarState, type SidebarStore,
+} from './state.ts'
+import css from './sidebar.module.css'
+
+/** Marks that the header-hosted cluster is mounted (layout.css / module CSS
+ *  hide the floating fallback and drop the tab-strip reservation). */
+export const HEADER_TOGGLE_ATTR = 'data-dsh-sidebar-in-header'
+
+/** Injected business face: the shared store the buttons write. */
+export interface HeaderToggleInjected {
+  store: SidebarStore
+}
+
+/** Full slot props: the session kit plus the injected store. */
+export type HeaderToggleProps = PropsRuntime<'conversation.session.header.utilities'> & HeaderToggleInjected
+
+/** Shared two-button cluster. `fixed` pins to the viewport corner (hero /
+ *  no-session fallback); `inline` sits in the header utilities row. */
+export function ToggleCluster(props: {
+  state: SidebarState | undefined
+  store: SidebarStore
+  narrow: boolean
+  variant: 'fixed' | 'inline'
+}): ReactNode {
+  const { state, store, narrow, variant } = props
+  const disabled = state === undefined
+  const bottomOpen = state?.bottomOpen === true
+  const panelOpen = state?.panelOpen === true
+  return (
+    <div
+      className={clsx(css.toggleCluster, variant === 'fixed' && css.toggleClusterFixed)}
+      data-dsh-sidebar-header-toggle={variant === 'inline' ? '' : undefined}
+    >
+      {!narrow && (
+        <Tooltip
+          label={disabled ? t('noSession') : bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')}
+          side="bottom"
+          delayMs={500}
+        >
+          <button
+            type="button"
+            className={css.toggleButton}
+            disabled={disabled}
+            aria-label={disabled ? t('noSession') : bottomOpen ? t('collapseBottomPanel') : t('expandBottomPanel')}
+            onClick={disabled ? undefined : () => { store.reduce(toggleBottomPanel) }}
+          >
+            <IconPanelBottomOutline16 />
+          </button>
+        </Tooltip>
+      )}
+      <Tooltip
+        label={disabled ? t('noSession') : panelOpen ? t('collapse') : t('expand')}
+        side="bottom"
+        delayMs={500}
+      >
+        <button
+          type="button"
+          className={css.toggleButton}
+          disabled={disabled}
+          aria-label={disabled ? t('noSession') : panelOpen ? t('collapse') : t('expand')}
+          onClick={disabled ? undefined : () => { store.reduce(togglePanel) }}
+        >
+          <IconPanelRightOutline16 />
+        </button>
+      </Tooltip>
+    </div>
+  )
+}
+
+/**
+ * Header-utilities occupant: the same cluster, in flow next to Session log.
+ * Sets {@link HEADER_TOGGLE_ATTR} for the lifetime of this mount so the
+ * floating fallback (and the tab-strip reserved pad) hide.
+ */
+export function HeaderToggleCluster({ store }: HeaderToggleInjected): ReactNode {
+  const snapshot = useSyncExternalStore(
+    useCallback((callback: () => void) => store.subscribe(callback), [store]),
+    useCallback(() => store.getSnapshot(), [store]),
+  )
+  const narrow = useNarrowViewport()
+  useEffect(() => {
+    document.body.setAttribute(HEADER_TOGGLE_ATTR, '')
+    return () => { document.body.removeAttribute(HEADER_TOGGLE_ATTR) }
+  }, [])
+  return <ToggleCluster state={snapshot.state} store={store} narrow={narrow} variant="inline" />
+}
+
+/**
+ * Register the cluster on the session-header utilities list. The slot is a
+ * child of `conversation.session.header`, so this waits for the declaration
+ * (direct `slots.register` races it). Returns the inject disposer.
+ */
+export function registerHeaderToggle(ctx: Context, store: SidebarStore): () => void {
+  return ctx.slots.inject('conversation.session.header.utilities', () => ctx.slots.register({
+    name: 'conversation.session.header.utilities',
+    id: 'better-sidebar-toggle',
+    order: 100,
+    inject: () => ({ store }),
+  }, HeaderToggleCluster))
+}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -3,10 +3,11 @@
  * preferences through the plugin's own fenced settings route, mounts the
  * right sidebar portal (inside an error boundary so a rendering failure
  * shows an error strip instead of a blank panel), registers the turn-tail
- * interception, and contributes the Side card settings section to the DSH
- * Settings shell. Requires the runtime's slots and sessions services; the
- * bundle itself is a module-table consumer only (react + ui-primitives +
- * xterm, all provided or inlined).
+ * interception, seats the panel toggles in the session header utilities
+ * row, and contributes the Side card settings section to the DSH Settings
+ * shell. Requires the runtime's slots and sessions services; the bundle
+ * itself is a module-table consumer only (react + ui-primitives + xterm,
+ * all provided or inlined).
  */
 import { createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -17,6 +18,7 @@ import { resetChunks } from './chunk-loader.ts'
 import { registerBuiltins } from './builtins/index.ts'
 import { Sidebar } from './Sidebar.tsx'
 import { RenderBoundary } from './RenderBoundary.tsx'
+import { registerHeaderToggle } from './ToggleCluster.tsx'
 import { registerOpenPathInterception, registerTurnTailInterception } from './intercept.tsx'
 import { registerLinkInterception } from './link-intercept.ts'
 import { registerImeGuard } from './ime-guard.ts'
@@ -211,6 +213,14 @@ export function apply(ctx: Context): void {
         }
       },
       'dsh-better-sidebar: IME composition guard',
+    )
+
+    // The panel toggles sit in the session header's utilities row (same
+    // seat as Session log) so they share the title-row baseline. The slot
+    // is a child of conversation.session.header; inject waits for it.
+    ctx.effect(
+      () => registerHeaderToggle(ctx, sidebarStore),
+      'dsh-better-sidebar: header toggle',
     )
 
     // The "Side card" settings section: appears in the DSH Settings shell

--- a/src/client/layout.css
+++ b/src/client/layout.css
@@ -33,19 +33,6 @@
   transition: margin-bottom var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
 
-/* When the sidebar is collapsed, the toggle cluster reclaims the top-right
-   corner. Push the DSH session header's right padding out so its right-aligned
-   utilities (the "Session log" download capsule) yield the corner instead of
-   hiding under the cluster. The header default right-pads 28px; the 2-button
-   cluster spans right 10→70px, so 78px clears it with an 8px gap. Anchor on
-   the header's slot host wrapper ([data-slot="conversation.session.header"])
-   rather than a positional path: DSH 0.1.x nests the header several levels
-   under the center column. The Sidebar shell toggles the body attribute with
-   the panel open state. */
-body[data-dsh-sidebar-collapsed] [data-slot="conversation.session.header"] > header {
-  padding-right: 78px;
-}
-
 body[data-dsh-sidebar-dragging] #root,
 body[data-dsh-sidebar-dragging] #root > div[data-slot="root"] > div > div:nth-child(2) {
   transition: none;

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -10,26 +10,39 @@
 
 /* ── Shell ─────────────────────────────────────────────────────────────── */
 
-/* The persistent expand/collapse cluster at the top-right corner: two rail
-   controls side by side (bottom panel's glyph LEFT of the right panel's).
-   Always pinned to the viewport corner — inside the right panel's top-right
-   while it is open, sitting flush in the 34px tab strip (28px buttons at
-   top: 3) whose right end it really squeezes. */
+/* The expand/collapse cluster: two rail controls side by side (bottom
+   panel's glyph LEFT of the right panel's). Shared by the header-utilities
+   seat (in flow) and the floating hero fallback. */
 .toggleCluster {
+  display: flex;
+  flex-direction: row;
+  flex: none;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Hero / no-session fallback: pinned to the viewport corner. Hidden once
+   the header-hosted copy mounts (it sets data-dsh-sidebar-in-header). */
+.toggleClusterFixed {
   position: fixed;
   top: 3px;
   right: 10px;
   z-index: 55;
-  display: flex;
-  flex-direction: row;
-  gap: 4px;
+}
+
+:global(body[data-dsh-sidebar-in-header]) .toggleClusterFixed {
+  display: none;
 }
 
 /* The tab strip of the OPEN right panel reserves the cluster's width at its
-   right end, so the tabs and the + menu genuinely yield space to the cluster
-   (never hiding under it). */
+   right end while the floating copy is the live affordance. The header seat
+   lives in the conversation column, so the reservation drops. */
 .panel:not(.panelHidden) .tabBar {
   padding-right: 72px;
+}
+
+:global(body[data-dsh-sidebar-in-header]) .panel:not(.panelHidden) .tabBar {
+  padding-right: 0;
 }
 
 /* The closed-state affordance is the native rail icon control: a plain
@@ -1793,6 +1806,10 @@
      yield space to the one remaining control. */
   .panel:not(.panelHidden) .tabBar {
     padding-right: 40px;
+  }
+
+  :global(body[data-dsh-sidebar-in-header]) .panel:not(.panelHidden) .tabBar {
+    padding-right: 0;
   }
 
   /* Narrower tabs: a phone-width drawer fits more open tabs before the

--- a/tests/header-toggle.spec.ts
+++ b/tests/header-toggle.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Header-utilities toggle: the cluster must land through `slots.inject` on
+ * `conversation.session.header.utilities` (a child of the session header,
+ * same race as turn-tail) and the header-hosted buttons must write the
+ * shared store. The floating fallback is a CSS concern (`data-dsh-sidebar-in-header`)
+ * and is asserted via the body attribute the occupant sets on mount.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import {
+  HEADER_TOGGLE_ATTR,
+  HeaderToggleCluster,
+  registerHeaderToggle,
+} from '../src/client/ToggleCluster.tsx'
+import { createSidebarStore } from '../src/client/state.ts'
+import { t } from '../src/client/locales.ts'
+import type { Context } from '../src/context-types.ts'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+interface RegisteredSlot {
+  options: Record<string, unknown>
+  component: unknown
+}
+
+/** Structural fake of SlotRegistry.inject (same timing as turn-tail). */
+const fakeSlots = (declared: boolean) => {
+  const registered: RegisteredSlot[] = []
+  const disposals: number[] = []
+  const pendings: Array<() => void> = []
+  return {
+    registered,
+    disposals,
+    pendings,
+    slots: {
+      register: (options: Record<string, unknown>, component: unknown) => {
+        registered.push({ options, component })
+        return () => { disposals.push(1) }
+      },
+      inject: (key: string, callback: () => () => void) => {
+        if (key !== 'conversation.session.header.utilities') {
+          throw new Error(`unexpected injected key "${key}"`)
+        }
+        let active: (() => void) | undefined
+        let stopped = false
+        const run = (): void => {
+          if (stopped || active !== undefined) return
+          active = callback()
+        }
+        if (declared) run()
+        else pendings.push(run)
+        return () => {
+          stopped = true
+          active?.()
+          active = undefined
+        }
+      },
+    },
+  }
+}
+
+const clientCtx = (slots: unknown): Context => ({ slots } as unknown as Context)
+
+describe('header toggle registration', () => {
+  it('registers through slots.inject once the utilities slot is declared', () => {
+    const fake = fakeSlots(true)
+    const store = createSidebarStore()
+    const restore = registerHeaderToggle(clientCtx(fake.slots), store)
+
+    expect(fake.registered).toHaveLength(1)
+    const { options, component } = fake.registered[0]!
+    expect(options.name).toBe('conversation.session.header.utilities')
+    expect(options.id).toBe('better-sidebar-toggle')
+    expect(options.order).toBe(100)
+    expect(options.inject).toBeTypeOf('function')
+    expect((options.inject as () => { store: unknown })()).toEqual({ store })
+    expect(component).toBe(HeaderToggleCluster)
+
+    restore()
+    expect(fake.disposals).toHaveLength(1)
+    restore()
+    expect(fake.disposals).toHaveLength(1)
+  })
+
+  it('waits for the host declaration instead of throwing', () => {
+    const fake = fakeSlots(false)
+    const store = createSidebarStore()
+    const restore = registerHeaderToggle(clientCtx(fake.slots), store)
+
+    expect(fake.registered).toHaveLength(0)
+    expect(fake.pendings).toHaveLength(1)
+    fake.pendings[0]!()
+    expect(fake.registered).toHaveLength(1)
+    expect(fake.registered[0]!.options.id).toBe('better-sidebar-toggle')
+
+    restore()
+    expect(fake.disposals).toHaveLength(1)
+  })
+})
+
+describe('HeaderToggleCluster', () => {
+  const mounts: Array<{ root: Root; host: HTMLDivElement }> = []
+
+  afterEach(() => {
+    for (const { root, host } of mounts) {
+      act(() => { root.unmount() })
+      host.remove()
+    }
+    mounts.length = 0
+    document.body.removeAttribute(HEADER_TOGGLE_ATTR)
+  })
+
+  function mount(store = createSidebarStore()): { host: HTMLDivElement; store: ReturnType<typeof createSidebarStore> } {
+    store.setSession('s1')
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = createRoot(host)
+    act(() => { root.render(createElement(HeaderToggleCluster, { store })) })
+    mounts.push({ root, host })
+    return { host, store }
+  }
+
+  it('sets the body attribute while mounted and clears it on unmount', () => {
+    const { host } = mount()
+    expect(document.body.hasAttribute(HEADER_TOGGLE_ATTR)).toBe(true)
+    expect(host.querySelector('[data-dsh-sidebar-header-toggle]')).not.toBeNull()
+
+    const { root } = mounts[0]!
+    act(() => { root.unmount() })
+    host.remove()
+    mounts.length = 0
+    expect(document.body.hasAttribute(HEADER_TOGGLE_ATTR)).toBe(false)
+  })
+
+  it('renders both panel buttons and writes the store', () => {
+    const { host, store } = mount()
+    const buttons = [...host.querySelectorAll('button')]
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0]!.getAttribute('aria-label')).toBe(t('expandBottomPanel'))
+    expect(buttons[1]!.getAttribute('aria-label')).toBe(t('collapse'))
+
+    act(() => { buttons[1]!.click() })
+    expect(store.getSnapshot().state?.panelOpen).toBe(false)
+    expect(buttons[1]!.getAttribute('aria-label')).toBe(t('expand'))
+
+    act(() => { buttons[0]!.click() })
+    expect(store.getSnapshot().state?.bottomOpen).toBe(true)
+    expect(buttons[0]!.getAttribute('aria-label')).toBe(t('collapseBottomPanel'))
+  })
+
+  it('disables both buttons when the store has no session', () => {
+    const store = createSidebarStore()
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = createRoot(host)
+    act(() => { root.render(createElement(HeaderToggleCluster, { store })) })
+    mounts.push({ root, host })
+
+    const buttons = [...host.querySelectorAll('button')]
+    expect(buttons).toHaveLength(2)
+    expect(buttons.every(button => button.disabled)).toBe(true)
+    expect(buttons[0]!.getAttribute('aria-label')).toBe(t('noSession'))
+  })
+})


### PR DESCRIPTION
## 问题

会话页头（标题 / 标准模式 / Session log / 对话·轨迹）和插件 `toggleCluster` 不在同一水平线上。

根因：cluster 是 `position: fixed; top: 3px`（中心约 y=17），DSH header title 行是 `padding-top: 12px` + `min-height: 32px`（Session log 中心 y=28），差 11px。折叠时再靠 `padding-right: 78px` 给 header 让位，header 一改版就会再次错位。

## 变更

走 DSH 官方加法座，不替换整条 header：

- 通过 `slots.inject('conversation.session.header.utilities')` 把面板开关挂到 **Session log 同一行**（`id: better-sidebar-toggle`，`order: 100`，坐在 Session log 右侧）。
- 抽出共用 `ToggleCluster`：header 内联一份；空白 hero / 无会话时 header 隐藏，仍用右上角 fixed 兜底。
- header 座挂载期间写 `data-dsh-sidebar-in-header`，CSS 藏掉 floating 副本，并撤掉侧栏 tab 条为角落按钮预留的 `padding-right`。
- 删除 `data-dsh-sidebar-collapsed` 的 header 右 padding hack。

与 #82（桌面标题带避让）、#88（位置兼容模式）正交：本 PR 修的是 Web 会话页头基线，用的是 `conversation.session.header.utilities`，不改桌面 inset。

## 测试

- 新增 `tests/header-toggle.spec.ts`：`slots.inject` 等到声明再注册；挂载写/卸载清 body 属性；按钮写 store；无会话时禁用。
- 本地：`pnpm test`（502 全绿）、`pnpm typecheck`。
- 真实 DSH web（`早上好问候`）：header 打开/折叠后，Session log 与两个开关中心都在 y=28；空白首页 header 隐藏时仍是右上角 floating 兜底。