### PR TITLE
Recommend dsh-git-remotes in the tab plugin catalog

### DIFF
--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -226,6 +226,7 @@ export const zh = {
   openPlugin: '跳转',
   copyInstall: '复制安装命令',
   pluginOfficeDesc: '为 better-sidebar 编辑器提供 Office 三件套预览（.docx / .xlsx / .pptx），把重型 Office 渲染库拆出主包、按需安装',
+  pluginGitRemotesDesc: 'better-sidebar Git 远程 Tab：看分支/上游/ahead-behind，fetch（可 prune）、ff-only pull、确认后才 push。不替换内置 Git 的暂存/提交，也不提供 force-push 或模型自动推送',
   pluginSentinelDesc: '条件驱动的 agent 唤醒系统：文件/进程/端口/HTTP/命令/webhook 传感器，条件达成自动唤醒休眠会话；注册「哨兵」Tab 展示服务器全局监控表',
   pluginSidebarQaDesc: '基于 better-sidebar 的划选提问tab分页: 对话划选 → 右侧面板提问 → 同工作区独立追问会话（❓追问·主题）：快速无思考模型压缩主对话上下文后与引文一起注入，不打断主对话；追问可嵌套、可继续、可归档',
 }
@@ -447,6 +448,7 @@ export const en: Record<keyof typeof zh, string> = {
   openPlugin: 'Open',
   copyInstall: 'Copy install command',
   pluginOfficeDesc: 'Office-suite preview (.docx / .xlsx / .pptx) for the better-sidebar editor, keeping the heavy Office render libraries out of the core bundle',
+  pluginGitRemotesDesc: 'Git Remotes tab: branch/upstream/ahead-behind, fetch (optional prune), ff-only pull, and push only after an in-tab confirm. Does not replace the built-in Git stage/commit tab, and does not offer force-push or a model auto-push tool',
   pluginSentinelDesc: 'Condition-driven agent wakeup: file/process/port/http/command/webhook sensors wake dormant sessions when conditions fire; registers a "Sentinel" tab with the server-wide watch table',
   pluginSidebarQaDesc: 'Select-and-ask: Select conversation text → ask in the right-side panel → a dedicated follow-up session (❓追问) in the same workspace; a fast no-thinking model compresses the main context and injects it with the quote, without interrupting the main conversation. Follow-ups nest, continue, and archive',
 }

--- a/src/client/plugins-tabs.ts
+++ b/src/client/plugins-tabs.ts
@@ -25,6 +25,13 @@ export const builtinTabPlugins: readonly PluginEntry[] = [
     install: 'cd ~/.dsh && dsh plugin --profile web add "github:fuhefei/dsh-sentinel#v0.7.0"',
   },
   {
+    id: 'dsh-git-remotes',
+    name: 'dsh-git-remotes Git 远程',
+    url: 'https://github.com/yq04/dsh-git-remotes',
+    description: () => t('pluginGitRemotesDesc'),
+    install: 'cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar && dsh plugin --profile web add git+https://github.com/yq04/dsh-git-remotes.git',
+  },
+  {
     id: 'dsh-sidebar-qa',
     name: 'dsh-sidebar-qa 划选追问',
     url: 'https://github.com/ChenRuoT/dsh-sidebar-qa',


### PR DESCRIPTION
## Summary
- Add `dsh-git-remotes` to `plugins-tabs.ts` (Git Remotes tab: fetch / ff-only pull / confirmed push).
- Localize `pluginGitRemotesDesc` in zh and en.
- Install line installs `dsh-better-sidebar` first, then `git+https://github.com/yq04/dsh-git-remotes.git`.

This does not replace the built-in Git stage/commit tab. The plugin repo is tagged `dsh-plugin` and `dsh-better-sidebar`.

## Test plan
- [ ] `pnpm vitest run tests/plugin-list.spec.ts tests/locales.spec.ts`
- [ ] Side card settings → Add tab plugins shows the new row
- [ ] Copy install command starts with `cd ~/.dsh` and mentions both packages

Made with [Cursor](https://cursor.com)