### PR TITLE
fix: auto-enable title-bar compat in desktop windows

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -177,7 +177,15 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // snapshot's prefs, so flipping the setting re-renders and re-applies
   // immediately; the cleanup removes both on unmount/boundary swap so a
   // crashed sidebar never leaves them behind.
-  const titleBarCompat = snapshot.prefs.titleBarCompat
+  //
+  // Auto-enable in desktop windows: the DeepSeek Harness desktop shell marks
+  // itself with a `dsh-desktop-platform` URL query parameter (win32/darwin/
+  // linux). Frameless desktop windows draw the native caption buttons over
+  // the web content, so the compat strip is effectively required there; the
+  // OR keeps the pref working for plain-browser users who want the same
+  // reserved strip.
+  const isDesktopWindow = new URLSearchParams(window.location.search).has('dsh-desktop-platform')
+  const titleBarCompat = snapshot.prefs.titleBarCompat || isDesktopWindow
   const titleBarStrip = snapshot.prefs.titleBarStripPx
   useEffect(() => {
     const root = document.documentElement


### PR DESCRIPTION
## Problem

The **DeepSeek Harness desktop shell** (`deepseek-harness-desktop`, an Electron wrapper that loads the web UI in a frameless window) draws the native caption buttons (minimize / maximize / close) **over the web content** at the window's top-right corner.

With better-sidebar mounted, the caption buttons overlap:
- the **toggle cluster** (fixed at `top: 3px; right: 10px`) — the sidebar's expand/collapse buttons sit directly under the window's close/min/max buttons, making them hard to hit and visually broken.

## Root cause

The repo already ships a **position-compatibility mode** (`titleBarCompat` pref, driven by `data-dsh-title-bar-compat` + `--dsh-title-bar-strip`), which drops the toggle cluster below the caption strip and pushes the right panel's content below it. But it:
1. **defaults to `false`**, and
2. is only reachable through the sidebar Settings panel — a desktop user must know to find it.

## Fix

Detect the desktop shell via its **URL marker** and auto-enable the compat strip there:

```ts
// The desktop shell marks itself with ?dsh-desktop-platform=<platform>
const isDesktopWindow = new URLSearchParams(window.location.search).has('dsh-desktop-platform')
const titleBarCompat = snapshot.prefs.titleBarCompat || isDesktopWindow
```

- **Desktop windows** (`?dsh-desktop-platform=win32|darwin|linux`): compat strip auto-enables → toggle cluster drops below the caption buttons, correct out of the box.
- **Plain browsers** (no marker): behavior unchanged (`top: 3px`), zero regression.
- The user pref still wins for browsers that want the same reserved strip, and desktop users can still turn it off in Settings (the pref is read first).

## Verification

Built and swapped into a live desktop install:

| Environment | `data-dsh-title-bar-compat` | toggle cluster top |
|---|---|---|
| Desktop (`?dsh-desktop-platform=win32`) | set | 43px (40px strip + 3px) — clear of caption buttons |
| Plain browser (no marker) | unset | 3px — unchanged |

`pnpm typecheck` passes.

## Notes

- The desktop shell's marker is set in `apps/desktop/src/main.ts` of `anywhere-labs/deepseek-harness-desktop` (`rendererUrl.searchParams.set('dsh-desktop-platform', process.platform)`).
- This is a small, additive change; no pref semantics are altered for existing users.
