### PR TITLE
fix: 桌面端无边框窗口下右上角折叠按钮点击无效

### DIFF
--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -25,6 +25,17 @@
   gap: 4px;
 }
 
+/* Desktop (frameless window): the cluster sits inside the app's
+   center-column titlebar drag strip (-webkit-app-region: drag, the top
+   40px band of the conversation column). Without no-drag, Electron
+   swallows the clicks for window dragging and the expand/collapse buttons
+   never fire — mark the cluster and its buttons no-drag so the toggles
+   receive the click (mirrors the official sidebar/header no-drag rules). */
+html[data-dsh-desktop=true] .toggleCluster,
+html[data-dsh-desktop=true] .toggleButton {
+  -webkit-app-region: no-drag;
+}
+
 /* The tab strip of the OPEN right panel reserves the cluster's width at its
    right end, so the tabs and the + menu genuinely yield space to the cluster
    (never hiding under it). */


### PR DESCRIPTION
## 问题

桌面端（macOS/Windows 无边框窗口，DSH 0.1.0-rc.5）点击右上角的两个面板按钮（底部面板 / 侧边面板）毫无反应，无法展开/收起面板。

## 根因

DSH 桌面端是无边框 Electron 窗口，官方 UI 在会话列顶部放了一条 **40px 高、全宽的标题栏拖拽条**（`.desktopTitlebarDragRegion`，`-webkit-app-region: drag`，`inset: 0`）。Electron 中，拖拽区域内的点击会被交给**窗口拖拽**：只有声明了 `-webkit-app-region: no-drag` 的元素才能收到鼠标事件（官方 sidebar / conversation header 正是这样给每个交互控件标 `no-drag` 的）。

本插件的 toggle cluster 固定定位在 `top: 3px; right: 10px`——恰好落在这条拖拽带内——而插件源码里**没有任何 `-webkit-app-region` 声明**。于是点击被 Electron 吞掉（表现为点了没反应、拖一下能拖窗），`togglePanel()` / `toggleBottomPanel()` 的 `onClick` 永远不触发。

## 修复

给 cluster 及其按钮补上 `-webkit-app-region: no-drag`（仅 `html[data-dsh-desktop=true]` 下生效；普通浏览器里该属性被忽略，行为不变）：

```css
html[data-dsh-desktop=true] .toggleCluster,
html[data-dsh-desktop=true] .toggleButton {
  -webkit-app-region: no-drag;
}
```

## 验证

本机 DSH 0.1.0-rc.5 桌面端（macOS）实测：硬刷新后两个按钮均可正常展开/收起面板。web 端行为不受影响。

## 附带说明

- 只改 CSS，未触碰任何 DSH 源码（符合仓库硬约束）。
- 同类风险点：open 状态下 panel 顶部 tab 条不在拖拽带内，无需处理；如后续有其他固定定位在顶部 40px 内的交互元素，记得同样加 `no-drag`。