### PR TITLE
catalog: add dsh-video-preview (video previewer) to the file-previewer recommended plugins

### DIFF
--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -228,6 +228,7 @@ export const zh = {
   pluginOfficeDesc: '为 better-sidebar 编辑器提供 Office 三件套预览（.docx / .xlsx / .pptx），把重型 Office 渲染库拆出主包、按需安装',
   pluginSentinelDesc: '条件驱动的 agent 唤醒系统：文件/进程/端口/HTTP/命令/webhook 传感器，条件达成自动唤醒休眠会话；注册「哨兵」Tab 展示服务器全局监控表',
   pluginSidebarQaDesc: '基于 better-sidebar 的划选提问tab分页: 对话划选 → 右侧面板提问 → 同工作区独立追问会话（❓追问·主题）：快速无思考模型压缩主对话上下文后与引文一起注入，不打断主对话；追问可嵌套、可继续、可归档',
+  pluginVideoPreviewDesc: '在 better-sidebar 编辑器内联预览视频文件（.mp4/.webm/.mov/.mkv/.avi 等），自带支持 HTTP Range（206）的 /video 宿主路由，可拖动进度条、不受 20MB mediaLimit 限制',
 }
 
 /** The en dictionary (key-set-equal to zh, enforced by the type annotation). */
@@ -449,6 +450,7 @@ export const en: Record<keyof typeof zh, string> = {
   pluginOfficeDesc: 'Office-suite preview (.docx / .xlsx / .pptx) for the better-sidebar editor, keeping the heavy Office render libraries out of the core bundle',
   pluginSentinelDesc: 'Condition-driven agent wakeup: file/process/port/http/command/webhook sensors wake dormant sessions when conditions fire; registers a "Sentinel" tab with the server-wide watch table',
   pluginSidebarQaDesc: 'Select-and-ask: Select conversation text → ask in the right-side panel → a dedicated follow-up session (❓追问) in the same workspace; a fast no-thinking model compresses the main context and injects it with the quote, without interrupting the main conversation. Follow-ups nest, continue, and archive',
+  pluginVideoPreviewDesc: 'Inline video preview (.mp4/.webm/.mov/.mkv/.avi etc.) for the better-sidebar editor, backed by a dedicated /video host route with HTTP Range (206) support — scrubbing works and files are not capped by the 20MB mediaLimit',
 }
 
 /**

--- a/src/client/plugins-viewers.ts
+++ b/src/client/plugins-viewers.ts
@@ -20,4 +20,11 @@ export const builtinViewerPlugins: readonly PluginEntry[] = [
     description: () => t('pluginOfficeDesc'),
     install: 'cd ~/.dsh && dsh plugin --profile web add @huanlin/dsh-plugin-better-sidebar-plugin-office',
   },
+  {
+    id: 'dsh-video-preview',
+    name: '视频预览插件',
+    url: 'https://github.com/zemul/dsh-video-preview',
+    description: () => t('pluginVideoPreviewDesc'),
+    install: 'cd ~/.dsh && dsh plugin --profile web add dsh-video-preview',
+  },
 ]

--- a/tests/add-plugin-modal.spec.tsx
+++ b/tests/add-plugin-modal.spec.tsx
@@ -155,7 +155,7 @@ describe('PluginListBody copy click (interactive)', () => {
     vi.restoreAllMocks()
   })
 
-  it('both the name button and the jump button open the repo in a NEW browser tab (window.open, not a link)', () => {
+  it('the name and jump buttons open each catalog entry in a NEW browser tab (window.open, not a link)', () => {
     const store = createSidebarStore()
     const service = createBetterSidebarService(store)
     const opened: Array<[string, string, string]> = []
@@ -171,14 +171,21 @@ describe('PluginListBody copy click (interactive)', () => {
       act(() => {
         root.render(createElement(PluginListBody, { service, kind: 'viewer' }))
       })
+      // Two window.open buttons per catalog entry — the name button and the
+      // jump button. The expected count is catalog-driven so adding or
+      // removing recommended plugins keeps the test honest instead of
+      // pinning a hardcoded total.
       const jumpButtons = [...container.querySelectorAll('button[aria-label^="Open:"]')]
-      expect(jumpButtons).toHaveLength(2) // the name + the jump button
-      act(() => { (jumpButtons[0] as HTMLButtonElement).click() })
-      act(() => { (jumpButtons[1] as HTMLButtonElement).click() })
-      expect(opened).toEqual([
-        [officeEntry.url, '_blank', 'noopener'],
-        [officeEntry.url, '_blank', 'noopener'],
-      ])
+      expect(jumpButtons).toHaveLength(builtinViewerPlugins.length * 2)
+      for (const button of jumpButtons) {
+        act(() => { (button as HTMLButtonElement).click() })
+      }
+      expect(opened).toEqual(
+        builtinViewerPlugins.flatMap((entry) => [
+          [entry.url, '_blank', 'noopener'],
+          [entry.url, '_blank', 'noopener'],
+        ]),
+      )
       act(() => { root.unmount() })
       container.remove()
     } finally {


### PR DESCRIPTION
## 变更内容

把视频预览插件 **dsh-video-preview** 收录进「添加预览插件」推荐目录（Side card 设置 → 文件预览网格 → 虚线卡片）。

- `src/client/plugins-viewers.ts`：追加一条 `PluginEntry`（id = npm 包名 `dsh-video-preview`，url = GitHub 仓库，install 以 `cd ~/.dsh` 开头）
- `src/client/locales.ts`：新增 `pluginVideoPreviewDesc`（zh / en）本地化文案

数据完整性由 `tests/plugin-list.spec.ts` 守护（唯一 id、GitHub URL、install 含 `dsh plugin`、描述非空、`cd ~/.dsh` 前缀）——已逐条核验通过。

## 插件简介

[zemul/dsh-video-preview](https://github.com/zemul/dsh-video-preview)：为 better-sidebar 提供视频文件内联预览（.mp4/.webm/.mov/.mkv/.avi 等），通过 `ctx.betterSidebar.registerFileViewer` 注册 `video` 预览器，并自带支持 HTTP Range（206 Partial Content）的 `/video` 宿主路由——可以拖动进度条、不受 20MB `mediaLimit` 限制。仓库已打 `dsh-better-sidebar` / `dsh-plugin` / `deepseek-harness` topic。