### PR TITLE
fix: 迁移弃用的 xterm 依赖至 @xterm/xterm（Closes #122）

### DIFF
--- a/docs/plans/2026-08-10-office-preview-design.md
+++ b/docs/plans/2026-08-10-office-preview-design.md
@@ -260,7 +260,9 @@ if (officeKind === 'docx' || officeKind === 'xlsx') {
 - `xlsx`(SheetJS,~400KB,xlsx 导入)
 - `@univerjs/core` + `@univerjs/sheets` + `@univerjs/sheets-ui` + `@univerjs/sheets-formula` + `@univerjs/sheets-conditional-formatting` + `@univerjs/sheets-chart` + `@univerjs/docs-ui` + `@univerjs/design` + `@univerjs/engine-render`(~5MB 合计)
 
-**不放 `peerDependencies`**:这些是插件自有运行时依赖,不由 web profile 提供(对比现有 `node-pty`/`xterm`/`CodeMirror` 也在 `dependencies`)。
+**不放 `peerDependencies`**:这些是插件自有运行时依赖,不由 web profile 提供(对比现有 `node-pty`/`CodeMirror` 也在 `dependencies`)。
+
+> **实施偏差记录（#122，2026-08）**：上文"`xterm` 也在 `dependencies`"已过时——`xterm` 与 `@xterm/addon-fit` 自 v0.13.0 起从 `dependencies` 迁至 `devDependencies`：二者始终内联进 `lib/client-terminal.js`（tsdown `noExternal` 全内联 + CSS 构建期解析），运行时零依赖；同时代码与开发依赖已从已弃用的 `xterm` 迁移到官方新包名 `@xterm/xterm@^5.5.0`（addon-fit@0.10.0 的 peer 约束锁 `^5.0.0`，不用 6.x），消除用户安装时的 deprecated 与 missing-peer 警告。Office 预览若落地，其依赖按同一原则处理。
 
 ### 5.2 tsdown.config.ts 调整
 

--- a/package.json
+++ b/package.json
@@ -129,13 +129,11 @@
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.8",
     "@lezer/highlight": "^1.2.3",
-    "@xterm/addon-fit": "^0.10.0",
     "clsx": "^2.1.1",
     "node-pty": "^1.1.0",
     "rxjs": "^7.8.2",
     "schemastery": "^3.18.0",
-    "ws": "^8.18.0",
-    "xterm": "^5.3.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@cordisjs/plugin-loader": "^1.0.0-rc.5",
@@ -159,6 +157,8 @@
     "@types/react": "~18.3.1",
     "@types/react-dom": "~18.3.1",
     "@types/ws": "^8.5.10",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "cordis": "^4.0.0-rc.7",
     "jsdom": "^29.1.1",
     "lightningcss": "^1.32.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@types/react": "~18.3.1",
     "@types/react-dom": "~18.3.1",
     "@types/ws": "^8.5.10",
-    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "cordis": "^4.0.0-rc.7",
     "jsdom": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
-      '@xterm/addon-fit':
-        specifier: ^0.10.0
-        version: 0.10.0(@xterm/xterm@5.4.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -92,9 +89,6 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.21.3
-      xterm:
-        specifier: ^5.3.0
-        version: 5.3.0
     devDependencies:
       '@cordisjs/plugin-loader':
         specifier: ^1.0.0-rc.5
@@ -159,6 +153,12 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.18.1
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       cordis:
         specifier: ^4.0.0-rc.7
         version: 4.0.0-rc.8(@cordisjs/plugin-loader@1.0.0-rc.5)
@@ -1191,8 +1191,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
-  '@xterm/xterm@5.4.0':
-    resolution: {integrity: sha512-GlyzcZZ7LJjhFevthHtikhiDIl8lnTSgol6eTM4aoSNLcuXu3OEhnbqdCVIjtIil3jjabf3gDtb1S8FGahsuEw==}
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   '@yuku-codegen/binding-android-arm64@0.8.5':
     resolution: {integrity: sha512-+oEBxK35kdbskhxozjZhI8N6qrMOfphpIkXnqBj6N2DC08rdkg10MUMRNKZLBNU6uNyoYiLcLyCE6aFV2sfMKw==}
@@ -2165,10 +2165,6 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-
-  xterm@5.3.0:
-    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
-    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
 
   yuku-ast@0.8.5:
     resolution: {integrity: sha512-Ez2CI2BnPK/if0tVI7jB9UUDSNibcChjJDEPEKuWPJNRkbvzSoAQrSqpKtdzl8qTPp4ftVb87f/jx5HIKOieQw==}
@@ -3390,11 +3386,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.4.0)':
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
-      '@xterm/xterm': 5.4.0
+      '@xterm/xterm': 5.5.0
 
-  '@xterm/xterm@5.4.0': {}
+  '@xterm/xterm@5.5.0': {}
 
   '@yuku-codegen/binding-android-arm64@0.8.5':
     optional: true
@@ -4384,8 +4380,6 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  xterm@5.3.0: {}
 
   yuku-ast@0.8.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ^8.5.10
         version: 8.18.1
       '@xterm/addon-fit':
-        specifier: ^0.10.0
-        version: 0.10.0(@xterm/xterm@5.5.0)
+        specifier: ^0.11.0
+        version: 0.11.0
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -1186,10 +1186,8 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@xterm/addon-fit@0.10.0':
-    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
-    peerDependencies:
-      '@xterm/xterm': ^5.0.0
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -3386,9 +3384,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
-    dependencies:
-      '@xterm/xterm': 5.5.0
+  '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/xterm@5.5.0': {}
 

--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -20,9 +20,9 @@
  *   reconnect grace.
  */
 import { useEffect, useRef, useState } from 'react'
-import { Terminal, type ITheme } from 'xterm'
+import { Terminal, type ITheme } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
-import 'xterm/css/xterm.css'
+import '@xterm/xterm/css/xterm.css'
 import { t } from './locales.ts'
 import { openWhenSized } from './open-when-sized.ts'
 import type { SessionScope } from './api.ts'

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -248,7 +248,7 @@ function makeCssPlugin(pluginId: string): BuildPlugin {
     resolveId(source: string, importer: string | undefined) {
       if (!source.endsWith('.css')) return null
       // Relative/absolute paths resolve against the importer; bare
-      // specifiers (e.g. 'xterm/css/xterm.css') resolve from the package.
+      // specifiers (e.g. '@xterm/xterm/css/xterm.css') resolve from the package.
       let abs: string
       if (source.startsWith('.') || source.startsWith('/') || /^[A-Za-z]:[\\/]/.test(source)) {
         abs = importer === undefined ? source : resolvePath(dirname(importer), source)


### PR DESCRIPTION
Closes #122

## 问题

- `dependencies` 声明旧 npm 包 `xterm@^5.3.0`（官方已弃用，项目 v5.5.0 起更名 `@xterm/xterm`），每次安装触发 `[WARN] 1 deprecated subdependencies found: xterm@5.3.0`；
- `@xterm/addon-fit@0.10.0` 的 peer 指向新包名 `@xterm/xterm (^5.0.0)`，新旧混用导致 `pnpm peers check` 报 missing peer。

## 分析与方案

xterm / @xterm/addon-fit **始终内联**进 `lib/client-terminal.js` 懒加载 chunk（`tsdown.config.ts` 的 `noExternal` 全内联 + CSS 构建期 `require.resolve`），运行时零依赖 → 采纳 issue 建议 1（移除运行时依赖），并合并建议 2（代码迁移新包名），开发/CI 环境同样干净：

| 变更 | 内容 |
|---|---|
| `package.json` | `dependencies` 删除 `xterm` / `@xterm/addon-fit`；`devDependencies` 添加 `@xterm/xterm@^5.5.0` + `@xterm/addon-fit@^0.11.0`（构建期仍需：tsdown 内联 + CSS 解析 + 类型） |
| `src/client/TerminalView.tsx` | import 改为 `@xterm/xterm`；CSS 路径 `@xterm/xterm/css/xterm.css` |
| `tsdown.config.ts` | 注释 specifier 示例同步 |
| `pnpm-lock.yaml` | 移除 `xterm@5.3.0` 条目；`@xterm/xterm` 由隐式 peer 5.4.0 变为显式 devDependency 5.5.0 |
| `docs/plans/2026-08-10-office-preview-design.md` | 补实施偏差记录 |

**版本选择**：
- `@xterm/xterm@^5.5.0`（5.x 最新 stable，非 6.0.0）：与 xterm 6.0.0 同分钟发布的 addon-fit 0.11.0 所用 API（`_renderService.clear()`、`options.overviewRuler?.width` 兜底）在 5.5.0 上均存在且行为一致——overviewRuler 在 5.x 为 undefined 时回退 14，与 0.10.0 旧逻辑相同；不夹带 6.0 的 major 升级。
- `@xterm/addon-fit@^0.11.0`（顺带升级，2025-12 发布）：不再声明 peer 依赖，peer 解析噪音进一步消除（lockfile 中 `0.10.0(@xterm/xterm@5.5.0)` 的挂载关系消失）。

## 验证（全部通过）

- `pnpm install`：无 deprecated 警告
- `pnpm peers check`：`No peer dependency issues found`
- `pnpm typecheck` / `pnpm build`：通过
- `pnpm test`：41 files / 515 tests passed（addon-fit 0.11.0 下复跑）
- `pnpm pack`：tarball `dependencies` 无任何 xterm 声明；`lib/client-terminal.js`（465KB）完全自包含（无外部 xterm require）
- `pnpm test:mount`（真实 DSH 挂载门禁）：2 e2e 通过（含终端懒加载 chunk 深扫 + fit/resize 路径，两次复跑均绿）
- 模拟用户安装（scratch profile）：无 deprecated / 无 xterm missing peer（仅剩宿主 peer 提示 `@deepseek-ai/dsh-tools`/`react`/`react-dom`——由 DSH web 运行时提供，pre-existing，与本次无关）

## 风险

- 纯 client-half 依赖声明变更，host half（node-pty 等）零接触；运行时行为不变（依赖 bundle 内联代码）。