### PR TITLE
fix(sidebar): drag-release bounce, session-delete terminal cleanup, silent resize

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -25,7 +25,7 @@
  * drawer floats). Widening does not migrate back: the tabs keep living in
  * the right tree.
  */
-import { createElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { createElement, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useSyncExternalStore } from 'react'
 import clsx from 'clsx'
 import { IconCloseFill14, Tooltip } from '@deepseek-ai/dsh-client-ui-primitives'
@@ -491,14 +491,23 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
    *  too — React state only updates on release, so the inline right must be
    *  written directly or the bottom panel would lag the sidebar mid-drag. */
   const applyDrag = (width: number, height: number): void => {
-    panelRef.current?.style.setProperty('width', `${width}px`)
+    // Fix (bounce): the width must only be written while the right panel is
+    // OPEN. When it is closed, `state.width` still holds the last used width,
+    // so dragging the bottom panel height used to write a stale non-zero
+    // `--dsh-sidebar-width` and squeezed the conversation left for the whole
+    // drag (it only recovered on release).
+    const effWidth = state?.panelOpen === true ? width : 0
+    const baseWidth = state?.panelOpen === true ? (state?.width ?? 0) : 0
+    panelRef.current?.style.setProperty('width', `${effWidth}px`)
     bottomRef.current?.style.setProperty('height', `${height}px`)
     // centerRect.right is the center column's right edge at the committed
     // width (innerWidth - state.width - detailsWidth), so this equals
-    // `width + detailsWidth` — derived from the measured column, keeping the
-    // drag write-only (no React re-render mid-drag).
-    bottomRef.current?.style.setProperty('right', `${(window.innerWidth - centerRect.right) + (width - (state?.width ?? 0))}px`)
-    document.documentElement.style.setProperty('--dsh-sidebar-width', `${width}px`)
+    // `effWidth + detailsWidth` — derived from the measured column, keeping the
+    // drag write-only (no React re-render mid-drag). With the panel closed
+    // both effWidth and baseWidth are 0, so the bottom panel keeps only the
+    // native details-column offset (0 on current DSH builds).
+    bottomRef.current?.style.setProperty('right', `${(window.innerWidth - centerRect.right) + (effWidth - baseWidth)}px`)
+    document.documentElement.style.setProperty('--dsh-sidebar-width', `${effWidth}px`)
     document.documentElement.style.setProperty('--dsh-sidebar-height', `${height}px`)
     // The corner handle positions itself relative to the panel (CSS
     // `bottom: calc(var(--dsh-sidebar-height) + 6px)`), so these two layout
@@ -542,7 +551,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // crush the app shell to zero. Dragging disables the layout transition.
   // On NARROW viewports the drawer FLOATS over the app shell — no push, the
   // conversation keeps the full width behind the drawer.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const width = !narrow && snapshot.state?.panelOpen === true
       ? Math.min(snapshot.state.width, window.innerWidth)
       : 0
@@ -556,8 +565,18 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // HMR), the CSS variables would otherwise stay on <html> and layout.css
     // keeps squeezing #root with a stale margin — "the sidebar cannot be
     // hidden" until a full reload. removeProperty restores the CSS fallback
-    // (var(--dsh-sidebar-width, 0px)); React re-runs cleanup+setup in the
-    // same commit on state changes, so there is no visible flicker.
+    // (var(--dsh-sidebar-width, 0px)).
+    //
+    // Fix (bounce): this effect was a passive `useEffect`, which runs AFTER
+    // paint. On release the cleanup removes the variables and the setup
+    // re-adds them, but the two phases can straddle a paint (React 18/19
+    // flush passive effects in chunks), so the browser paints the
+    // intermediate state where `--dsh-sidebar-width` is missing and #root's
+    // margin-right falls back to 0 — the conversation flashes back to full
+    // width and then returns ("bounce"). A layout effect runs synchronously
+    // before paint, so cleanup+setup land in the same frame and the
+    // intermediate state is never painted, while the unmount cleanup above
+    // still releases the push exactly as before.
     return () => {
       document.documentElement.style.removeProperty('--dsh-sidebar-width')
       document.documentElement.style.removeProperty('--dsh-sidebar-height')
@@ -798,8 +817,23 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
                 if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
                 event.currentTarget.releasePointerCapture(event.pointerId)
                 const { startX, startWidth } = widthDrag.current
+                // Fix (bounce): flush the FINAL frame BEFORE stopDragScheduling.
+                // The stop cancels the pending rAF, so the DOM variables would
+                // otherwise stay at the second-to-last frame's width while the
+                // store commits the final one — a few px that re-animate when
+                // the drag transition comes back.
+                const finalWidth = clampWidth(startWidth + (startX - event.clientX))
+                const finalHeight = state.bottomOpen ? Math.min(state.bottomHeight, window.innerHeight) : 0
+                applyDrag(finalWidth, finalHeight)
+                // Keep the bottom panel's measured right edge in sync with the
+                // committed width (details-column offset preserved), so the
+                // release render doesn't paint the pre-drag edge.
+                const detailsOffset = Math.max(0, window.innerWidth - centerRect.right - (state.panelOpen ? state.width : 0))
+                setCenterRect(prev => prev.right === centerRect.right
+                  ? { left: prev.left, right: window.innerWidth - finalWidth - detailsOffset }
+                  : prev)
                 stopDragScheduling()
-                store.reduce(s => setWidth(s, startWidth + (startX - event.clientX)))
+                store.reduce(s => setWidth(s, finalWidth))
                 setDraggingWidth(false)
               }}
             />
@@ -852,8 +886,17 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
               if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
               event.currentTarget.releasePointerCapture(event.pointerId)
               const { startX, startY, startWidth, startHeight } = cornerDrag.current
+              // Fix (bounce): flush the final frame before stopDragScheduling
+              // (same as the width/bottom drags).
+              const finalWidth = clampWidth(startWidth + (startX - event.clientX))
+              const finalHeight = clampHeight(startHeight + (startY - event.clientY))
+              applyDrag(finalWidth, finalHeight)
+              const detailsOffset = Math.max(0, window.innerWidth - centerRect.right - state.width)
+              setCenterRect(prev => prev.right === centerRect.right
+                ? { left: prev.left, right: window.innerWidth - finalWidth - detailsOffset }
+                : prev)
               stopDragScheduling()
-              store.reduce(s => setBottomHeight(setWidth(s, startWidth + (startX - event.clientX)), startHeight + (startY - event.clientY)))
+              store.reduce(s => setBottomHeight(setWidth(s, finalWidth), finalHeight))
               setDraggingCorner(false)
             }}
           />
@@ -908,8 +951,13 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
             if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
             event.currentTarget.releasePointerCapture(event.pointerId)
             const { startY, startHeight } = bottomDrag.current
+            // Fix (bounce): flush the final frame before stopDragScheduling
+            // (same as the width drag — the pending rAF would otherwise be
+            // dropped and the height would snap back a few px on release).
+            const finalHeight = clampHeight(startHeight + (startY - event.clientY))
+            applyDrag(Math.min(state.width, window.innerWidth), finalHeight)
             stopDragScheduling()
-            store.reduce(s => setBottomHeight(s, startHeight + (startY - event.clientY)))
+            store.reduce(s => setBottomHeight(s, finalHeight))
             setDraggingBottom(false)
           }}
         />

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -132,7 +132,7 @@
 }
 
 .panelResizeActive {
-  background: var(--dsw-alias-interactive-bg-hover-accent);
+  /* Drag feedback disabled by local preference: no highlight while resizing. */
 }
 
 .panelBody {
@@ -195,7 +195,7 @@
 }
 
 .bottomResizeActive {
-  background: var(--dsw-alias-interactive-bg-hover-accent);
+  /* Drag feedback disabled by local preference: no highlight while resizing. */
 }
 
 /* The bottom panel's close control: the app's icon-button pattern (28px
@@ -274,8 +274,8 @@
   touch-action: none;
 }
 
-.cornerHandle:hover,
-.cornerHandle[data-dragging] {
+.cornerHandle:hover {
+  /* Only hover feedback stays; dragging highlight disabled by local preference. */
   background: var(--dsw-alias-interactive-bg-hover-accent);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -705,6 +705,13 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
     wss.close()
     agentListWss.close()
   }, 'dsh-better-sidebar: teardown')
+
+  // Close all UI terminals of a session when the conversation is deleted —
+  // terminals follow the session, not the reconnect grace. Agent terminals
+  // are owned by the agent lifecycle and are not touched here.
+  ctx.on('session/disposed', (session) => {
+    try { ptyManager.closeSession(session?.id) } catch {}
+  }, { global: true })
 }
 
 /** Push the live agent-terminal list for one session to a connected sidebar view. */

--- a/src/pty-manager.ts
+++ b/src/pty-manager.ts
@@ -184,6 +184,12 @@ export class PtyManager {
     }
   }
 
+  /** Close every terminal of one session (the conversation was deleted —
+   *  terminals must follow the session, not linger until the grace expires). */
+  closeSession(sessionId: string): void {
+    for (const key of this.keysOf(sessionId)) this.close(key)
+  }
+
   /** Close every terminal (plugin teardown). */
   disposeAll(): void {
     for (const timer of this.pendingCloses.values()) clearTimeout(timer)


### PR DESCRIPTION
# PR 描述（复制到 GitHub Pull Request 使用）

## 标题

```
fix(sidebar): eliminate drag-release bounce, clean up terminals on session delete, silent resize drag
```

## 描述（中文版）

### 一、修复拖动松手时的布局弹跳（3 个根因，`src/client/Sidebar.tsx`）

**1. 聊天区弹回全宽再回归**

- 现象：拖动右栏拉宽/拉窄松手后，聊天区瞬间弹回全宽再缩回。
- 根因：`--dsh-sidebar-width/-height` 的维护 effect 是 `useEffect`（paint 后异步执行），cleanup 的 `removeProperty` 与 setup 的 `setProperty` 在 passive-effect 分片 flush 时可能跨一次 paint——变量缺失帧里 `#root` 的 `margin-right: var(...,0px)` 回退到 0，聊天区被画成全宽。
- 修复：改为 `useLayoutEffect`（paint 前同步，cleanup+setup 同帧），卸载时的 `removeProperty`（issue #31 语义）原样保留。

**2. 底部面板右侧跳位**

- 现象：开着底部面板拖右栏宽度，松手后底部面板右侧跳位。
- 根因：`right: window.innerWidth - centerRect.right` 依赖最近一次测量，松手提交那一帧 centerRect 还是拖动前旧值。
- 修复：宽度/角部拖动 `onPointerUp` 提交时同步更新 `centerRect.right`（用最终宽度 + 保留 details 列偏移推导），与 `applyDrag` 拖动中的直写一致。

**3. 右栏关闭时聊天区被误挤 + 松手微跳**

- 根因 A：`applyDrag` 无条件写 `--dsh-sidebar-width`，拖底部高度时传入的是 `state.width` 历史值（右栏已关闭仍非 0），聊天区被挤左。
- 根因 B：`onPointerUp` 先 `stopDragScheduling()` 丢弃挂起的 rAF，DOM 停留在倒数第二帧，与提交值差几像素。
- 修复：`applyDrag` 宽度只在 `panelOpen` 时写（`effWidth`，保留 details 偏移语义）；三个拖动（宽度/高度/角部）松手时先 flush 最终帧再提交。

### 二、会话删除时立即关闭该会话终端（`src/index.ts` + `src/pty-manager.ts`）

- 背景：UI 终端断开后由 `reconnectGraceMs`（默认 30s）宽限回收，用于"切换会话/刷新后重连同一 shell"。但**删除会话**后终端仍要等宽限到期才被回收。
- 修复：新增 `PtyManager.closeSession(sessionId)`，订阅 DSH 的 `session/disposed` 事件，会话销毁时立即关闭该会话全部 UI 终端（agent 终端由 agent 生命周期管理，不受影响）。

### 三、拖动时不高亮可拖动范围（`src/client/sidebar.module.css`）

- 本地偏好：右栏/底部/角部拖动手柄在拖动中不再显示高亮背景（`panelResizeActive`/`bottomResizeActive`/`cornerHandle[data-dragging]` 的 background 移除）；角部 hover 提示保留。如与项目风格冲突可舍弃此条。

### 测试

本机 DSH 0.1.0-rc.6 + 0.12.2（Windows）实测：
- 右栏/底部/角部拖动松手无弹跳、底部面板无跳位、右栏关闭时拖底部不挤聊天区
- 删除会话后该会话终端立即释放
- 切换会话后终端保留并在宽限期内重连同一条 shell

### 补丁文件

`better-sidebar-contribution.patch`（4 文件，93 增 22 删，`git apply` 干净通过）。

---

## Description (English)

### 1. Fix drag-release layout bounce (`src/client/Sidebar.tsx`)

- **Conversation flashes full-width**: the `--dsh-sidebar-width/-height` effect ran as a passive `useEffect`; during chunked passive-effect flushing, the cleanup's `removeProperty` and setup's `setProperty` can straddle a paint, so `#root`'s `margin-right` falls back to `0px` for one painted frame. Switching to `useLayoutEffect` keeps cleanup+setup in the same pre-paint frame; the unmount `removeProperty` (issue #31 semantics) is preserved.
- **Bottom panel jumps on width drag release**: `right: window.innerWidth - centerRect.right` used the pre-drag measurement for one frame. The width/corner `onPointerUp` now updates `centerRect.right` synchronously with the final width (details-column offset preserved).
- **Closed right panel still squeezed the conversation** while dragging the bottom height (`applyDrag` wrote the stale `state.width`), and release snapped a few px because `stopDragScheduling()` dropped the pending rAF. `applyDrag` now writes the width only when `panelOpen` (`effWidth`), and all three drags flush the final frame before committing.

### 2. Close a session's terminals when the conversation is deleted (`src/index.ts` + `src/pty-manager.ts`)

UI terminals survive disconnects for `reconnectGraceMs` (default 30 s) so a tab switch/refresh reattaches the same shell — but deleting a session left them lingering until the grace expired. Added `PtyManager.closeSession(sessionId)` and subscribed to DSH's `session/disposed` to release them immediately. Agent terminals are agent-lifecycle-owned and untouched.

### 3. No highlight while dragging the resize handles (`src/client/sidebar.module.css`)

Local preference: removed the drag-state background on the width/height/corner handles; the corner hover hint stays. Drop this commit if it conflicts with the project style.

### Tests

Verified on DSH 0.1.0-rc.6 + 0.12.2 (Windows): no bounce on any drag release, bottom panel stays put, closed right panel no longer squeezes the conversation, session deletion releases its terminals immediately, and tab switches keep the same shell within the grace window.
