### PR TITLE
fix(sidebar): avoid direct betterSidebar reads with dsh-web-mobile

### DIFF
--- a/src/client/EditorHost.tsx
+++ b/src/client/EditorHost.tsx
@@ -70,7 +70,7 @@ export function EditorHost(props: { ctx: Context; store: SidebarStore; scope: Se
               content: result.kind === 'text' ? result.content : '',
               truncated: result.truncated,
               head: result.kind === 'binary' ? result.head : undefined,
-            }, (head) => ctx.betterSidebar?.matchFileViewer(path, head), mediaUrlOf)
+            }, (head) => ctx.get('betterSidebar')?.matchFileViewer(path, head), mediaUrlOf)
             apply(outcome)
           }).catch((error: unknown) => {
             if (cancelled) return
@@ -79,7 +79,7 @@ export function EditorHost(props: { ctx: Context; store: SidebarStore; scope: Se
           return
       }
     }
-    apply(planFirstMatch(ctx.betterSidebar?.matchFileViewer(path), mediaUrlOf))
+    apply(planFirstMatch(ctx.get('betterSidebar')?.matchFileViewer(path), mediaUrlOf))
     return () => { cancelled = true; controller.abort() }
   }, [scope.sessionId, scope.cwd, path, ctx])
 

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -42,6 +42,7 @@ import { Workbench, type WorkbenchActions } from './split-pane.tsx'
 import { useNarrowViewport } from './breakpoints.ts'
 import type { NewTabOption } from './TabBar.tsx'
 import type { TabDragPayload } from './TabBar.tsx'
+import type { BetterSidebarService } from './service.ts'
 import { relativeTo } from './paths.ts'
 import { OrphanedTab } from './OrphanedTab.tsx'
 import { RenderBoundary } from './RenderBoundary.tsx'
@@ -64,6 +65,7 @@ function TabContent(props: {
   onToggleDir: (path: string) => void
   onReferenceFile: (path: string) => void
   ctx: Context
+  service: BetterSidebarService
   store: SidebarStore
   /** Whether this tab is the active one AND the panel is open (live views pause otherwise). */
   visible: boolean
@@ -72,9 +74,9 @@ function TabContent(props: {
   /** Open a diff tab from the git panel (placement handled by the store). */
   onOpenDiff: (tab: SidebarTab) => void
 }) {
-  const { tab, sessionId, cwd, expanded, onToggleDir, onReferenceFile, ctx, store, visible, onSubagentJump, onOpenDiff } = props
+  const { tab, sessionId, cwd, expanded, onToggleDir, onReferenceFile, ctx, service, store, visible, onSubagentJump, onOpenDiff } = props
   const scope = { sessionId, cwd }
-  const descriptor = ctx.betterSidebar?.getTab(tab.type)
+  const descriptor = service.getTab(tab.type)
   if (descriptor === undefined) {
     return <OrphanedTab ctx={ctx} store={store} scope={scope} tab={tab} visible={visible} />
   }
@@ -101,9 +103,7 @@ function TabContent(props: {
  * a disabled row (e.g. terminal at capacity) instead of hiding the option.
  * Tabs the user disabled in the side card settings are filtered out
  * entirely — re-enabling them is the settings page's job. */
-function buildNewTabOptions(state: SidebarState, ctx: Context, scope: SessionScope): NewTabOption[] {
-  const service = ctx.betterSidebar
-  if (service === undefined) return []
+function buildNewTabOptions(state: SidebarState, ctx: Context, service: BetterSidebarService, scope: SessionScope): NewTabOption[] {
   return service.getTabs()
     .filter(d => !d.hidden && service.isTabEnabled(d.id))
     .sort((a, b) => (a.order ?? 100) - (b.order ?? 100))
@@ -115,8 +115,8 @@ function buildNewTabOptions(state: SidebarState, ctx: Context, scope: SessionSco
     }))
 }
 
-export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
-  const { ctx, store } = props
+export function Sidebar(props: { ctx: Context; store: SidebarStore; service: BetterSidebarService }) {
+  const { ctx, store, service } = props
 
   // Copy freshness: re-render the whole tree when the DSH locale switches.
   // The module-level t() reads the active locale at call time, so a root
@@ -252,7 +252,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
         try {
           const list = JSON.parse(event.data) as Array<{ uuid: string; title: string; command: string; exited: boolean }>
           if (!Array.isArray(list)) return
-          store.reduce(s => ctx.betterSidebar?.isTabEnabled('terminal') === false
+          store.reduce(s => service.isTabEnabled('terminal') === false
             ? s
             : reconcileAgentTerminals(s, list))
         } catch {
@@ -276,7 +276,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       window.clearTimeout(retry)
       socket?.close()
     }
-  }, [sessionId, store])
+  }, [sessionId, store, service])
 
   /**
    * Subagent auto-activation: the moment the current conversation spawns its
@@ -295,14 +295,14 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     if (sessionId === undefined || prev === undefined) return
     if (!detectNewDirectSubagent(prev, sessionList, sessionId)) return
     if (!store.getPrefs().autoOpenSubagent) return
-    if (ctx.betterSidebar?.isTabEnabled('subagent') === false) return
+    if (service.isTabEnabled('subagent') === false) return
     store.reduce(s => s.panelOpen ? s : togglePanel(s))
     // Pin the landing to the right panel: the auto-opened Subagent page must
     // appear where the panel just expanded, not in a bottom-panel pane the
     // user last touched.
     store.reduce(s => ({ ...s, activePane: firstLeaf(s.splits).id }))
-    ctx.betterSidebar?.openTab({ type: 'subagent', title: t('subagent') })
-  }, [sessionList, sessionId, store, ctx])
+    service.openTab({ type: 'subagent', title: t('subagent') })
+  }, [sessionList, sessionId, store, ctx, service])
 
   /**
    * Job auto-activation: the moment a NEW background job appears for the
@@ -320,11 +320,11 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     if (sessionId === undefined || prev === undefined) return
     if (!detectNewJob(prev, sessionList, sessionId)) return
     if (!store.getPrefs().autoOpenJobs) return
-    if (ctx.betterSidebar?.isTabEnabled('subagent') === false) return
+    if (service.isTabEnabled('subagent') === false) return
     store.reduce(s => s.panelOpen ? s : togglePanel(s))
     store.reduce(s => ({ ...s, activePane: firstLeaf(s.splits).id }))
-    ctx.betterSidebar?.openTab({ type: 'subagent', title: t('subagent') })
-  }, [sessionList, sessionId, store, ctx])
+    service.openTab({ type: 'subagent', title: t('subagent') })
+  }, [sessionList, sessionId, store, ctx, service])
 
   /**
    * Topology jump-back: clicking a subagent node on the Subagent page calls
@@ -344,8 +344,8 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     subagentJumpRef.current = undefined
     store.reduce(s => s.panelOpen ? s : togglePanel(s))
     store.reduce(s => ({ ...s, activePane: firstLeaf(s.splits).id }))
-    ctx.betterSidebar?.openTab({ type: 'subagent', title: t('subagent') })
-  }, [sessionId, store, ctx])
+    service.openTab({ type: 'subagent', title: t('subagent') })
+  }, [sessionId, store, ctx, service])
 
   // The app shell's center column: the bottom panel spans ONLY that column
   // ("squeezes the agent output area") — it starts at the app sidebar's
@@ -446,12 +446,12 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     if (wasOpen === undefined || wasOpen || !state.bottomOpen) return
     if (state.bottomOpenedOnce) return
     if (store.getPrefs().bottomPanelAutoTerminal === false) return
-    if (ctx.betterSidebar?.isTabEnabled('terminal') === false) return
+    if (service.isTabEnabled('terminal') === false) return
     // Land the tab in the bottom panel's first pane; the once-flag is set
     // atomically so later expansions never repeat the auto-open.
     store.reduce(s => ({ ...s, activePane: firstLeaf(s.bottomSplits).id, bottomOpenedOnce: true }))
-    ctx.betterSidebar?.openTab({ type: 'terminal' })
-  }, [state, store, ctx, narrow])
+    service.openTab({ type: 'terminal' })
+  }, [state, store, ctx, narrow, service])
 
   // Panel drags: the right panel's width (left edge strip), the bottom
   // panel's height (top edge strip), and the shared corner (both at once).
@@ -589,7 +589,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       // Route through the service: the tab-bar close is the canonical close
       // path (finds the pane itself, fires descriptor.onClose); the session
       // scope (with its cwd) rides to the callback.
-      ctx.betterSidebar?.closeTab(tabId, sessionId === undefined ? undefined : { sessionId, cwd })
+      service.closeTab(tabId, sessionId === undefined ? undefined : { sessionId, cwd })
       if (tab?.type === 'terminal') {
         if (isAgentTabId(tabId)) {
           const uuid = agentUuidOf(tabId)
@@ -603,7 +603,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       // Route through the service: same reducer (finds the pane in EITHER
       // tree, sets the active pane) and fires descriptor.onActivate; the
       // session scope (with its cwd) rides to the callback.
-      ctx.betterSidebar?.activateTab(tabId, sessionId === undefined ? undefined : { sessionId, cwd })
+      service.activateTab(tabId, sessionId === undefined ? undefined : { sessionId, cwd })
     },
     focusPane: (paneId) => { store.reduce(s => ({ ...s, activePane: paneId })) },
     moveTabToEdge: (payload: TabDragPayload, toPane: string, zone: DropZone) => {
@@ -622,7 +622,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     resizeSplit: (splitId, index, deltaFrac) => {
       store.reduce(s => resizeSplitIn(s, splitId, index, deltaFrac))
     },
-  }), [store, sessionId, cwd])
+  }), [store, sessionId, cwd, service])
 
   /**
    * The explorer's @-reference button: append `@<relative path>` to the
@@ -658,8 +658,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   }
 
   const onNewTab = (optionId: string): void => {
-    const service = ctx.betterSidebar
-    const descriptor = service?.getTab(optionId)
+    const descriptor = service.getTab(optionId)
     if (descriptor === undefined) return
     const title = typeof descriptor.title === 'function' ? descriptor.title() : descriptor.title
     // The session scope rides along: lifecycle callbacks receive it (and
@@ -675,7 +674,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
    */
   /** The tab icon from the tab-type registry (shared by every workbench). */
   const tabIconOf = (tab: SidebarTab): ReactNode => {
-    const descriptor = ctx.betterSidebar?.getTab(tab.type)
+    const descriptor = service.getTab(tab.type)
     if (descriptor === undefined) return null
     return typeof descriptor.icon === 'function' ? descriptor.icon(14) : descriptor.icon
   }
@@ -686,7 +685,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
    * strip must never break because a plugin's badge computation failed.
    */
   const tabBadgeOf = (tab: SidebarTab): ReactNode => {
-    const descriptor = ctx.betterSidebar?.getTab(tab.type)
+    const descriptor = service.getTab(tab.type)
     if (descriptor?.badge === undefined) return null
     let value: string | number | null | undefined
     try {
@@ -716,6 +715,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       onToggleDir={(path) => { store.reduce(s => toggleExpanded(s, path)) }}
       onReferenceFile={referenceInChat}
       ctx={ctx}
+      service={service}
       store={store}
       visible={bottom ? state.bottomOpen && active : state.panelOpen && active}
       onSubagentJump={(childSessionId) => { subagentJumpRef.current = childSessionId }}
@@ -807,7 +807,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
         <div className={css.panelBody}>
           <Workbench
             state={state}
-            newTabOptions={buildNewTabOptions(state, ctx, { sessionId, cwd })}
+            newTabOptions={buildNewTabOptions(state, ctx, service, { sessionId, cwd })}
             actions={actions}
             onNewTab={onNewTab}
             renderTab={renderTab}
@@ -932,7 +932,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
           <Workbench
             state={state}
             tree={state.bottomSplits}
-            newTabOptions={buildNewTabOptions(state, ctx, { sessionId, cwd })}
+            newTabOptions={buildNewTabOptions(state, ctx, service, { sessionId, cwd })}
             actions={actions}
             onNewTab={onNewTab}
             renderTab={(tab, active, paneId) => renderTab(tab, active, paneId, true)}

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -115,7 +115,7 @@ export function apply(ctx: Context): void {
           host.setAttribute('data-dsh-better-sidebar', '')
           document.body.appendChild(host)
           root = createRoot(host)
-          root.render(createElement(RenderBoundary, { className: css.boundaryError }, createElement(Sidebar, { ctx, store: sidebarStore })))
+          root.render(createElement(RenderBoundary, { className: css.boundaryError }, createElement(Sidebar, { ctx, service, store: sidebarStore })))
         } catch (error) {
           fail('mount', error)
         }
@@ -182,7 +182,7 @@ export function apply(ctx: Context): void {
               let title: string | undefined
               try { title = new URL(url).hostname } catch { /* keep the default title */ }
               const type = urlTargetOf(new URL(url)) ?? 'browser'
-              ctx.betterSidebar?.openTab({ type, url, title })
+              service.openTab({ type, url, title })
             },
             selfOrigin: window.location.origin,
           })

--- a/src/client/intercept.tsx
+++ b/src/client/intercept.tsx
@@ -22,7 +22,7 @@ export function openSidebarFile(ctx: Context, store: SidebarStore, sessionId: st
   const title = at === -1 ? absolute : absolute.slice(at + 1)
   // Route through the sidebar service so the editor descriptor's dedupeKey
   // (per-path) applies; the id is path-derived so multiple editors coexist.
-  ctx.betterSidebar?.openTab({ type: 'editor', title, path: absolute, id: `editor:${absolute}` })
+  ctx.get('betterSidebar')?.openTab({ type: 'editor', title, path: absolute, id: `editor:${absolute}` })
 }
 
 /** The intercepted produced-files row (visual twin of the deliverables chips). */

--- a/tests/bottom-auto-terminal.spec.tsx
+++ b/tests/bottom-auto-terminal.spec.tsx
@@ -64,10 +64,9 @@ function mountSidebar(): MountedSidebar {
   const ctx = {
     locale: { subscribe: () => () => {}, getSnapshot: () => localeSnapshot },
     sessions: { list: { subscribe: () => () => {}, getSnapshot: () => sessionsSnapshot } },
-    betterSidebar: service,
   }
   const root: Root = createRoot(container)
-  act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, store })) })
+  act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, service, store })) })
   return {
     container,
     store,

--- a/tests/sidebar-crash.spec.tsx
+++ b/tests/sidebar-crash.spec.tsx
@@ -66,10 +66,9 @@ function mountSidebar(): MountedSidebar {
   const ctx = {
     locale: { subscribe: () => () => {}, getSnapshot: () => localeSnapshot },
     sessions: { list: { subscribe: () => () => {}, getSnapshot: () => sessionsSnapshot } },
-    betterSidebar: service,
   }
   const root: Root = createRoot(container)
-  act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, store })) })
+  act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, service, store })) })
   return {
     container,
     store,
@@ -84,6 +83,34 @@ function mountSidebar(): MountedSidebar {
 afterEach(() => {
   document.body.innerHTML = ''
   vi.unstubAllGlobals()
+})
+
+describe('service seat compatibility', () => {
+  it('renders without reading ctx.betterSidebar directly', () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const container = document.createElement('div')
+    document.body.append(container)
+    const store = createSidebarStore()
+    const service = createBetterSidebarService(store)
+    store.setSession('s1')
+    const localeSnapshot = { active: 'en' }
+    const sessionsSnapshot = {
+      current: 's1', byId: { s1: { cwd: '/tmp' } },
+    }
+    const ctx = {
+      locale: { subscribe: () => () => {}, getSnapshot: () => localeSnapshot },
+      sessions: { list: { subscribe: () => () => {}, getSnapshot: () => sessionsSnapshot } },
+      get: (name: string) => name === 'betterSidebar' ? service : undefined,
+    }
+    Object.defineProperty(ctx, 'betterSidebar', {
+      get() { throw new Error('cannot get property "betterSidebar" without inject') },
+    })
+    const root: Root = createRoot(container)
+    act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, service, store })) })
+    expect(container.textContent).not.toContain('without inject')
+    act(() => { root.unmount() })
+    container.remove()
+  })
 })
 
 describe('layout-push variable cleanup', () => {

--- a/tests/turn-tail-intercept.spec.ts
+++ b/tests/turn-tail-intercept.spec.ts
@@ -75,13 +75,17 @@ const producedOwner = (paths: string[]): unknown => ({
 const emptyOwner = (): unknown => ({ nodes: [{ kind: 'assistant', seq: 1, turn: 1 }], seq: 1 })
 
 /** The minimal client-context fake the registration (and its seats) touch. */
-const clientCtx = (slots: unknown): Context => ({
-  slots,
-  sessions: {
-    list: { getSnapshot: () => ({ current: 's1', byId: { s1: { id: 's1', cwd: '/w', displayTitle: 's1' } } }) },
-  },
-  betterSidebar: { openTab: vi.fn() },
-} as unknown as Context)
+const clientCtx = (slots: unknown): Context => {
+  const betterSidebar = { openTab: vi.fn() }
+  return {
+    slots,
+    sessions: {
+      list: { getSnapshot: () => ({ current: 's1', byId: { s1: { id: 's1', cwd: '/w', displayTitle: 's1' } } }) },
+    },
+    get: (name: string) => name === 'betterSidebar' ? betterSidebar : undefined,
+    betterSidebar,
+  } as unknown as Context
+}
 
 describe('turn-tail interception registration (issue #15)', () => {
   it('registers through slots.inject and lands once the slot is already declared', () => {
@@ -169,7 +173,7 @@ describe('turn-tail interception registration (issue #15)', () => {
     const seat = inject('s1')
     expect(seat.openInSidebar).toBeTypeOf('function')
     seat.openInSidebar('/w/src/a.ts')
-    expect(ctx.betterSidebar.openTab).toHaveBeenCalledWith({
+    expect(ctx.get('betterSidebar')!.openTab).toHaveBeenCalledWith({
       type: 'editor',
       title: 'a.ts',
       path: '/w/src/a.ts',

--- a/tests/unit.spec.ts
+++ b/tests/unit.spec.ts
@@ -1697,12 +1697,14 @@ describe('open-path interception wiring', () => {
     // the workspaces funnel, and the sidebar service the editor goes through.
     const opened: Array<Record<string, unknown>> = []
     const funnel = { openPath: async (): Promise<void> => {} }
+    const betterSidebar = { openTab: (seed: unknown) => { opened.push(seed as Record<string, unknown>) } }
     const ctx = {
       sessions: {
         list: { getSnapshot: () => ({ current: 's1', byId: { s1: { cwd: '/w' } } }) },
       },
       workspaces: funnel,
-      betterSidebar: { openTab: (seed: unknown) => { opened.push(seed as Record<string, unknown>) } },
+      get: (name: string) => name === 'betterSidebar' ? betterSidebar : undefined,
+      betterSidebar,
     } as unknown as Context
     const store = createSidebarStore()
     const original = ctx.workspaces.openPath


### PR DESCRIPTION
## Problem

Installing dsh-better-sidebar together with dsh-web-mobile can make the sidebar render fail with:

    cannot get property "betterSidebar" without inject

Cordis traceable method binding can register betterSidebar in a neighboring client fiber while the rendering fiber does not declare it as an injected service. Internal direct property reads then throw.

## Change

- Pass the concrete service into the Sidebar tree instead of reading ctx.betterSidebar.
- Use ctx.get("betterSidebar") in the remaining internal consumers.
- Add a regression test that makes direct ctx.betterSidebar access fail.

## Verification

- pnpm typecheck
- pnpm build
- Focused compatibility tests: 125/125
- Full suite excluding host pty smoke tests: 485/485
- Real DSH scratch profile with dsh-web-mobile and an active session: both plugins mount with no sidebar error.
