### PR TITLE
feat(explorer): restore passive fs-events file tree refresh

### DIFF
--- a/src/client/ExplorerView.tsx
+++ b/src/client/ExplorerView.tsx
@@ -36,8 +36,10 @@ function baseName(path: string): string {
 /** How long the row's "copied" label stays after a successful write. */
 const COPIED_MS = 1200
 
-/** How many consecutive fs-events reconnect failures stop the push loop. */
-const FS_FAILURE_LIMIT = 3
+/** Reconnect backoff for the passive fs-events socket. */
+const FS_RETRY_BASE_MS = 1000
+const FS_RETRY_MAX_MS = 30_000
+const FS_RETRY_STABLE_MS = 10_000
 
 export function ExplorerView(props: {
   sessionId: string
@@ -49,9 +51,16 @@ export function ExplorerView(props: {
   onReferenceFile: (path: string) => void
 }) {
   const { sessionId, cwd, expanded, onToggle, onOpenFile, onReferenceFile } = props
+  const expandedKey = expanded.join('\0')
   const [data, setData] = useState<Record<string, LevelData>>({})
   const dataRef = useRef(data)
-  const [refreshTick, setRefreshTick] = useState(0)
+  /** Latest request generation per directory; stale responses never win. */
+  const requestVersionRef = useRef(new Map<string, number>())
+  /** Directories visible during the previous render (collapsed levels can go stale). */
+  const visibleDirsRef = useRef<{ cwd: string | undefined; expanded: Set<string> }>({
+    cwd: undefined,
+    expanded: new Set(),
+  })
   /** The row whose path was just copied ("copied" label replaces its button). */
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
   /** Open context menu: the row path (and whether it is a directory) plus the cursor position. */
@@ -62,38 +71,59 @@ export function ExplorerView(props: {
     setData(dataRef.current)
   }, [])
 
-  const loadDir = useCallback((dir: string) => {
-    if (dataRef.current[dir] !== undefined) return
-    storeLevel(dir, {})
+  const loadDir = useCallback((dir: string, force = false) => {
+    const previous = dataRef.current[dir]
+    if (!force && previous !== undefined) return
+    const version = (requestVersionRef.current.get(dir) ?? 0) + 1
+    requestVersionRef.current.set(dir, version)
+    // Initial loads show the loading row. Refreshes keep the previous listing
+    // mounted and swap the new entries in atomically, avoiding tree flicker.
+    if (previous === undefined) storeLevel(dir, {})
     api.fsTree({ sessionId, cwd }, dir).then((listing) => {
+      if (requestVersionRef.current.get(dir) !== version) return
       storeLevel(dir, { entries: listing.entries })
     }).catch((error: unknown) => {
+      if (requestVersionRef.current.get(dir) !== version) return
+      // A passive refresh failure must not replace a usable tree with an error.
+      if (previous?.entries !== undefined) return
       storeLevel(dir, { error: error instanceof Error ? error.message : String(error) })
     })
   }, [sessionId, cwd, storeLevel])
 
   useEffect(() => {
-    // Load the visible set; already-loaded levels (kept in the cache) are
-    // not refetched. Only the refresh button wipes the cache.
     const root = cwd
     if (root === undefined) return
+    const previous = visibleDirsRef.current.cwd === root
+      ? visibleDirsRef.current.expanded
+      : new Set<string>()
     loadDir(root)
-    for (const dir of expanded) loadDir(dir)
-  }, [cwd, expanded, refreshTick, loadDir])
+    // A directory can change while collapsed because it is intentionally not
+    // watched then. Re-expansion therefore performs one background revalidate.
+    for (const dir of expanded) loadDir(dir, !previous.has(dir))
+    visibleDirsRef.current = { cwd: root, expanded: new Set(expanded) }
+  }, [cwd, expandedKey, loadDir])
+
+  /** Revalidate the visible tree without clearing any rendered rows. */
+  const refreshVisible = useCallback(() => {
+    if (cwd === undefined) return
+    loadDir(cwd, true)
+    for (const dir of expanded) loadDir(dir, true)
+  }, [cwd, expandedKey, loadDir])
 
   /**
    * Passive file-tree refresh: subscribe to host fs.watch events for the
    * visible/expanded directories. The host pushes `{type:'change', path}`
-   * when a watched directory's contents change; we drop that directory from
-   * the local cache and let the loading effect above refetch it. No polling.
+   * when a watched directory's contents change; we revalidate that level in
+   * the background and atomically swap the result. No polling or blank state.
    */
-  const expandedKey = expanded.join('\0')
   useEffect(() => {
     if (cwd === undefined) return
     let socket: WebSocket | null = null
     let retry: number | undefined
+    let stable: number | undefined
     let closed = false
     let failures = 0
+    let openedOnce = false
     const connect = (): void => {
       if (closed) return
       const url = new URL('/sidebar/ws/fs-events', location.origin)
@@ -101,13 +131,18 @@ export function ExplorerView(props: {
       url.search = new URLSearchParams({ sessionId, cwd }).toString()
       socket = new WebSocket(url.toString())
       socket.onopen = () => {
-        failures = 0
+        window.clearTimeout(stable)
+        stable = window.setTimeout(() => { failures = 0 }, FS_RETRY_STABLE_MS)
         const dirs = [cwd, ...expanded]
         for (const dir of dirs) {
           if (socket?.readyState === WebSocket.OPEN) {
             socket.send(JSON.stringify({ type: 'watch', path: dir }))
           }
         }
+        // Changes can happen during a broken connection. A reconnect closes
+        // that blind spot with one no-flicker revalidation of visible levels.
+        if (openedOnce) refreshVisible()
+        openedOnce = true
       }
       socket.onmessage = (event) => {
         if (typeof event.data !== 'string') return
@@ -116,22 +151,17 @@ export function ExplorerView(props: {
           if (msg?.type !== 'change' || typeof msg.path !== 'string') return
           const changed = msg.path
           if (dataRef.current[changed] === undefined && cwd !== changed && !expanded.includes(changed)) return
-          if (dataRef.current[changed] !== undefined) {
-            const next = { ...dataRef.current }
-            delete next[changed]
-            dataRef.current = next
-            setData(next)
-          }
-          setRefreshTick(tick => tick + 1)
+          loadDir(changed, true)
         } catch {
           // Malformed push: ignore (the next real change will refresh).
         }
       }
       socket.onclose = () => {
         if (closed) return
+        window.clearTimeout(stable)
         failures += 1
-        if (failures >= FS_FAILURE_LIMIT) return
-        retry = window.setTimeout(connect, 2000)
+        const delay = Math.min(FS_RETRY_BASE_MS * (2 ** Math.min(failures - 1, 5)), FS_RETRY_MAX_MS)
+        retry = window.setTimeout(connect, delay)
       }
       socket.onerror = () => { socket?.close() }
     }
@@ -139,9 +169,10 @@ export function ExplorerView(props: {
     return () => {
       closed = true
       window.clearTimeout(retry)
+      window.clearTimeout(stable)
       socket?.close()
     }
-  }, [sessionId, cwd, expandedKey])
+  }, [sessionId, cwd, expandedKey, loadDir, refreshVisible])
 
   /** Copy `text`; on success flip the row's copied label for a moment. */
   const copyPath = useCallback((text: string, path: string): void => {
@@ -268,11 +299,7 @@ export function ExplorerView(props: {
           className={css.iconButton}
           aria-label={t('refresh')}
           title={t('refresh')}
-          onClick={() => {
-            dataRef.current = {}
-            setData({})
-            setRefreshTick(tick => tick + 1)
-          }}
+          onClick={refreshVisible}
         >
           <IconRefreshOutline16 size={14} />
         </button>

--- a/src/client/ExplorerView.tsx
+++ b/src/client/ExplorerView.tsx
@@ -36,6 +36,9 @@ function baseName(path: string): string {
 /** How long the row's "copied" label stays after a successful write. */
 const COPIED_MS = 1200
 
+/** How many consecutive fs-events reconnect failures stop the push loop. */
+const FS_FAILURE_LIMIT = 3
+
 export function ExplorerView(props: {
   sessionId: string
   cwd: string | undefined
@@ -77,6 +80,68 @@ export function ExplorerView(props: {
     loadDir(root)
     for (const dir of expanded) loadDir(dir)
   }, [cwd, expanded, refreshTick, loadDir])
+
+  /**
+   * Passive file-tree refresh: subscribe to host fs.watch events for the
+   * visible/expanded directories. The host pushes `{type:'change', path}`
+   * when a watched directory's contents change; we drop that directory from
+   * the local cache and let the loading effect above refetch it. No polling.
+   */
+  const expandedKey = expanded.join('\0')
+  useEffect(() => {
+    if (cwd === undefined) return
+    let socket: WebSocket | null = null
+    let retry: number | undefined
+    let closed = false
+    let failures = 0
+    const connect = (): void => {
+      if (closed) return
+      const url = new URL('/sidebar/ws/fs-events', location.origin)
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      url.search = new URLSearchParams({ sessionId, cwd }).toString()
+      socket = new WebSocket(url.toString())
+      socket.onopen = () => {
+        failures = 0
+        const dirs = [cwd, ...expanded]
+        for (const dir of dirs) {
+          if (socket?.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: 'watch', path: dir }))
+          }
+        }
+      }
+      socket.onmessage = (event) => {
+        if (typeof event.data !== 'string') return
+        try {
+          const msg = JSON.parse(event.data) as { type?: unknown; path?: unknown }
+          if (msg?.type !== 'change' || typeof msg.path !== 'string') return
+          const changed = msg.path
+          if (dataRef.current[changed] === undefined && cwd !== changed && !expanded.includes(changed)) return
+          if (dataRef.current[changed] !== undefined) {
+            const next = { ...dataRef.current }
+            delete next[changed]
+            dataRef.current = next
+            setData(next)
+          }
+          setRefreshTick(tick => tick + 1)
+        } catch {
+          // Malformed push: ignore (the next real change will refresh).
+        }
+      }
+      socket.onclose = () => {
+        if (closed) return
+        failures += 1
+        if (failures >= FS_FAILURE_LIMIT) return
+        retry = window.setTimeout(connect, 2000)
+      }
+      socket.onerror = () => { socket?.close() }
+    }
+    connect()
+    return () => {
+      closed = true
+      window.clearTimeout(retry)
+      socket?.close()
+    }
+  }, [sessionId, cwd, expandedKey])
 
   /** Copy `text`; on success flip the row's copied label for a moment. */
   const copyPath = useCallback((text: string, path: string): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
  * processes are keyed by session.
  */
 import { mkdir, open, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { watch as fsWatch, type FSWatcher } from 'node:fs'
 import { basename, dirname, extname, isAbsolute, join } from 'node:path'
 import type { IncomingMessage } from 'node:http'
 import type { Duplex } from 'node:stream'
@@ -123,6 +124,91 @@ async function resolveGitPath(cwd: string, raw: string): Promise<string> {
 
 /** How many leading bytes a binary read returns for client-side detect sniffing. */
 const READ_HEAD_LIMIT = 4096
+
+/** Debounce for batched fs.watch notifications per directory. */
+const FS_WATCH_DEBOUNCE_MS = 120
+
+/**
+ * Shared fs.watch hub for the explorer's passive refresh. Watchers are
+ * keyed by absolute directory and reference-counted per connected socket;
+ * a directory is watched only while at least one explorer view is watching
+ * it. Events are debounced per directory to avoid spamming the browser.
+ */
+class FsWatchHub {
+  private readonly watchers = new Map<string, {
+    watcher: FSWatcher
+    sockets: Set<WebSocket>
+    timer: ReturnType<typeof setTimeout> | null
+  }>()
+
+  watch(dir: string, socket: WebSocket): void {
+    const existing = this.watchers.get(dir)
+    if (existing !== undefined) {
+      existing.sockets.add(socket)
+      return
+    }
+    let watcher: FSWatcher
+    try {
+      watcher = fsWatch(dir, { persistent: false }, (eventType) => {
+        // Only directory-entry changes (create/delete/rename) alter the tree;
+        // file content edits don't need an explorer refresh.
+        if (eventType === 'rename') this.schedule(dir)
+      })
+    } catch {
+      return
+    }
+    watcher.on('error', () => {
+      this.notify(dir)
+      this.drop(dir)
+    })
+    this.watchers.set(dir, { watcher, sockets: new Set([socket]), timer: null })
+  }
+
+  unwatch(dir: string, socket: WebSocket): void {
+    const entry = this.watchers.get(dir)
+    if (entry === undefined) return
+    entry.sockets.delete(socket)
+    if (entry.sockets.size === 0) this.drop(dir)
+  }
+
+  removeSocket(socket: WebSocket): void {
+    for (const [dir, entry] of this.watchers) {
+      if (entry.sockets.delete(socket) && entry.sockets.size === 0) this.drop(dir)
+    }
+  }
+
+  dispose(): void {
+    for (const dir of [...this.watchers.keys()]) this.drop(dir)
+  }
+
+  private schedule(dir: string): void {
+    const entry = this.watchers.get(dir)
+    if (entry === undefined || entry.timer !== null) return
+    entry.timer = setTimeout(() => {
+      const current = this.watchers.get(dir)
+      if (current === undefined) return
+      current.timer = null
+      this.notify(dir)
+    }, FS_WATCH_DEBOUNCE_MS)
+  }
+
+  private notify(dir: string): void {
+    const entry = this.watchers.get(dir)
+    if (entry === undefined) return
+    const message = JSON.stringify({ type: 'change', path: dir })
+    for (const socket of [...entry.sockets]) {
+      if (socket.readyState === WebSocket.OPEN) socket.send(message)
+    }
+  }
+
+  private drop(dir: string): void {
+    const entry = this.watchers.get(dir)
+    if (entry === undefined) return
+    if (entry.timer !== null) clearTimeout(entry.timer)
+    entry.watcher.close()
+    this.watchers.delete(dir)
+  }
+}
 
 /** Text read of a file with the size cap; binary detection via NUL probe.
  *  Binary reads also return the first {@link READ_HEAD_LIMIT} bytes (base64)
@@ -443,6 +529,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // through the terminal_create tool; the sidebar view attaches through the
   // same /sidebar/ws/terminal upgrade with ?uuid=... instead of ?tab=...
   const agentPtyRegistry = new AgentPtyRegistry(terminalShell)
+  const fsWatchHub = new FsWatchHub()
 
   // ── User-facing "Side card" preferences ──────────────────────────────────
   // Register the namespace with the settings provider so the Settings page
@@ -698,12 +785,33 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
     },
   }), 'dsh-better-sidebar: agent-terminals push WebSocket')
 
+  // ── Explorer fs-events push WebSocket ───────────────────────────────────
+  // Passive file-tree refresh: the explorer subscribes to fs.watch events
+  // for the directories it currently shows. The host watches only those
+  // directories (reference-counted) and pushes a lightweight change notice;
+  // the client drops the cached listing for that directory and refetches.
+  const fsWatchWss = new WebSocketServer({ noServer: true })
+  ctx.effect(() => ctx.webServer.registerUpgrade({
+    path: '/sidebar/ws/fs-events',
+    handler: (req, socket, head) => {
+      if (!fence(req)) {
+        socket.destroy()
+        return
+      }
+      fsWatchWss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
+        void attachFsEvents(ctx, fsWatchHub, ws, req)
+      })
+    },
+  }), 'dsh-better-sidebar: fs-events push WebSocket')
+
   ctx.effect(() => () => {
     toolsDisposers?.()
     ptyManager.disposeAll()
     agentPtyRegistry.disposeAll()
     wss.close()
     agentListWss.close()
+    fsWatchWss.close()
+    fsWatchHub.dispose()
   }, 'dsh-better-sidebar: teardown')
 }
 
@@ -729,6 +837,41 @@ async function attachAgentList(
     const unsubscribe = registry.subscribe(send)
     ws.on('close', () => { unsubscribe() })
     ws.on('error', () => { unsubscribe() })
+  } catch (error) {
+    ws.close(1011, error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Subscribe an explorer socket to host fs.watch notifications for its cwd. */
+async function attachFsEvents(
+  ctx: Context,
+  hub: FsWatchHub,
+  ws: WebSocket,
+  req: SidebarHttpRequest,
+): Promise<void> {
+  try {
+    const url = new URL(req.url ?? '/', 'http://dsh.internal')
+    const sessionId = url.searchParams.get('sessionId')
+    if (sessionId === null) {
+      ws.close(1008, 'sessionId is required')
+      return
+    }
+    const cwd = sessionCwdOf(ctx, sessionId, url.searchParams.get('cwd') ?? undefined)
+    ws.on('message', (data) => {
+      try {
+        const msg = JSON.parse(String(data)) as { type?: unknown; path?: unknown }
+        if (typeof msg?.path !== 'string') return
+        const absolute = requireAbsolute(msg.path)
+        if (!isWithin(cwd, absolute)) return
+        if (msg.type === 'watch') hub.watch(absolute, ws)
+        else if (msg.type === 'unwatch') hub.unwatch(absolute, ws)
+      } catch {
+        // Malformed message: ignore.
+      }
+    })
+    const cleanup = (): void => { hub.removeSocket(ws) }
+    ws.on('close', cleanup)
+    ws.on('error', cleanup)
   } catch (error) {
     ws.close(1011, error instanceof Error ? error.message : String(error))
   }


### PR DESCRIPTION
## Summary

Restore passive, event-driven file-tree auto-refresh via a host `fs.watch` WebSocket. v0.12.2 dropped the auto-refresh path, so the explorer file tree only updates when the user clicks the manual refresh button (README records the current state as “无文件 watcher（手动刷新）”).

This PR re-adds the plugin-owned host route + client subscription, using DSH public/plugin-owned APIs only (no harness changes):

- **Host** (`src/index.ts`): a reference-counted `FsWatchHub` backed by `node:fs` `fs.watch` (`persistent: false`), watching only the directories the explorer currently shows; `rename` events are debounced (120 ms) and pushed to subscribers as `{type:'change', path}`. A new upgrade route `/sidebar/ws/fs-events` is registered via `ctx.webServer.registerUpgrade`, guarded by the existing `fence(req)` trust check; watch paths are confined to the session cwd with `isWithin`. Hub + WS server are torn down in the plugin teardown effect.
- **Client** (`src/client/ExplorerView.tsx`): a passive effect opens `ws(s)://…/sidebar/ws/fs-events`, sends `watch` for `[cwd, ...expanded]`, and on a `change` push revalidates that directory in the background and atomically swaps the result — no polling, no blank/loading flicker. Reconnects with exponential backoff (2s base, capped), and resets after a stable period.

## Why

The file tree currently refreshes only manually. External file changes (e.g. `git clone`, editor saves that add/remove files, build outputs) are invisible until the user clicks refresh. Unlike client-side polling (see PR #10, which polls every 2 s), this is passive/event-driven — no setState storms, and only the changed directory is refetched.

## Files changed

- `src/index.ts` — `FsWatchHub` + `/sidebar/ws/fs-events` upgrade route + `attachFsEvents` handler + teardown
- `src/client/ExplorerView.tsx` — fs-events subscription effect + no-flicker background revalidation + `FS_RETRY_*` backoff constants

## Testing notes

- `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm check:consumer-types` should pass.
- Manual: create/delete/rename a file inside a visible directory → the tree updates without clicking refresh; a file *content* edit (not an entry change) does not spuriously refresh; a path outside cwd is rejected (no watch).
- CI `plugin-mount` job exercises the Explorer tab headlessly, so the new WS upgrade path is covered by the mount smoke gate.

## Notes

- Follows the AGENTS.md hard rule: host-side additions are plugin-owned routes only, no DSH harness modifications.
- Should be reviewed against the open PR #37 (explorer drag & drop touches the same files) to keep merges clean.