### PR TITLE
feat(sidebar): share the panel width across sessions so switching never makes it jump

### DIFF
--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -728,6 +728,37 @@ export function reconcileAgentTerminals(
 
 const STORAGE_PREFIX = 'dsh-sidebar:v1'
 
+/**
+ * Global (cross-session) panel width: when the user drags the sidebar in one
+ * conversation, the width is shared by every conversation so switching never
+ * makes the panel jump. Kept OUT of the per-session persisted layout (which
+ * historically stored its own width) under a dedicated key, so a width drag
+ * in one session propagates to all sessions without rewriting each layout.
+ */
+const GLOBAL_WIDTH_KEY = 'dsh-sidebar:width:v1'
+
+/** Read the globally shared panel width (clamped to the contract floor);
+ *  `undefined` when never set (the first active session seeds it). */
+function readGlobalWidth(): number | undefined {
+  try {
+    const raw = localStorage.getItem(GLOBAL_WIDTH_KEY)
+    if (raw === null) return undefined
+    const n = Number(raw)
+    return Number.isFinite(n) ? Math.max(PANEL_MIN, Math.round(n)) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Persist the globally shared panel width (best-effort). */
+function writeGlobalWidth(width: number): void {
+  try {
+    localStorage.setItem(GLOBAL_WIDTH_KEY, String(width))
+  } catch {
+    // Storage full or unavailable: the width memory is best-effort.
+  }
+}
+
 /** Immutable snapshot handed to React (replaced only on real changes). */
 export interface SidebarSnapshot {
   sessionId: string | undefined
@@ -943,6 +974,11 @@ export class SidebarStore {
   private readonly persistTimers = new Map<string, number>()
   /** User-facing side card prefs seeding brand-new session states (defaults until the settings RPC resolves). */
   private prefs: SidebarPrefs = { ...SIDEBAR_PREFS_DEFAULTS }
+  /** The globally shared panel width: read once from storage (persisted by a
+   *  previous reload) and lazily adopted from the first active session when
+   *  no persisted value exists yet. Written on every width drag and applied
+   *  to every session. */
+  private globalWidth: number | undefined = readGlobalWidth()
 
   /**
    * Replace the side card prefs (the settings RPC result / settings page
@@ -977,6 +1013,13 @@ export class SidebarStore {
         // pane/split ids can never collide with its tree.
         nextIdCounter = maxCounterId(state)
       }
+      // Global width: the panel width is SHARED across sessions. The first
+      // session to become active seeds the shared value (from its own
+      // default/persisted width); later sessions are forced to it so
+      // switching never makes the panel jump. Cached entries get the same
+      // treatment, keeping the switch consistent even after a drag.
+      state = this.withWidth(state)
+      if (state !== this.bySession.get(sessionId)) this.bySession.set(sessionId, state)
       this.snapshot = { sessionId, state, prefs: this.prefs }
     }
     this.notify()
@@ -997,7 +1040,9 @@ export class SidebarStore {
     const state = this.snapshot.state
     if (sessionId === undefined || state === undefined) return
     const draft = structuredClone(state)
+    const widthBefore = draft.width
     mutator(draft)
+    if (draft.width !== widthBefore) this.propagateWidth(sessionId, draft.width)
     this.bySession.set(sessionId, draft)
     this.snapshot = { sessionId, state: draft, prefs: this.prefs }
     this.schedulePersist(sessionId, draft)
@@ -1030,6 +1075,9 @@ export class SidebarStore {
     // patchTab on a missing tab) must not churn the state or rewrite
     // localStorage.
     if (next === state) return
+    // A width change (the width drag / shared corner commit) is GLOBAL: push
+    // it to every session so switching never makes the panel jump.
+    if (next.width !== state.width) this.propagateWidth(sessionId, next.width)
     this.bySession.set(sessionId, next)
     this.snapshot = { sessionId, state: next, prefs: this.prefs }
     this.schedulePersist(sessionId, next)
@@ -1065,8 +1113,45 @@ export class SidebarStore {
     // have been seeded down) but skip the write.
     nextIdCounter = Math.max(nextIdCounter, counterBefore)
     if (next === state) return
+    // A width change is global even from a targeted open.
+    if (next.width !== state.width) this.propagateWidth(sessionId, next.width)
     this.bySession.set(sessionId, next)
     this.schedulePersist(sessionId, next)
+  }
+
+  /**
+   * Apply the globally shared width to a session's state. When no shared
+   * value exists yet, ADOPT the session's current width as the global
+   * default (persisted under the global key). Otherwise force `state.width`
+   * to the shared value (clamped to the viewport so a stale fullscreen
+   * width can never crush the app shell).
+   */
+  private withWidth(state: SidebarState): SidebarState {
+    const max = typeof window !== 'undefined' ? Math.max(PANEL_MIN, window.innerWidth) : PANEL_MAX
+    const clamp = (w: number): number => Math.min(max, Math.max(PANEL_MIN, Math.round(w)))
+    if (this.globalWidth === undefined) {
+      this.globalWidth = clamp(state.width)
+      writeGlobalWidth(this.globalWidth)
+      return state.width === this.globalWidth ? state : { ...state, width: this.globalWidth }
+    }
+    const w = clamp(this.globalWidth)
+    return state.width === w ? state : { ...state, width: w }
+  }
+
+  /**
+   * React to a session's width changing (through setWidth / the corner
+   * drag): the new width becomes the GLOBAL width — persisted under the
+   * global key and pushed into every other cached session so a later switch
+   * is instantly consistent (no per-session jump).
+   */
+  private propagateWidth(sessionId: string, width: number): void {
+    const max = typeof window !== 'undefined' ? Math.max(PANEL_MIN, window.innerWidth) : PANEL_MAX
+    const w = Math.min(max, Math.max(PANEL_MIN, Math.round(width)))
+    this.globalWidth = w
+    writeGlobalWidth(w)
+    for (const [id, s] of this.bySession) {
+      if (id !== sessionId && s.width !== w) this.bySession.set(id, { ...s, width: w })
+    }
   }
 
   private schedulePersist(sessionId: string, state: SidebarState): void {

--- a/tests/unit.spec.ts
+++ b/tests/unit.spec.ts
@@ -17,7 +17,7 @@ import { parseLogLines, parsePorcelainZ } from '../src/git.ts'
 import { parseUnifiedDiff } from '../src/client/DiffView.tsx'
 import {
   activateTab, allLeaves, BOTTOM_DEFAULT, BOTTOM_MIN, closeTab, createSidebarStore, defaultWidthFor, insertLeafAt, makeDefaultState,
-  migrateBottomTabs, moveTab, moveTabToEdge, openDiffTab, openTabInActivePane, patchTab, reconcileAgentTerminals, resizeSplit, resizeSplitIn, sanitizeState, setBottomHeight, splitPane, tabOpenIn, toggleBottomPanel, toggleExpanded, togglePanel,
+  migrateBottomTabs, moveTab, moveTabToEdge, openDiffTab, openTabInActivePane, patchTab, reconcileAgentTerminals, resizeSplit, resizeSplitIn, sanitizeState, setBottomHeight, setWidth, splitPane, tabOpenIn, toggleBottomPanel, toggleExpanded, togglePanel,
   type SidebarState, type SidebarTab, type SplitNode,
 } from '../src/client/state.ts'
 import { loadPrefs, type SidebarSettingsClient } from '../src/client/prefs.ts'
@@ -1397,6 +1397,46 @@ describe('side card preferences', () => {
     }
   })
 
+  it('shares the panel width across sessions: a drag in one session is kept when switching', () => {
+    const g = globalThis as Record<string, unknown>
+    let seq = 0
+    const timers = new Map<number, () => void>()
+    const storeMap = new Map<string, string>()
+    g.window = {
+      clearTimeout: (id: number) => { timers.delete(id) },
+      setTimeout: (fn: () => void) => { const id = ++seq; timers.set(id, fn); return id },
+      innerWidth: 1024,
+      innerHeight: 800,
+    }
+    g.localStorage = {
+      getItem: (key: string) => storeMap.get(key) ?? null,
+      setItem: (key: string, value: string) => { storeMap.set(key, value) },
+    }
+    try {
+      const store = createSidebarStore()
+      // The first session seeds the shared width from its own default.
+      store.setSession('s1')
+      expect(store.getSnapshot().state?.width).toBe(307) // 30% of 1024
+      // Drag the width open in the FIRST session.
+      store.reduce(s => setWidth(s, 520))
+      expect(store.getSnapshot().state?.width).toBe(520)
+
+      // A second session, selected later, inherits the shared 520 — no jump.
+      store.setSession('s2')
+      expect(store.getSnapshot().state?.width).toBe(520)
+
+      // Switch BACK to the first session: still 520.
+      store.setSession('s1')
+      expect(store.getSnapshot().state?.width).toBe(520)
+
+      // The shared width persists under the global key (survives reload).
+      expect(storeMap.get('dsh-sidebar:width:v1')).toBe('520')
+    } finally {
+      delete g.window
+      delete g.localStorage
+    }
+  })
+
   it('skips the default explorer tab when the explorer type is disabled', () => {
     const store = createSidebarStore()
     store.setPrefs({ openByDefault: true, defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: { explorer: false }, viewersEnabled: {}, pluginSettings: {} })
@@ -1819,10 +1859,13 @@ describe('store.reduceFor (targeted opens, v0.12.0)', () => {
       store.reduce(s => ({ ...s, expanded: ['/a'] })) // schedules persist(a)
       store.reduceFor('b', s => ({ ...s, expanded: ['/b'] })) // schedules persist(b)
       // A shared timer would have cancelled persist(a) — with per-session
-      // timers BOTH writes are pending and both land when they fire.
+      // timers BOTH writes are pending and both land when they fire. The
+      // leading write is the glob-wide width key (the first session seeds
+      // the shared width on selection) — the point here is that the two
+      // SESSION layouts are written independently.
       expect(timers.size).toBe(2)
       for (const [, fn] of [...timers]) fn()
-      expect(writes).toEqual(['dsh-sidebar:v1:a', 'dsh-sidebar:v1:b'])
+      expect(writes).toEqual(['dsh-sidebar:width:v1', 'dsh-sidebar:v1:a', 'dsh-sidebar:v1:b'])
     } finally {
       delete g.window
       delete g.localStorage


### PR DESCRIPTION
## 问题

侧边栏宽度原来**按会话各自持久化**：每个对话窗口都记住自己独立的宽度，所以切换会话时侧边栏宽度会跳变（每个窗口宽度不一致，切起来很不舒服）。

期望：在当前窗口拖好宽度后，切换会话窗口时**宽度保持不变**。

## 改动

把宽度改为**全局共享**（跨会话），每个会话仍保留各自的打开/折叠、tabs、split 布局，只有 width 一项变为全局：

- 新增独立 localStorage 键 \dsh-sidebar:width:v1\（与每会话布局键分离）存共享宽度。
- 第一个激活的会话用其默认/持久化宽度**播种**该共享值。
- 任意会话里拖动宽度（右侧栏宽度拖动 / 共享角手柄提交）都成为全局值：写入全局键并同步到所有已缓存会话。
- \setSession\ 强制每个会话使用共享宽度（按视口 clamp），切换时面板不再跳变。

## 验证

- \pnpm typecheck\ 通过；\pnpm build\（tsc + tsdown）通过。
- 新增 store 测试：一个会话里拖宽度 → 切换另一个会话宽度保持；更新了一条 per-session 持久化计数测试以计入全局宽度键的额外写入。
- 完整测试套件：**9 failed / 493 passed / 1 skipped** —— 与 clean main 基线一致，9 个失败均为本机环境固有（Windows git CRLF / 路径分隔符 / 中文 locale 渲染），与本次改动无关，未引入任何新失败。