### PR TITLE
fix(tab-bar): middle-click close lost to autoscroll / release drift

### DIFF
--- a/src/client/TabBar.tsx
+++ b/src/client/TabBar.tsx
@@ -74,6 +74,38 @@ export function TabBar(props: {
   const [dragOver, setDragOver] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
 
+  // Middle-click close: the press target is recorded on middle mousedown
+  // (preventDefaulted to disarm Chrome's middle-click autoscroll — its
+  // indicator is inert here because the strip hides its scrollbar and only
+  // the wheel handler scrolls) and the close settles on the first middle
+  // mouseup OVER that same tab. Release-position semantics match VS Code
+  // (microsoft/vscode#101028) and what users expect from Chrome tabs
+  // (crbug/40679924): pressing on a tab and releasing elsewhere cancels the
+  // close. The browser dispatches auxclick to the nearest common ancestor of
+  // the press/release targets when they differ, so any drift, autoscroll
+  // scroll, or tab-list reflow between press and release would otherwise
+  // swallow the close; settling on the recorded press target at mouseup
+  // keeps release semantics without depending on auxclick delivery.
+  const onCloseRef = useRef(onClose)
+  const middlePressed = useRef<{ id: string; node: HTMLElement } | null>(null)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+  useEffect(() => {
+    const onMouseUp = (event: MouseEvent): void => {
+      if (event.button !== 1) return
+      const pressed = middlePressed.current
+      middlePressed.current = null
+      // Close only when the release lands on the pressed tab; a drag-away
+      // release cancels the press (one-shot per press).
+      if (pressed !== null && pressed.node.isConnected && pressed.node.contains(event.target as Node)) {
+        onCloseRef.current(pressed.id)
+      }
+    }
+    window.addEventListener('mouseup', onMouseUp)
+    return () => { window.removeEventListener('mouseup', onMouseUp) }
+  }, [])
+
   // Wheel over the strip scrolls the tab row horizontally (a plain mouse
   // wheel emits deltaY, which overflow-x alone never consumes). Bound as a
   // native NON-passive listener: React registers onWheel passively at the
@@ -151,11 +183,15 @@ export function TabBar(props: {
               if (payload !== null) onDropTab(payload, tab.id)
             }}
             onClick={() => { onActivate(tab.id) }}
-            onAuxClick={(event) => {
-              // Middle-click closes the tab (and suppresses autoscroll).
+            onMouseDown={(event) => {
+              // Middle-click close: record the press target and disarm
+              // Chrome's middle-click autoscroll (its indicator is inert
+              // here — the strip scrolls via the wheel handler only). The
+              // close itself settles on the first middle mouseup over this
+              // same tab (window-level), keeping release semantics.
               if (event.button === 1) {
                 event.preventDefault()
-                onClose(tab.id)
+                middlePressed.current = { id: tab.id, node: event.currentTarget }
               }
             }}
           >

--- a/tests/tab-bar-middle-click.spec.tsx
+++ b/tests/tab-bar-middle-click.spec.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tab-strip middle-click close tests. The press target is recorded on middle
+ * mousedown (preventDefaulted to disarm Chrome's middle-click autoscroll)
+ * and the close settles on the first middle mouseup OVER that same tab —
+ * release-position semantics matching VS Code (microsoft/vscode#101028) and
+ * user expectations for Chrome tabs (crbug/40679924): pressing on a tab and
+ * releasing elsewhere cancels. The browser dispatches auxclick to the common
+ * ancestor of the press/release targets when they differ (or suppresses it
+ * entirely), so settling on the recorded press target keeps release
+ * semantics without depending on auxclick delivery. Left-button paths
+ * (activate / drag) and wheel scrolling are untouched.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+
+// The act() environment flag (React 18.2 reads it before flushing effects).
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+import { TabBar } from '../src/client/TabBar.tsx'
+import type { SidebarTab } from '../src/client/state.ts'
+
+function mountBar(): {
+  tab0: HTMLElement
+  tab1: HTMLElement
+  onClose: ReturnType<typeof vi.fn>
+  onActivate: ReturnType<typeof vi.fn>
+  unmount: () => void
+} {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const onClose = vi.fn()
+  const onActivate = vi.fn()
+  const tabs: SidebarTab[] = [
+    { id: 't1', type: 'explorer', title: 'Explorer' },
+    { id: 't2', type: 'git', title: 'Git' },
+  ]
+  const root: Root = createRoot(container)
+  act(() => {
+    root.render(createElement(TabBar, {
+      paneId: 'pane:1',
+      tabs,
+      active: 't1',
+      onActivate,
+      onClose,
+      onNewTab: () => {},
+      newTabOptions: [],
+      onDropTab: () => {},
+    }))
+  })
+  const tabEls = [...container.querySelectorAll('[class*="tabList"] > [class*="tab"]')] as HTMLElement[]
+  expect(tabEls.length).toBe(2)
+  // noUncheckedIndexedAccess: the length assertion above is the guard, but
+  // the compiler still sees `HTMLElement | undefined` through indexing.
+  const tab0 = tabEls[0]!
+  const tab1 = tabEls[1]!
+  return {
+    tab0,
+    tab1,
+    onClose,
+    onActivate,
+    unmount: () => {
+      act(() => { root.unmount() })
+      container.remove()
+    },
+  }
+}
+
+/** Dispatch a native mouse event; returns the event (to read defaultPrevented). */
+function mouse(target: EventTarget, type: string, button: number): MouseEvent {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, button })
+  target.dispatchEvent(event)
+  return event
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('TabBar middle-click close', () => {
+  it('closes when the middle mouseup lands on the same tab', () => {
+    const { tab0, onClose, unmount } = mountBar()
+    try {
+      mouse(tab0, 'mousedown', 1)
+      mouse(tab0, 'mouseup', 1)
+      expect(onClose).toHaveBeenCalledWith('t1')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('preventDefaults the middle mousedown (disarms browser autoscroll)', () => {
+    const { tab0, unmount } = mountBar()
+    try {
+      const event = mouse(tab0, 'mousedown', 1)
+      expect(event.defaultPrevented).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('a release elsewhere (drag-away) cancels the close — one-shot', () => {
+    const { tab0, onClose, unmount } = mountBar()
+    try {
+      // Press on tab 0, release on unrelated element: no close.
+      mouse(tab0, 'mousedown', 1)
+      mouse(document.body, 'mouseup', 1)
+      expect(onClose).not.toHaveBeenCalled()
+      // A later middle mouseup over the tab (no new press) must NOT close.
+      mouse(tab0, 'mouseup', 1)
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('a release over a DIFFERENT tab does not close', () => {
+    const { tab0, tab1, onClose, unmount } = mountBar()
+    try {
+      mouse(tab0, 'mousedown', 1)
+      mouse(tab1, 'mouseup', 1)
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('middle mousedown on the close button closes (release over the tab)', () => {
+    const { tab0, onClose, unmount } = mountBar()
+    try {
+      const button = tab0.querySelector('button') as HTMLButtonElement
+      expect(button).not.toBeNull()
+      mouse(button, 'mousedown', 1)
+      mouse(button, 'mouseup', 1)
+      expect(onClose).toHaveBeenCalledWith('t1')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('left mousedown does not close; left click activates', () => {
+    const { tab0, onClose, onActivate, unmount } = mountBar()
+    try {
+      mouse(tab0, 'mousedown', 0)
+      mouse(tab0, 'mouseup', 0)
+      expect(onClose).not.toHaveBeenCalled()
+      mouse(tab0, 'click', 0)
+      expect(onActivate).toHaveBeenCalledWith('t1')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('a middle auxclick alone (no mousedown) does not close', () => {
+    // Pins the contract: the close settles on the mouseup of the recorded
+    // press, not on auxclick delivery — the browser redirects auxclick to
+    // the common ancestor (or suppresses it) when press/release targets
+    // differ, which was the failure mode.
+    const { tab0, onClose, unmount } = mountBar()
+    try {
+      mouse(tab0, 'auxclick', 1)
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('a left mouseup after a middle press does not consume the press', () => {
+    const { tab0, onClose, unmount } = mountBar()
+    try {
+      mouse(tab0, 'mousedown', 1)
+      mouse(window, 'mouseup', 0)
+      expect(onClose).not.toHaveBeenCalled()
+      mouse(tab0, 'mouseup', 1)
+      expect(onClose).toHaveBeenCalledWith('t1')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('stops closing after unmount', () => {
+    const { tab0, onClose, unmount } = mountBar()
+    mouse(tab0, 'mousedown', 1)
+    unmount()
+    mouse(tab0, 'mouseup', 1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #144

## Summary / 概述

Middle-click to close a tab was unreliable when the tab strip overflowed. The close settled on `auxclick` delivery, but the browser dispatches `auxclick` to the **nearest common ancestor** of the press/release targets when they differ — so any drift, middle-button autoscroll scroll, or tab-list reflow between press and release swallowed the close, leaving only an inert left-right scroll indicator (the strip hides its scrollbar; only the wheel handler scrolls).

中键关闭 tab 在页签填满时不可靠。关闭依赖 `auxclick` 派发,而浏览器在按下/松开目标元素不同时，把 `auxclick` 派发给**最近共同祖先**——位移、中键 autoscroll 滚动、tab 栏重排都会吞掉关闭，只留下一个无效的左右滚动光标(tab 栏隐藏了滚动条，只有滚轮能滚动)。

## Root cause / 根因

1. `onAuxClick` 关闭路径的前提是“按下/松开落在同一 tab 上”，这个前提不受项目控制
2. tab 栏填满(可滚动)时，Chrome 在 `mousedown` 时武装中键 autoscroll——按滚轮键的微位移即被接管，`auxclick` 丢失;而旧代码的 `preventDefault` 写在 auxclick 里，发生时序太晚
3. 按下与松开之间 tab 栏插入/移除页签(如 agent 终端自动开 tab)→ `auxclick` 干脆不派发

## Fix / 修复

`src/client/TabBar.tsx`:

- 每个 tab 新增 `onMouseDown`(button=1):`preventDefault()` 从源头解除 Chrome 的 autoscroll 武装(光标不再出现;该光标在本 UI 中无效——tab 栏隐藏滚动条、仅滚轮滚动)+ 记录按下目标(tab 元素引用)
- 移除 `onAuxClick` 关闭路径;window 级 `mouseup`(button=1)结算，**松开落在按下的那个 tab 上才关闭，否则取消**——release-position 语义，与 VS Code 一致(microsoft/vscode#101028)，也符合 Chrome tab 的用户预期(crbug/40679924:Chrome 目前“按下即记”的行为被用户当作 bug 上报)。每次按下一次性结算(one-shot)
- 左键激活/拖拽、滚轮横向滚动不受影响

`tests/tab-bar-middle-click.spec.tsx`:新增 9 个回归用例(同 tab 松开关闭、mousedown preventDefault、拖走松开取消且 one-shot、松开在别的 tab 不关、× 按钮冒泡、左键不关/激活、auxclick 单独不关、非中键 mouseup 不消耗记录、卸载后清理)。

## Testing / 验证

- 新增 9 测试全过;全套非 pty 测试通过(23 个 pty 测试为环境性失败:`posix_spawnp failed`，干净树上同样失败，与本次改动无关)
- 真实 DSH + Chrome 直连实测(溢出状态，6 场景):精确中键关闭 ✅;同 tab 内拖 40px 松开关闭 ✅;按下 A 松开 B 取消 ✅;按下 A 拖到面板中部松开取消 ✅;按下 A 拖走再拖回 A 松开关闭 ✅;左键激活/拖拽不受影响 ✅

## Notes / 备注

- 语义边界(有意为之，与 VS Code/Chrome 用户预期一致):中键**按下只记录意向**，**松开落在 tab 上才确认关闭**;拖走松手即取消
- 已知取舍:按下与松开之间 tab 栏发生重排(如 agent 终端自动插入页签)时，松手位置已不在原 tab 上 → 取消关闭(release-position 语义的固有行为)
- 分支基于 d33d676(TabBar.tsx 在 d33d676 ↔ main(fc4031e) 之间无改动，合并无冲突;xterm 迁移等 main 上的更新不在本 PR 范围内)
