### PR TITLE
feat(sidebar): default the side card width to 20 percent

### DIFF
--- a/src/prefs-shared.ts
+++ b/src/prefs-shared.ts
@@ -156,7 +156,7 @@ export interface SidebarPrefs {
 /** Range contract of {@link SidebarPrefs.defaultWidthPercent}. */
 export const WIDTH_PERCENT_MIN = 20
 export const WIDTH_PERCENT_MAX = 60
-export const WIDTH_PERCENT_DEFAULT = 30
+export const WIDTH_PERCENT_DEFAULT = 20
 
 /** Range contract of {@link SidebarPrefs.terminalFontSize}. */
 export const TERMINAL_FONT_SIZE_MIN = 9

--- a/tests/plugin-shape.spec.ts
+++ b/tests/plugin-shape.spec.ts
@@ -50,7 +50,7 @@ describe('dsh-better-sidebar plugin export shape', () => {
       (input: Record<string, unknown> | undefined): Record<string, unknown>
     })(undefined)
     expect(resolved.openByDefault).toBe(true)
-    expect(resolved.defaultWidthPercent).toBe(30)
+    expect(resolved.defaultWidthPercent).toBe(20)
     expect(resolved.autoOpenSubagent).toBe(true)
     // A new background job auto-opens the Jobs page too.
     expect(resolved.autoOpenJobs).toBe(true)

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -567,7 +567,7 @@ describe('side card settings routes', () => {
     expect(read.value).toEqual({
       value: {
         openByDefault: true,
-        defaultWidthPercent: 30,
+        defaultWidthPercent: 20,
         autoOpenSubagent: true,
         autoOpenJobs: true,
         agentTerminalTools: false,
@@ -596,7 +596,7 @@ describe('side card settings routes', () => {
     expect(written.ok).toBe(true)
     const view = written.value as { value: { openByDefault: boolean; defaultWidthPercent: number }; revision: number }
     expect(view.value.openByDefault).toBe(false)
-    expect(view.value.defaultWidthPercent).toBe(30)
+    expect(view.value.defaultWidthPercent).toBe(20)
     expect(view.revision).toBe(1)
   })
 


### PR DESCRIPTION
## Summary
Change the built-in default side-card width from **30%** to **20%** of the window width (defaultWidthPercent, the floor of the 20-60 contract range). A fresh install now opens the Explorer panel at 20% without a manual setting; the user-facing setting in the settings document still overrides this default.

## Packages
- dsh-better-sidebar (prefs default + tests)

## Type
feat (behavior/default change)

## AI coding disclosure
This change was prepared with the assistance of an AI coding agent (including the fork + push workflow through the GitHub API because the git HTTPS endpoint is unreachable on the contributor machine).

## Repo convention checks
- No emoji in code/comments/commit message.
- Conventional Commits subject: eat(sidebar): ....
- Only the constant and its test expectations changed.

## Local verification
- pnpm typecheck passes.
- itest run tests/plugin-shape.spec.ts passes (schema default assertion now expects 20).
- 	ests/smoke.spec.ts settings tests pass; 4 unrelated git-operation tests fail locally because no git identity is configured on this machine (scratch-repo commits), not caused by this change.