### PR TITLE
feat: add explicit Federation sidebar backend

### DIFF
--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -509,6 +509,8 @@ declare module 'cordis' {
      * the disposer.
      */
     on(event: string, listener: (session: unknown, event: SidebarSessionEvent) => void): () => void
+    /** Resolve an optional Host service by name without making it a hard inject dependency. */
+    get(name: string, strict?: boolean): any
     /**
      * Register a lifecycle callback (DSH-vendored cordis): runs at plugin
      * activation; its returned cleanup runs at disposal.

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -411,6 +411,41 @@ export interface SidebarAgent {
   }
 }
 
+export interface SidebarFederationExtensionRouter {
+  invokeJson(call: {
+    namespace: string
+    version: string
+    capability: string
+    sessionId: string
+    payload: unknown
+  }, signal?: AbortSignal): Promise<
+    | { ok: true; value: unknown }
+    | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
+  >
+}
+
+export interface SidebarFederatedExtensionRegistry {
+  register(registration: {
+    manifest: {
+      namespace: string
+      version: string
+      capabilities: readonly {
+        name: string
+        scope: 'session'
+        risk: 'read' | 'write'
+        transport: 'json'
+      }[]
+    }
+    handlers: Readonly<Record<string, (
+      context: { callerNodeId: string; sessionId: string; signal: AbortSignal },
+      payload: unknown,
+    ) => Promise<
+      | { ok: true; value: unknown }
+      | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
+    >>>
+  }): () => void
+}
+
 declare module 'cordis' {
   interface Context {
     webServer: SidebarWebServer
@@ -438,6 +473,10 @@ declare module 'cordis' {
      * resolve the caller the jobs fence compares against).
      */
     agents: SidebarAgentsService
+    /** Optional Host-side Federation extension registry. */
+    federatedExtensions: SidebarFederatedExtensionRegistry
+    /** Optional ingress owner router for global Session-scoped calls. */
+    federationExtensionRouter: SidebarFederationExtensionRouter
     /**
      * The client-side sidebar registry: external plugins register tab types
      * and file previewers here. Provided by the client half (see

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -422,6 +422,16 @@ export interface SidebarFederationExtensionRouter {
     | { ok: true; value: unknown }
     | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
   >
+  invokeBinary(call: {
+    namespace: string
+    version: string
+    capability: string
+    sessionId: string
+    payload: unknown
+  }, signal?: AbortSignal): Promise<
+    | { status: number; headers: Readonly<Record<string, string>>; body: Uint8Array }
+    | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
+  >
 }
 
 export interface SidebarFederatedExtensionRegistry {
@@ -433,7 +443,7 @@ export interface SidebarFederatedExtensionRegistry {
         name: string
         scope: 'session'
         risk: 'read' | 'write'
-        transport: 'json'
+        transport: 'json' | 'binary'
       }[]
     }
     handlers: Readonly<Record<string, (
@@ -441,6 +451,13 @@ export interface SidebarFederatedExtensionRegistry {
       payload: unknown,
     ) => Promise<
       | { ok: true; value: unknown }
+      | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
+    >>>
+    binaryHandlers?: Readonly<Record<string, (
+      context: { callerNodeId: string; sessionId: string; signal: AbortSignal },
+      payload: unknown,
+    ) => Promise<
+      | { status: number; headers: Readonly<Record<string, string>>; body: Uint8Array }
       | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
     >>>
   }): () => void

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,8 +131,8 @@ function sessionCwdOf(ctx: Context, sessionId: string, clientCwd?: string): stri
  * unknown owner-local Session would turn a routing mistake into filesystem
  * access on an unrelated directory.
  */
-function ownerSessionCwdOf(ctx: Context, sessionId: string): string {
-  const cwd = ctx.sessions.get(sessionId)?.header.cwd
+function ownerSessionCwdOf(sessions: Context['sessions'], sessionId: string): string {
+  const cwd = sessions.get(sessionId)?.header.cwd
   if (cwd === undefined || cwd === '') {
     throw new SidebarError('not-found', `session "${sessionId}" has no owner-local working directory`, 404)
   }
@@ -217,6 +217,7 @@ function registerFederatedJsonApi(
   ctx: Context,
   resolved: ResolvedSidebarConfig,
   ptyManager: PtyManager | null,
+  ownerSessions: Context['sessions'],
   registry: import('./context-types.ts').SidebarFederatedExtensionRegistry,
   api: Record<string, ApiMethod>,
 ): () => void {
@@ -259,7 +260,7 @@ function registerFederatedJsonApi(
   }
   handlers['terminal.open'] = async (context, payload) => {
     if (ptyManager === null) return { ok: false, error: { code: 'pty-deps-missing', message: PTY_DEPS_MISSING, details: {} } }
-    const cwd = ownerSessionCwdOf(ctx, context.sessionId)
+    const cwd = ownerSessionCwdOf(ownerSessions, context.sessionId)
     const tab = requireString(payload, 'tab')
     const record = payload as { cols?: unknown; rows?: unknown }
     const dims = clampDims(typeof record.cols === 'number' ? record.cols : 80, typeof record.rows === 'number' ? record.rows : 24)
@@ -303,7 +304,7 @@ function registerFederatedJsonApi(
   }
   const binaryHandlers = {
     'file.read': async (context: { sessionId: string }, payload: unknown) => {
-      const cwd = ownerSessionCwdOf(ctx, context.sessionId)
+      const cwd = ownerSessionCwdOf(ownerSessions, context.sessionId)
       const record = payload as { path?: unknown; download?: unknown } | null
       const path = requireAbsolute(requireString(record, 'path'))
       if (!isWithin(cwd, path)) throw new SidebarError('fs-error', 'media path outside the session working directory', 403)
@@ -314,7 +315,7 @@ function registerFederatedJsonApi(
       return { status: 200, headers, body: new Uint8Array(await readFile(path)) }
     },
     'html.read': async (context: { sessionId: string }, payload: unknown) => {
-      const cwd = ownerSessionCwdOf(ctx, context.sessionId)
+      const cwd = ownerSessionCwdOf(ownerSessions, context.sessionId)
       const path = requireAbsolute(requireString(payload, 'path'))
       if (!isWithin(cwd, path)) throw new SidebarError('fs-error', 'html path outside the session working directory', 403)
       const info = await stat(path)
@@ -397,10 +398,11 @@ function buildApi(
   resolved: ResolvedSidebarConfig,
   getSettings: () => SidebarSettingsFace | undefined,
   cwdMode: CwdMode = 'local-fallbacks',
+  ownerSessions: Context['sessions'] = ctx.sessions,
 ): Record<string, ApiMethod> {
   const cwdOf = (payload: unknown): { sessionId: string; cwd: string } => {
     const sessionId = requireString(payload, 'sessionId')
-    if (cwdMode === 'owner-strict') return { sessionId, cwd: ownerSessionCwdOf(ctx, sessionId) }
+    if (cwdMode === 'owner-strict') return { sessionId, cwd: ownerSessionCwdOf(ownerSessions, sessionId) }
     const record = payload as { cwd?: unknown } | null
     const clientCwd = typeof record?.cwd === 'string' && record.cwd !== '' ? record.cwd : undefined
     return { sessionId, cwd: sessionCwdOf(ctx, sessionId, clientCwd) }
@@ -759,14 +761,15 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
   let extensionDisposer: (() => void) | undefined
-  const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
+  const ownerSessions = ctx.sessions
+  const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict', ownerSessions)
   const ensureFederationRegistration = (): void => {
     if (extensionDisposer !== undefined) return
     const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
       ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
     if (extensionRegistry !== undefined) {
       try {
-        extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi)
+        extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, ownerSessions, extensionRegistry, ownerApi)
       } catch (error) {
         ctx.logger?.warn(`[dsh-better-sidebar] federation registration deferred: ${error instanceof Error ? error.message : String(error)}`)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -762,7 +762,11 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
   let extensionDisposer: (() => void) | undefined
-  const ownerSessionGet = ctx.sessions.get.bind(ctx.sessions)
+  const root = ctx.root
+  const ownerSessionGet: OwnerSessionGet = (sessionId) => {
+    const sessions = root.get('sessions', true) as Context['sessions']
+    return sessions.get(sessionId)
+  }
   const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict', ownerSessionGet)
   const ensureFederationRegistration = (): void => {
     if (extensionDisposer !== undefined) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,12 +207,16 @@ const FEDERATED_JSON_WRITE_METHODS = [
  * and UUID-only agent terminal operations are deliberately not exported.
  */
 function registerFederatedJsonApi(
+  ctx: Context,
+  resolved: ResolvedSidebarConfig,
   registry: import('./context-types.ts').SidebarFederatedExtensionRegistry,
   api: Record<string, ApiMethod>,
 ): () => void {
   const capabilities = [
     ...FEDERATED_JSON_READ_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'read' as const, transport: 'json' as const })),
     ...FEDERATED_JSON_WRITE_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'write' as const, transport: 'json' as const })),
+    { name: 'file.read', scope: 'session' as const, risk: 'read' as const, transport: 'binary' as const },
+    { name: 'html.read', scope: 'session' as const, risk: 'read' as const, transport: 'binary' as const },
   ]
   const handlers: Record<string, (
     context: { callerNodeId: string; sessionId: string; signal: AbortSignal },
@@ -244,9 +248,35 @@ function registerFederatedJsonApi(
       }
     }
   }
+  const binaryHandlers = {
+    'file.read': async (context: { sessionId: string }, payload: unknown) => {
+      const cwd = ownerSessionCwdOf(ctx, context.sessionId)
+      const record = payload as { path?: unknown; download?: unknown } | null
+      const path = requireAbsolute(requireString(record, 'path'))
+      if (!isWithin(cwd, path)) throw new SidebarError('fs-error', 'media path outside the session working directory', 403)
+      const info = await stat(path)
+      if (!info.isFile() || info.size > resolved.mediaLimit) throw new SidebarError('fs-error', 'not a file or too large', 400)
+      const headers: Record<string, string> = { 'content-type': mediaTypeForPath(path), 'cache-control': 'no-cache' }
+      if (record?.download === true) headers['content-disposition'] = `attachment; filename*=UTF-8''${encodeURIComponent(basename(path))}`
+      return { status: 200, headers, body: new Uint8Array(await readFile(path)) }
+    },
+    'html.read': async (context: { sessionId: string }, payload: unknown) => {
+      const cwd = ownerSessionCwdOf(ctx, context.sessionId)
+      const path = requireAbsolute(requireString(payload, 'path'))
+      if (!isWithin(cwd, path)) throw new SidebarError('fs-error', 'html path outside the session working directory', 403)
+      const info = await stat(path)
+      if (!info.isFile() || info.size > resolved.mediaLimit) throw new SidebarError('fs-error', 'not a file or too large', 400)
+      return { status: 200, headers: {
+        'content-type': mediaTypeForPath(path), 'cache-control': 'no-cache',
+        'x-content-type-options': 'nosniff', 'referrer-policy': 'no-referrer',
+        'content-security-policy': "sandbox allow-scripts allow-popups allow-downloads allow-modals; object-src 'none'",
+      }, body: new Uint8Array(await readFile(path)) }
+    },
+  }
   return registry.register({
     manifest: { namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE, version: BETTER_SIDEBAR_FEDERATION_VERSION, capabilities },
     handlers,
+    binaryHandlers,
   })
 }
 
@@ -674,7 +704,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // remains fully usable when Federation is not installed.
   ctx.inject(['federatedExtensions'], (fctx) => {
     const ownerApi = buildApi(fctx as Context, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
-    return registerFederatedJsonApi(fctx.federatedExtensions, ownerApi)
+    return registerFederatedJsonApi(fctx as Context, resolved, fctx.federatedExtensions, ownerApi)
   })
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
@@ -739,6 +769,18 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         const sessionId = url.searchParams.get('sessionId')
         const raw = url.searchParams.get('path')
         if (sessionId === null || raw === null) throw new SidebarError('bad-request', 'sessionId and path are required')
+        if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
+          const result = await federationRouter.invokeBinary({
+            namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
+            version: BETTER_SIDEBAR_FEDERATION_VERSION,
+            capability: 'file.read', sessionId,
+            payload: { path: raw, download: url.searchParams.get('download') === '1' },
+          })
+          if ('ok' in result) throw new SidebarError('internal', result.error.message, 502)
+          res.writeHead(result.status, result.headers)
+          res.end(Buffer.from(result.body))
+          return
+        }
         const cwd = sessionCwdOf(ctx, sessionId, url.searchParams.get('cwd') ?? undefined)
         const path = requireAbsolute(raw)
         if (!isWithin(cwd, path)) {
@@ -800,6 +842,17 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
           return
         }
         const { sessionId, path } = decoded.ref
+        if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
+          const result = await federationRouter.invokeBinary({
+            namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
+            version: BETTER_SIDEBAR_FEDERATION_VERSION,
+            capability: 'html.read', sessionId, payload: { path },
+          })
+          if ('ok' in result) throw new SidebarError('internal', result.error.message, 502)
+          res.writeHead(result.status, result.headers)
+          res.end(Buffer.from(result.body))
+          return
+        }
         // The session's authoritative cwd (client cwd cannot ride in the URL
         // — the path encoding has no query; a detached first request falls
         // back to the process cwd and is normally refused by isWithin, same

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,8 +131,10 @@ function sessionCwdOf(ctx: Context, sessionId: string, clientCwd?: string): stri
  * unknown owner-local Session would turn a routing mistake into filesystem
  * access on an unrelated directory.
  */
-function ownerSessionCwdOf(sessions: Context['sessions'], sessionId: string): string {
-  const cwd = sessions.get(sessionId)?.header.cwd
+type OwnerSessionGet = Context['sessions']['get']
+
+function ownerSessionCwdOf(getSession: OwnerSessionGet, sessionId: string): string {
+  const cwd = getSession(sessionId)?.header.cwd
   if (cwd === undefined || cwd === '') {
     throw new SidebarError('not-found', `session "${sessionId}" has no owner-local working directory`, 404)
   }
@@ -217,7 +219,7 @@ function registerFederatedJsonApi(
   ctx: Context,
   resolved: ResolvedSidebarConfig,
   ptyManager: PtyManager | null,
-  ownerSessions: Context['sessions'],
+  ownerSessionGet: OwnerSessionGet,
   registry: import('./context-types.ts').SidebarFederatedExtensionRegistry,
   api: Record<string, ApiMethod>,
 ): () => void {
@@ -259,7 +261,7 @@ function registerFederatedJsonApi(
   }
   handlers['terminal.open'] = async (context, payload) => {
     if (ptyManager === null) return { ok: false, error: { code: 'pty-deps-missing', message: PTY_DEPS_MISSING, details: {} } }
-    const cwd = ownerSessionCwdOf(ownerSessions, context.sessionId)
+    const cwd = ownerSessionCwdOf(ownerSessionGet, context.sessionId)
     const tab = requireString(payload, 'tab')
     const record = payload as { cols?: unknown; rows?: unknown }
     const dims = clampDims(typeof record.cols === 'number' ? record.cols : 80, typeof record.rows === 'number' ? record.rows : 24)
@@ -303,7 +305,7 @@ function registerFederatedJsonApi(
   }
   const binaryHandlers = {
     'file.read': async (context: { sessionId: string }, payload: unknown) => {
-      const cwd = ownerSessionCwdOf(ownerSessions, context.sessionId)
+      const cwd = ownerSessionCwdOf(ownerSessionGet, context.sessionId)
       const record = payload as { path?: unknown; download?: unknown } | null
       const path = requireAbsolute(requireString(record, 'path'))
       if (!isWithin(cwd, path)) throw new SidebarError('fs-error', 'media path outside the session working directory', 403)
@@ -314,7 +316,7 @@ function registerFederatedJsonApi(
       return { status: 200, headers, body: new Uint8Array(await readFile(path)) }
     },
     'html.read': async (context: { sessionId: string }, payload: unknown) => {
-      const cwd = ownerSessionCwdOf(ownerSessions, context.sessionId)
+      const cwd = ownerSessionCwdOf(ownerSessionGet, context.sessionId)
       const path = requireAbsolute(requireString(payload, 'path'))
       if (!isWithin(cwd, path)) throw new SidebarError('fs-error', 'html path outside the session working directory', 403)
       const info = await stat(path)
@@ -397,11 +399,11 @@ function buildApi(
   resolved: ResolvedSidebarConfig,
   getSettings: () => SidebarSettingsFace | undefined,
   cwdMode: CwdMode = 'local-fallbacks',
-  ownerSessions: Context['sessions'] = ctx.sessions,
+  ownerSessionGet: OwnerSessionGet = ctx.sessions.get.bind(ctx.sessions),
 ): Record<string, ApiMethod> {
   const cwdOf = (payload: unknown): { sessionId: string; cwd: string } => {
     const sessionId = requireString(payload, 'sessionId')
-    if (cwdMode === 'owner-strict') return { sessionId, cwd: ownerSessionCwdOf(ownerSessions, sessionId) }
+    if (cwdMode === 'owner-strict') return { sessionId, cwd: ownerSessionCwdOf(ownerSessionGet, sessionId) }
     const record = payload as { cwd?: unknown } | null
     const clientCwd = typeof record?.cwd === 'string' && record.cwd !== '' ? record.cwd : undefined
     return { sessionId, cwd: sessionCwdOf(ctx, sessionId, clientCwd) }
@@ -760,15 +762,15 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
   let extensionDisposer: (() => void) | undefined
-  const ownerSessions = (ctx.get('sessions', true) ?? ctx.sessions) as Context['sessions']
-  const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict', ownerSessions)
+  const ownerSessionGet = ctx.sessions.get.bind(ctx.sessions)
+  const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict', ownerSessionGet)
   const ensureFederationRegistration = (): void => {
     if (extensionDisposer !== undefined) return
     const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
       ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
     if (extensionRegistry !== undefined) {
       try {
-        extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, ownerSessions, extensionRegistry, ownerApi)
+        extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, ownerSessionGet, extensionRegistry, ownerApi)
       } catch (error) {
         ctx.logger?.warn(`[dsh-better-sidebar] federation registration deferred: ${error instanceof Error ? error.message : String(error)}`)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -758,12 +758,21 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // cwd resolver. The service is optional; because the Federation bundle is
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
-  const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
-    ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
-  if (extensionRegistry !== undefined) {
-    const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
-    ctx.effect(() => registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi))
+  let extensionDisposer: (() => void) | undefined
+  const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
+  const ensureFederationRegistration = (): void => {
+    if (extensionDisposer !== undefined) return
+    const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
+      ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
+    if (extensionRegistry !== undefined) {
+      extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi)
+    }
   }
+  ensureFederationRegistration()
+  ctx.effect(() => {
+    const timer = setInterval(ensureFederationRegistration, 100)
+    return () => { clearInterval(timer); extensionDisposer?.(); extensionDisposer = undefined }
+  })
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
     path: '/sidebar/api',

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,7 @@ const FEDERATED_JSON_READ_METHODS = [
 const FEDERATED_JSON_WRITE_METHODS = [
   'fs.write', 'git.stage', 'git.unstage', 'git.commit', 'git.checkout',
   'git.discard', 'git.revert', 'git.cherry-pick', 'pty.close', 'jobs.kill',
+  'terminal.open', 'terminal.input', 'terminal.resize', 'terminal.terminate', 'terminal.detach',
 ] as const
 
 /**
@@ -209,12 +210,14 @@ const FEDERATED_JSON_WRITE_METHODS = [
 function registerFederatedJsonApi(
   ctx: Context,
   resolved: ResolvedSidebarConfig,
+  ptyManager: PtyManager | null,
   registry: import('./context-types.ts').SidebarFederatedExtensionRegistry,
   api: Record<string, ApiMethod>,
 ): () => void {
   const capabilities = [
     ...FEDERATED_JSON_READ_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'read' as const, transport: 'json' as const })),
     ...FEDERATED_JSON_WRITE_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'write' as const, transport: 'json' as const })),
+    { name: 'terminal.read', scope: 'session' as const, risk: 'read' as const, transport: 'json' as const },
     { name: 'file.read', scope: 'session' as const, risk: 'read' as const, transport: 'binary' as const },
     { name: 'html.read', scope: 'session' as const, risk: 'read' as const, transport: 'binary' as const },
   ]
@@ -247,6 +250,50 @@ function registerFederatedJsonApi(
         return { ok: false, error: { code: 'internal', message: error instanceof Error ? error.message : String(error), details: {} } }
       }
     }
+  }
+  handlers['terminal.open'] = async (context, payload) => {
+    if (ptyManager === null) return { ok: false, error: { code: 'pty-deps-missing', message: PTY_DEPS_MISSING, details: {} } }
+    const cwd = ownerSessionCwdOf(ctx, context.sessionId)
+    const tab = requireString(payload, 'tab')
+    const record = payload as { cols?: unknown; rows?: unknown }
+    const dims = clampDims(typeof record.cols === 'number' ? record.cols : 80, typeof record.rows === 'number' ? record.rows : 24)
+    const handle = ptyManager.open(context.sessionId, tab, cwd, dims.cols, dims.rows)
+    return { ok: true, value: { base: handle.transcriptBase, next: handle.outputOffset, exited: handle.exited, exitCode: handle.exitCode ?? null } }
+  }
+  handlers['terminal.read'] = async (context, payload) => {
+    if (ptyManager === null) return { ok: false, error: { code: 'pty-deps-missing', message: PTY_DEPS_MISSING, details: {} } }
+    const tab = requireString(payload, 'tab')
+    const handle = ptyManager.get(`${context.sessionId}:${tab}`)
+    if (handle === undefined) return { ok: false, error: { code: 'not-found', message: 'terminal not found', details: {} } }
+    const record = payload as { offset?: unknown }
+    const requested = typeof record.offset === 'number' && Number.isInteger(record.offset) ? record.offset : handle.transcriptBase
+    const offset = Math.max(handle.transcriptBase, Math.min(requested, handle.outputOffset))
+    return { ok: true, value: { offset, next: handle.outputOffset, data: handle.transcript.slice(offset - handle.transcriptBase), base: handle.transcriptBase, exited: handle.exited, exitCode: handle.exitCode ?? null } }
+  }
+  handlers['terminal.input'] = async (context, payload) => {
+    const tab = requireString(payload, 'tab'); const data = requireString(payload, 'data')
+    const handle = ptyManager?.get(`${context.sessionId}:${tab}`)
+    if (handle === undefined) return { ok: false, error: { code: 'not-found', message: 'terminal not found', details: {} } }
+    if (!handle.exited) handle.pty.write(data)
+    return { ok: true, value: { accepted: true } }
+  }
+  handlers['terminal.resize'] = async (context, payload) => {
+    const tab = requireString(payload, 'tab'); const record = payload as { cols?: unknown; rows?: unknown }
+    const handle = ptyManager?.get(`${context.sessionId}:${tab}`)
+    if (handle === undefined) return { ok: false, error: { code: 'not-found', message: 'terminal not found', details: {} } }
+    if (typeof record.cols === 'number' && typeof record.rows === 'number' && !handle.exited) {
+      const dims = clampDims(record.cols, record.rows); handle.pty.resize(dims.cols, dims.rows)
+    }
+    return { ok: true, value: { accepted: true } }
+  }
+  handlers['terminal.terminate'] = async (context, payload) => {
+    const tab = requireString(payload, 'tab'); ptyManager?.close(`${context.sessionId}:${tab}`)
+    return { ok: true, value: { terminated: true } }
+  }
+  handlers['terminal.detach'] = async (context, payload) => {
+    const tab = requireString(payload, 'tab')
+    ptyManager?.scheduleClose(`${context.sessionId}:${tab}`, resolved.reconnectGraceMs)
+    return { ok: true, value: { detached: true } }
   }
   const binaryHandlers = {
     'file.read': async (context: { sessionId: string }, payload: unknown) => {
@@ -704,7 +751,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // remains fully usable when Federation is not installed.
   ctx.inject(['federatedExtensions'], (fctx) => {
     const ownerApi = buildApi(fctx as Context, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
-    return registerFederatedJsonApi(fctx as Context, resolved, fctx.federatedExtensions, ownerApi)
+    return registerFederatedJsonApi(fctx as Context, resolved, ptyManager, fctx.federatedExtensions, ownerApi)
   })
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
@@ -904,6 +951,12 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       // The structural request/socket/head faces satisfy the shared fence;
       // the `ws` package wants the real Node types — cast at this boundary.
       wss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
+        const url = new URL(req.url ?? '/', 'http://dsh.internal')
+        const sessionId = url.searchParams.get('sessionId')
+        if (federationRouter !== undefined && sessionId !== null && isFederatedSessionId(sessionId)) {
+          void attachFederatedTerminal(federationRouter, ws, sessionId, url.searchParams.get('tab'), resolved)
+          return
+        }
         void attachTerminal(ctx, ptyManager, agentPtyRegistry, ws, req, resolved)
       })
     },
@@ -966,6 +1019,57 @@ async function attachAgentList(
     ws.on('error', () => { unsubscribe?.() })
   } catch (error) {
     ws.close(1011, error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Ingress-side terminal channel gateway over owner-routed extension calls. */
+async function attachFederatedTerminal(
+  router: import('./context-types.ts').SidebarFederationExtensionRouter,
+  ws: WebSocket,
+  sessionId: string,
+  tabId: string | null,
+  resolved: ResolvedSidebarConfig,
+): Promise<void> {
+  if (tabId === null) { ws.close(1008, 'tab is required'); return }
+  const call = (capability: string, payload: unknown) => router.invokeJson({
+    namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
+    version: BETTER_SIDEBAR_FEDERATION_VERSION,
+    capability, sessionId, payload,
+  })
+  let offset = 0
+  let closed = false
+  try {
+    const opened = await call('terminal.open', { tab: tabId, cols: 80, rows: 24 })
+    if (!opened.ok) { ws.close(1011, opened.error.message.slice(0, 120)); return }
+    offset = Number((opened.value as { base?: number }).base ?? 0)
+    const pump = async (): Promise<void> => {
+      while (!closed && ws.readyState === WebSocket.OPEN) {
+        const result = await call('terminal.read', { tab: tabId, offset })
+        if (!result.ok) { ws.close(1011, result.error.message.slice(0, 120)); return }
+        const page = result.value as { offset: number; next: number; data: string; exited?: boolean; exitCode?: number | null }
+        if (page.data !== '') ws.send(page.data)
+        offset = page.next
+        if (page.exited === true) {
+          if (page.data === '') ws.send(`\r\n[process exited with code ${String(page.exitCode ?? 0)}]\r\n`)
+          return
+        }
+        await new Promise(resolve => setTimeout(resolve, 40))
+      }
+    }
+    void pump()
+    ws.on('message', (raw) => {
+      const text = raw.toString('utf8')
+      let control: { type?: unknown; cols?: unknown; rows?: unknown } | undefined
+      try { const value = JSON.parse(text) as unknown; if (value !== null && typeof value === 'object') control = value as never } catch {}
+      if (control?.type === 'close') { void call('terminal.terminate', { tab: tabId }); return }
+      if (control?.type === 'resize' && typeof control.cols === 'number' && typeof control.rows === 'number') {
+        void call('terminal.resize', { tab: tabId, cols: control.cols, rows: control.rows }); return
+      }
+      void call('terminal.input', { tab: tabId, data: text })
+    })
+    ws.on('close', () => { closed = true; void call('terminal.detach', { tab: tabId, graceMs: resolved.reconnectGraceMs }) })
+  } catch (error) {
+    ws.close(1011, (error instanceof Error ? error.message : String(error)).slice(0, 120))
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ function registerFederatedJsonApi(
     | { ok: true; value: unknown }
     | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
   >> = {}
-  for (const capability of capabilities) {
+  for (const capability of capabilities.filter(entry => entry.transport === 'json')) {
     handlers[capability.name] = async (context, payload) => {
       const source = payload !== null && typeof payload === 'object' && !Array.isArray(payload)
         ? payload as Record<string, unknown>
@@ -765,7 +765,11 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
     const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
       ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
     if (extensionRegistry !== undefined) {
-      extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi)
+      try {
+        extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi)
+      } catch (error) {
+        ctx.logger?.warn(`[dsh-better-sidebar] federation registration deferred: ${error instanceof Error ? error.message : String(error)}`)
+      }
     }
   }
   ensureFederationRegistration()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1072,9 +1072,34 @@ async function attachFederatedTerminal(
   })
   let offset = 0
   let closed = false
+  let ready = false
+  const pending: string[] = []
+  const forward = (text: string): void => {
+    let control: { type?: unknown; cols?: unknown; rows?: unknown } | undefined
+    try { const value = JSON.parse(text) as unknown; if (value !== null && typeof value === 'object') control = value as never } catch {}
+    if (control?.type === 'close') { void call('terminal.terminate', { tab: tabId }); return }
+    if (control?.type === 'resize' && typeof control.cols === 'number' && typeof control.rows === 'number') {
+      void call('terminal.resize', { tab: tabId, cols: control.cols, rows: control.rows }); return
+    }
+    void call('terminal.input', { tab: tabId, data: text })
+  }
+  // Install listeners before the owner open RPC. Browser WebSocket `open`
+  // fires as soon as the upgrade completes, and xterm may send resize/input
+  // while the owner is still creating the PTY.
+  ws.on('message', raw => {
+    const text = raw.toString('utf8')
+    if (ready) forward(text)
+    else pending.push(text)
+  })
+  ws.on('close', () => {
+    closed = true
+    if (ready) void call('terminal.detach', { tab: tabId, graceMs: resolved.reconnectGraceMs })
+  })
   try {
     const opened = await call('terminal.open', { tab: tabId, cols: 80, rows: 24 })
     if (!opened.ok) { ws.close(1011, opened.error.message.slice(0, 120)); return }
+    ready = true
+    for (const text of pending.splice(0)) forward(text)
     offset = Number((opened.value as { base?: number }).base ?? 0)
     const pump = async (): Promise<void> => {
       while (!closed && ws.readyState === WebSocket.OPEN) {
@@ -1091,17 +1116,6 @@ async function attachFederatedTerminal(
       }
     }
     void pump()
-    ws.on('message', (raw) => {
-      const text = raw.toString('utf8')
-      let control: { type?: unknown; cols?: unknown; rows?: unknown } | undefined
-      try { const value = JSON.parse(text) as unknown; if (value !== null && typeof value === 'object') control = value as never } catch {}
-      if (control?.type === 'close') { void call('terminal.terminate', { tab: tabId }); return }
-      if (control?.type === 'resize' && typeof control.cols === 'number' && typeof control.rows === 'number') {
-        void call('terminal.resize', { tab: tabId, cols: control.cols, rows: control.rows }); return
-      }
-      void call('terminal.input', { tab: tabId, data: text })
-    })
-    ws.on('close', () => { closed = true; void call('terminal.detach', { tab: tabId, graceMs: resolved.reconnectGraceMs }) })
   } catch (error) {
     ws.close(1011, (error instanceof Error ? error.message : String(error)).slice(0, 120))
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ type ApiMethod = (payload: unknown) => Promise<unknown> | unknown
 const FEDERATED_JSON_READ_METHODS = [
   'session.cwd', 'fs.tree', 'fs.search', 'fs.read',
   'git.status', 'git.diff', 'git.branch', 'git.log', 'git.commit-diff', 'git.show',
-  'jobs.output',
+  'jobs.output', 'terminal.read',
 ] as const
 const FEDERATED_JSON_WRITE_METHODS = [
   'fs.write', 'git.stage', 'git.unstage', 'git.commit', 'git.checkout',
@@ -224,7 +224,6 @@ function registerFederatedJsonApi(
   const capabilities = [
     ...FEDERATED_JSON_READ_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'read' as const, transport: 'json' as const })),
     ...FEDERATED_JSON_WRITE_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'write' as const, transport: 'json' as const })),
-    { name: 'terminal.read', scope: 'session' as const, risk: 'read' as const, transport: 'json' as const },
     { name: 'file.read', scope: 'session' as const, risk: 'read' as const, transport: 'binary' as const },
     { name: 'html.read', scope: 'session' as const, risk: 'read' as const, transport: 'binary' as const },
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,12 @@ export type {
 export const name = 'dsh-better-sidebar'
 export const BETTER_SIDEBAR_FEDERATION_NAMESPACE = 'dsh-better-sidebar'
 export const BETTER_SIDEBAR_FEDERATION_VERSION = '0.12.3'
+const FEDERATED_EXTENSIONS_GLOBAL = Symbol.for('fzhiyu.dsh.federation.extensions.v1')
+const FEDERATION_EXTENSION_ROUTER_GLOBAL = Symbol.for('fzhiyu.dsh.federation.extension-router.v1')
+
+function globalService<T>(key: symbol): T | undefined {
+  return (globalThis as Record<symbol, unknown>)[key] as T | undefined
+}
 
 /** Services required before mounting: the webserver routes, the session store, the web runtime's trusted hosts, and the tool registry. */
 export const inject = ['webServer', 'sessions', 'webRuntime', 'tools']
@@ -741,7 +747,8 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
 
   // ── JSON API ────────────────────────────────────────────────────────────
   const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace)
-  let federationRouter = ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+  let federationRouter = globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
+    ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
   ctx.effect(() => {
     // Rows may activate in either order. Resolve lazily from the root service
     // registry on every request if the router was not present at sidebar boot.
@@ -751,7 +758,8 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // cwd resolver. The service is optional; because the Federation bundle is
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
-  const extensionRegistry = ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
+  const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
+    ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
   if (extensionRegistry !== undefined) {
     const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
     ctx.effect(() => registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi))
@@ -776,7 +784,8 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       }
       try {
         const payload = await readJsonBody(req)
-        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
+          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined
           && isFederatedSessionId((payload as { sessionId?: unknown } | null)?.sessionId)
           && [...FEDERATED_JSON_READ_METHODS, ...FEDERATED_JSON_WRITE_METHODS].includes(method as never)) {
@@ -820,7 +829,8 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         const sessionId = url.searchParams.get('sessionId')
         const raw = url.searchParams.get('path')
         if (sessionId === null || raw === null) throw new SidebarError('bad-request', 'sessionId and path are required')
-        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
+          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
           const result = await federationRouter.invokeBinary({
             namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
@@ -894,7 +904,8 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
           return
         }
         const { sessionId, path } = decoded.ref
-        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
+          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
           const result = await federationRouter.invokeBinary({
             namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
@@ -959,7 +970,8 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       wss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
         const url = new URL(req.url ?? '/', 'http://dsh.internal')
         const sessionId = url.searchParams.get('sessionId')
-        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
+          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined && sessionId !== null && isFederatedSessionId(sessionId)) {
           void attachFederatedTerminal(federationRouter, ws, sessionId, url.searchParams.get('tab'), resolved)
           return

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,18 +750,15 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
 
   // ── JSON API ────────────────────────────────────────────────────────────
   const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace)
-  let federationRouter = globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
-    ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
-  ctx.effect(() => {
-    // Rows may activate in either order. Resolve lazily from the root service
-    // registry on every request if the router was not present at sidebar boot.
-    return () => { federationRouter = undefined }
-  })
+  const federationRouter = (): import('./context-types.ts').SidebarFederationExtensionRouter | undefined =>
+    globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
+      ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
   // Federation calls the same business handlers, but through a strict owner
   // cwd resolver. The service is optional; because the Federation bundle is
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
   let extensionDisposer: (() => void) | undefined
+  let boundRegistry: import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
   const root = ctx.root
   const ownerSessionGet: OwnerSessionGet = (sessionId) => {
     const sessions = root.get('sessions', true) as Context['sessions']
@@ -769,9 +766,12 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   }
   const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict', ownerSessionGet)
   const ensureFederationRegistration = (): void => {
-    if (extensionDisposer !== undefined) return
     const extensionRegistry = globalService<import('./context-types.ts').SidebarFederatedExtensionRegistry>(FEDERATED_EXTENSIONS_GLOBAL)
       ?? ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
+    if (extensionRegistry === boundRegistry) return
+    extensionDisposer?.()
+    extensionDisposer = undefined
+    boundRegistry = extensionRegistry
     if (extensionRegistry !== undefined) {
       try {
         extensionDisposer = registerFederatedJsonApi(ctx, resolved, ptyManager, ownerSessionGet, extensionRegistry, ownerApi)
@@ -783,7 +783,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   ensureFederationRegistration()
   ctx.effect(() => {
     const timer = setInterval(ensureFederationRegistration, 100)
-    return () => { clearInterval(timer); extensionDisposer?.(); extensionDisposer = undefined }
+    return () => { clearInterval(timer); extensionDisposer?.(); extensionDisposer = undefined; boundRegistry = undefined }
   })
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
@@ -805,12 +805,11 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       }
       try {
         const payload = await readJsonBody(req)
-        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
-          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
-        if (federationRouter !== undefined
+        const router = federationRouter()
+        if (router !== undefined
           && isFederatedSessionId((payload as { sessionId?: unknown } | null)?.sessionId)
           && [...FEDERATED_JSON_READ_METHODS, ...FEDERATED_JSON_WRITE_METHODS].includes(method as never)) {
-          writeOk(res, await invokeFederatedJson(federationRouter, method, payload))
+          writeOk(res, await invokeFederatedJson(router, method, payload))
           return
         }
         const handler = api[method]
@@ -850,10 +849,9 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         const sessionId = url.searchParams.get('sessionId')
         const raw = url.searchParams.get('path')
         if (sessionId === null || raw === null) throw new SidebarError('bad-request', 'sessionId and path are required')
-        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
-          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
-        if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
-          const result = await federationRouter.invokeBinary({
+        const router = federationRouter()
+        if (router !== undefined && isFederatedSessionId(sessionId)) {
+          const result = await router.invokeBinary({
             namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
             version: BETTER_SIDEBAR_FEDERATION_VERSION,
             capability: 'file.read', sessionId,
@@ -925,10 +923,9 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
           return
         }
         const { sessionId, path } = decoded.ref
-        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
-          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
-        if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
-          const result = await federationRouter.invokeBinary({
+        const router = federationRouter()
+        if (router !== undefined && isFederatedSessionId(sessionId)) {
+          const result = await router.invokeBinary({
             namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
             version: BETTER_SIDEBAR_FEDERATION_VERSION,
             capability: 'html.read', sessionId, payload: { path },
@@ -991,10 +988,9 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       wss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
         const url = new URL(req.url ?? '/', 'http://dsh.internal')
         const sessionId = url.searchParams.get('sessionId')
-        federationRouter ??= globalService<import('./context-types.ts').SidebarFederationExtensionRouter>(FEDERATION_EXTENSION_ROUTER_GLOBAL)
-          ?? ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
-        if (federationRouter !== undefined && sessionId !== null && isFederatedSessionId(sessionId)) {
-          void attachFederatedTerminal(federationRouter, ws, sessionId, url.searchParams.get('tab'), resolved)
+        const router = federationRouter()
+        if (router !== undefined && sessionId !== null && isFederatedSessionId(sessionId)) {
+          void attachFederatedTerminal(router, ws, sessionId, url.searchParams.get('tab'), resolved)
           return
         }
         void attachTerminal(ctx, ptyManager, agentPtyRegistry, ws, req, resolved)
@@ -1062,6 +1058,8 @@ async function attachAgentList(
   }
 }
 
+const FEDERATED_TERMINAL_OFFSETS = new Map<string, number>()
+
 /** Ingress-side terminal channel gateway over owner-routed extension calls. */
 async function attachFederatedTerminal(
   router: import('./context-types.ts').SidebarFederationExtensionRouter,
@@ -1076,18 +1074,36 @@ async function attachFederatedTerminal(
     version: BETTER_SIDEBAR_FEDERATION_VERSION,
     capability, sessionId, payload,
   })
-  let offset = 0
+  const channelKey = `${sessionId}\u001f${tabId}`
+  let offset = FEDERATED_TERMINAL_OFFSETS.get(channelKey) ?? 0
   let closed = false
   let ready = false
+  let terminated = false
+  let outbound = Promise.resolve()
   const pending: string[] = []
+  const enqueue = (task: () => Promise<void>): void => {
+    outbound = outbound.then(task).catch((error) => {
+      if (ws.readyState === WebSocket.OPEN) ws.close(1011, String((error as Error).message).slice(0, 120))
+    })
+  }
   const forward = (text: string): void => {
+    if (terminated) return
     let control: { type?: unknown; cols?: unknown; rows?: unknown } | undefined
     try { const value = JSON.parse(text) as unknown; if (value !== null && typeof value === 'object') control = value as never } catch {}
-    if (control?.type === 'close') { void call('terminal.terminate', { tab: tabId }); return }
-    if (control?.type === 'resize' && typeof control.cols === 'number' && typeof control.rows === 'number') {
-      void call('terminal.resize', { tab: tabId, cols: control.cols, rows: control.rows }); return
-    }
-    void call('terminal.input', { tab: tabId, data: text })
+    enqueue(async () => {
+      if (terminated) return
+      if (control?.type === 'close') {
+        terminated = true
+        FEDERATED_TERMINAL_OFFSETS.delete(channelKey)
+        await call('terminal.terminate', { tab: tabId })
+        return
+      }
+      if (control?.type === 'resize' && typeof control.cols === 'number' && typeof control.rows === 'number') {
+        await call('terminal.resize', { tab: tabId, cols: control.cols, rows: control.rows })
+        return
+      }
+      await call('terminal.input', { tab: tabId, data: text })
+    })
   }
   // Install listeners before the owner open RPC. Browser WebSocket `open`
   // fires as soon as the upgrade completes, and xterm may send resize/input
@@ -1099,14 +1115,18 @@ async function attachFederatedTerminal(
   })
   ws.on('close', () => {
     closed = true
-    if (ready) void call('terminal.detach', { tab: tabId, graceMs: resolved.reconnectGraceMs })
+    if (ready && !terminated) enqueue(async () => { await call('terminal.detach', { tab: tabId, graceMs: resolved.reconnectGraceMs }) })
   })
   try {
     const opened = await call('terminal.open', { tab: tabId, cols: 80, rows: 24 })
     if (!opened.ok) { ws.close(1011, opened.error.message.slice(0, 120)); return }
     ready = true
+    const openedValue = opened.value as { base?: number; next?: number }
+    const base = Number(openedValue.base ?? 0)
+    const next = Number(openedValue.next ?? base)
+    if (offset < base || offset > next) offset = base
+    if (closed && !terminated) enqueue(async () => { await call('terminal.detach', { tab: tabId, graceMs: resolved.reconnectGraceMs }) })
     for (const text of pending.splice(0)) forward(text)
-    offset = Number((opened.value as { base?: number }).base ?? 0)
     const pump = async (): Promise<void> => {
       while (!closed && ws.readyState === WebSocket.OPEN) {
         const result = await call('terminal.read', { tab: tabId, offset })
@@ -1114,6 +1134,7 @@ async function attachFederatedTerminal(
         const page = result.value as { offset: number; next: number; data: string; exited?: boolean; exitCode?: number | null }
         if (page.data !== '') ws.send(page.data)
         offset = page.next
+        FEDERATED_TERMINAL_OFFSETS.set(channelKey, offset)
         if (page.exited === true) {
           if (page.data === '') ws.send(`\r\n[process exited with code ${String(page.exitCode ?? 0)}]\r\n`)
           return

--- a/src/index.ts
+++ b/src/index.ts
@@ -741,18 +741,21 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
 
   // ── JSON API ────────────────────────────────────────────────────────────
   const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace)
-  let federationRouter: import('./context-types.ts').SidebarFederationExtensionRouter | undefined
-  ctx.inject(['federationExtensionRouter'], (fctx) => {
-    federationRouter = fctx.federationExtensionRouter
+  let federationRouter = ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+  ctx.effect(() => {
+    // Rows may activate in either order. Resolve lazily from the root service
+    // registry on every request if the router was not present at sidebar boot.
     return () => { federationRouter = undefined }
   })
   // Federation calls the same business handlers, but through a strict owner
-  // cwd resolver. The optional service is lifecycle-injected, so the sidebar
-  // remains fully usable when Federation is not installed.
-  ctx.inject(['federatedExtensions'], (fctx) => {
-    const ownerApi = buildApi(fctx as Context, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
-    return registerFederatedJsonApi(fctx as Context, resolved, ptyManager, fctx.federatedExtensions, ownerApi)
-  })
+  // cwd resolver. The service is optional; because the Federation bundle is
+  // ordered before the sidebar bundle in deployment, a root lookup avoids
+  // Cordis child-context injection ordering differences between profiles.
+  const extensionRegistry = ctx.get('federatedExtensions') as import('./context-types.ts').SidebarFederatedExtensionRegistry | undefined
+  if (extensionRegistry !== undefined) {
+    const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
+    ctx.effect(() => registerFederatedJsonApi(ctx, resolved, ptyManager, extensionRegistry, ownerApi))
+  }
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
     path: '/sidebar/api',
@@ -773,6 +776,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       }
       try {
         const payload = await readJsonBody(req)
+        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined
           && isFederatedSessionId((payload as { sessionId?: unknown } | null)?.sessionId)
           && [...FEDERATED_JSON_READ_METHODS, ...FEDERATED_JSON_WRITE_METHODS].includes(method as never)) {
@@ -816,6 +820,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         const sessionId = url.searchParams.get('sessionId')
         const raw = url.searchParams.get('path')
         if (sessionId === null || raw === null) throw new SidebarError('bad-request', 'sessionId and path are required')
+        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
           const result = await federationRouter.invokeBinary({
             namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
@@ -889,6 +894,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
           return
         }
         const { sessionId, path } = decoded.ref
+        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined && isFederatedSessionId(sessionId)) {
           const result = await federationRouter.invokeBinary({
             namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
@@ -953,6 +959,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       wss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
         const url = new URL(req.url ?? '/', 'http://dsh.internal')
         const sessionId = url.searchParams.get('sessionId')
+        federationRouter ??= ctx.get('federationExtensionRouter') as import('./context-types.ts').SidebarFederationExtensionRouter | undefined
         if (federationRouter !== undefined && sessionId !== null && isFederatedSessionId(sessionId)) {
           void attachFederatedTerminal(federationRouter, ws, sessionId, url.searchParams.get('tab'), resolved)
           return

--- a/src/index.ts
+++ b/src/index.ts
@@ -760,7 +760,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // ordered before the sidebar bundle in deployment, a root lookup avoids
   // Cordis child-context injection ordering differences between profiles.
   let extensionDisposer: (() => void) | undefined
-  const ownerSessions = ctx.sessions
+  const ownerSessions = (ctx.get('sessions', true) ?? ctx.sessions) as Context['sessions']
   const ownerApi = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict', ownerSessions)
   const ensureFederationRegistration = (): void => {
     if (extensionDisposer !== undefined) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,8 @@ export type {
 
 /** Plugin identity for cordis.yml rows. */
 export const name = 'dsh-better-sidebar'
+export const BETTER_SIDEBAR_FEDERATION_NAMESPACE = 'dsh-better-sidebar'
+export const BETTER_SIDEBAR_FEDERATION_VERSION = '0.12.3'
 
 /** Services required before mounting: the webserver routes, the session store, the web runtime's trusted hosts, and the tool registry. */
 export const inject = ['webServer', 'sessions', 'webRuntime', 'tools']
@@ -113,6 +115,26 @@ function sessionCwdOf(ctx: Context, sessionId: string, clientCwd?: string): stri
     }
   }
   return process.cwd()
+}
+
+/**
+ * Resolve a Session cwd strictly on its owner node.
+ *
+ * Federation callers never get the hydration fallbacks used by the local UI:
+ * their `cwd` field is untrusted, and falling back to process.cwd() for an
+ * unknown owner-local Session would turn a routing mistake into filesystem
+ * access on an unrelated directory.
+ */
+function ownerSessionCwdOf(ctx: Context, sessionId: string): string {
+  const cwd = ctx.sessions.get(sessionId)?.header.cwd
+  if (cwd === undefined || cwd === '') {
+    throw new SidebarError('not-found', `session "${sessionId}" has no owner-local working directory`, 404)
+  }
+  try {
+    return requireAbsolute(cwd)
+  } catch {
+    throw new SidebarError('fs-error', `session "${sessionId}" has an invalid working directory`, 400)
+  }
 }
 
 /**
@@ -169,6 +191,104 @@ async function readText(path: string, readLimit: number): Promise<{
 /** One API method dispatch table entry. */
 type ApiMethod = (payload: unknown) => Promise<unknown> | unknown
 
+const FEDERATED_JSON_READ_METHODS = [
+  'session.cwd', 'fs.tree', 'fs.search', 'fs.read',
+  'git.status', 'git.diff', 'git.branch', 'git.log', 'git.commit-diff', 'git.show',
+  'jobs.output',
+] as const
+const FEDERATED_JSON_WRITE_METHODS = [
+  'fs.write', 'git.stage', 'git.unstage', 'git.commit', 'git.checkout',
+  'git.discard', 'git.revert', 'git.cherry-pick', 'pty.close', 'jobs.kill',
+] as const
+
+/**
+ * Registers the owner-local JSON backend with Federation when that optional
+ * Host service is present. Global settings, browser probes, dependency status,
+ * and UUID-only agent terminal operations are deliberately not exported.
+ */
+function registerFederatedJsonApi(
+  registry: import('./context-types.ts').SidebarFederatedExtensionRegistry,
+  api: Record<string, ApiMethod>,
+): () => void {
+  const capabilities = [
+    ...FEDERATED_JSON_READ_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'read' as const, transport: 'json' as const })),
+    ...FEDERATED_JSON_WRITE_METHODS.map(name => ({ name, scope: 'session' as const, risk: 'write' as const, transport: 'json' as const })),
+  ]
+  const handlers: Record<string, (
+    context: { callerNodeId: string; sessionId: string; signal: AbortSignal },
+    payload: unknown,
+  ) => Promise<
+    | { ok: true; value: unknown }
+    | { ok: false; error: { code: string; message: string; details: Record<string, unknown> } }
+  >> = {}
+  for (const capability of capabilities) {
+    handlers[capability.name] = async (context, payload) => {
+      const source = payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+        ? payload as Record<string, unknown>
+        : {}
+      // Owner routing decides sessionId. A caller-supplied cwd is never carried
+      // into the owner backend, even when hidden inside the ordinary payload.
+      const ownerPayload: Record<string, unknown> = { ...source, sessionId: context.sessionId }
+      delete ownerPayload.cwd
+      try {
+        const handler = api[capability.name]
+        if (handler === undefined) {
+          return { ok: false, error: { code: 'not-found', message: `unknown sidebar API method "${capability.name}"`, details: {} } }
+        }
+        return { ok: true, value: await handler(ownerPayload) }
+      } catch (error) {
+        if (error instanceof SidebarError) {
+          return { ok: false, error: { code: error.code, message: error.message, details: {} } }
+        }
+        return { ok: false, error: { code: 'internal', message: error instanceof Error ? error.message : String(error), details: {} } }
+      }
+    }
+  }
+  return registry.register({
+    manifest: { namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE, version: BETTER_SIDEBAR_FEDERATION_VERSION, capabilities },
+    handlers,
+  })
+}
+
+/**
+ * Routes an ingress `/sidebar/api/*` request through Federation only when the
+ * supplied Session id is node-scoped. Bare ids keep the original local fast
+ * path, so installing Federation does not add a network hop to local sidebar
+ * use.
+ */
+function isFederatedSessionId(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const separator = value.indexOf('~')
+  return separator > 0 && separator < value.length - 1
+}
+
+async function invokeFederatedJson(
+  router: import('./context-types.ts').SidebarFederationExtensionRouter,
+  method: string,
+  payload: unknown,
+): Promise<unknown> {
+  const sessionId = requireString(payload, 'sessionId')
+  const source = payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload as Record<string, unknown>
+    : {}
+  const forwarded: Record<string, unknown> = { ...source }
+  delete forwarded.sessionId
+  delete forwarded.cwd
+  const result = await router.invokeJson({
+    namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
+    version: BETTER_SIDEBAR_FEDERATION_VERSION,
+    capability: method,
+    sessionId,
+    payload: forwarded,
+  })
+  if (result.ok) return result.value
+  throw new SidebarError(
+    result.error.code === 'session-not-found' ? 'not-found' : 'internal',
+    result.error.message,
+    result.error.code === 'session-not-found' ? 404 : 502,
+  )
+}
+
 /**
  * The live face of the side card settings namespace, bound to the settings
  * service when it is mounted. The DSH settings RPC domain only serves
@@ -183,6 +303,9 @@ export interface SidebarSettingsFace {
   update(patch: Record<string, unknown>, expectedRevision?: number): Promise<{ value?: unknown; revision?: number }>
 }
 
+/** How API methods resolve the owner-local Session cwd. */
+type CwdMode = 'local-fallbacks' | 'owner-strict'
+
 /** Build the API method table bound to the plugin context, pty manager, agent pty registry, and resolved config. */
 function buildApi(
   ctx: Context,
@@ -190,9 +313,11 @@ function buildApi(
   agentPtyRegistry: AgentPtyRegistry | null,
   resolved: ResolvedSidebarConfig,
   getSettings: () => SidebarSettingsFace | undefined,
+  cwdMode: CwdMode = 'local-fallbacks',
 ): Record<string, ApiMethod> {
   const cwdOf = (payload: unknown): { sessionId: string; cwd: string } => {
     const sessionId = requireString(payload, 'sessionId')
+    if (cwdMode === 'owner-strict') return { sessionId, cwd: ownerSessionCwdOf(ctx, sessionId) }
     const record = payload as { cwd?: unknown } | null
     const clientCwd = typeof record?.cwd === 'string' && record.cwd !== '' ? record.cwd : undefined
     return { sessionId, cwd: sessionCwdOf(ctx, sessionId, clientCwd) }
@@ -539,6 +664,18 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
 
   // ── JSON API ────────────────────────────────────────────────────────────
   const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, () => settingsFace)
+  let federationRouter: import('./context-types.ts').SidebarFederationExtensionRouter | undefined
+  ctx.inject(['federationExtensionRouter'], (fctx) => {
+    federationRouter = fctx.federationExtensionRouter
+    return () => { federationRouter = undefined }
+  })
+  // Federation calls the same business handlers, but through a strict owner
+  // cwd resolver. The optional service is lifecycle-injected, so the sidebar
+  // remains fully usable when Federation is not installed.
+  ctx.inject(['federatedExtensions'], (fctx) => {
+    const ownerApi = buildApi(fctx as Context, ptyManager, agentPtyRegistry, resolved, () => settingsFace, 'owner-strict')
+    return registerFederatedJsonApi(fctx.federatedExtensions, ownerApi)
+  })
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
     path: '/sidebar/api',
@@ -559,6 +696,12 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       }
       try {
         const payload = await readJsonBody(req)
+        if (federationRouter !== undefined
+          && isFederatedSessionId((payload as { sessionId?: unknown } | null)?.sessionId)
+          && [...FEDERATED_JSON_READ_METHODS, ...FEDERATED_JSON_WRITE_METHODS].includes(method as never)) {
+          writeOk(res, await invokeFederatedJson(federationRouter, method, payload))
+          return
+        }
         const handler = api[method]
         if (handler === undefined) {
           throw new SidebarError('not-found', `unknown sidebar API method "${method}"`, 404)

--- a/src/pty-manager.ts
+++ b/src/pty-manager.ts
@@ -56,6 +56,10 @@ export interface SidebarPty {
   pty: IPty
   /** Output accumulated since spawn (bounded; head dropped when over the limit). */
   transcript: string
+  /** Monotonic UTF-16 output offset after the retained transcript. */
+  outputOffset: number
+  /** Offset represented by transcript[0]. */
+  transcriptBase: number
   /** Whether the top-level process exited (transcript stays replayable). */
   exited: boolean
   exitCode?: number | null
@@ -130,13 +134,17 @@ export class PtyManager {
         env: { ...process.env },
       }),
       transcript: '',
+      outputOffset: 0,
+      transcriptBase: 0,
       exited: false,
     }
     handle.pty.onData((data) => {
       handle.transcript += data
+      handle.outputOffset += data.length
       if (handle.transcript.length > TRANSCRIPT_LIMIT) {
         handle.transcript = handle.transcript.slice(handle.transcript.length - TRANSCRIPT_LIMIT)
       }
+      handle.transcriptBase = handle.outputOffset - handle.transcript.length
     })
     handle.pty.onExit(({ exitCode }) => {
       handle.exited = true

--- a/tests/federation-extension.spec.ts
+++ b/tests/federation-extension.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { apply, BETTER_SIDEBAR_FEDERATION_NAMESPACE, BETTER_SIDEBAR_FEDERATION_VERSION } from '../src/index.ts'
+
+type Registration = {
+  manifest: { namespace: string; version: string; capabilities: readonly { name: string; risk: string; transport: string }[] }
+  handlers: Record<string, (context: { callerNodeId: string; sessionId: string; signal: AbortSignal }, payload: unknown) => Promise<any>>
+}
+type Route = { kind: string; path: string; handler: (req: any, res: any) => Promise<void> }
+
+function mount(options: { cwd?: string; withRouter?: boolean } = {}) {
+  let registration: Registration | undefined
+  let disposed = false
+  let routedCall: unknown
+  const routes: Route[] = []
+  const ctx = {
+    webRuntime: { trustedHosts: [] },
+    webServer: { register: (route: Route) => { routes.push(route); return () => {} }, registerUpgrade: () => () => {} },
+    sessions: { get: (id: string) => id === 'owner-local' && options.cwd !== undefined ? { header: { cwd: options.cwd } } : undefined },
+    tools: { register: () => () => {} },
+    effect: (fn: () => void | (() => void)) => { fn() },
+    inject: (deps: string[], callback: (injected: any) => void | (() => void)) => {
+      if (deps.includes('federatedExtensions')) {
+        callback({
+          ...ctx,
+          federatedExtensions: {
+            register(value: Registration) {
+              registration = value
+              return () => { disposed = true }
+            },
+          },
+        })
+      }
+      if (deps.includes('federationExtensionRouter') && options.withRouter === true) {
+        callback({
+          ...ctx,
+          federationExtensionRouter: {
+            async invokeJson(call: unknown) { routedCall = call; return { ok: true, value: { remote: true } } },
+          },
+        })
+      }
+      return () => {}
+    },
+    get: () => undefined,
+  }
+  apply(ctx as never)
+  if (registration === undefined) throw new Error('federation registration was not captured')
+  return { registration, disposed: () => disposed, routedCall: () => routedCall, api: routes.find(route => route.path === '/sidebar/api')! }
+}
+
+describe('better-sidebar Federation extension', () => {
+  it('registers an explicit read/write JSON capability catalog only', () => {
+    const { registration } = mount({ cwd: process.cwd() })
+    expect(registration.manifest.namespace).toBe(BETTER_SIDEBAR_FEDERATION_NAMESPACE)
+    expect(registration.manifest.version).toBe(BETTER_SIDEBAR_FEDERATION_VERSION)
+    expect(registration.manifest.capabilities.every(entry => entry.transport === 'json')).toBe(true)
+    expect(registration.manifest.capabilities).toContainEqual({ name: 'fs.tree', scope: 'session', risk: 'read', transport: 'json' })
+    expect(registration.manifest.capabilities).toContainEqual({ name: 'fs.write', scope: 'session', risk: 'write', transport: 'json' })
+    expect(registration.manifest.capabilities.some(entry => entry.name === 'settings.update')).toBe(false)
+    expect(registration.manifest.capabilities.some(entry => entry.name === 'browser.probe')).toBe(false)
+    expect(registration.manifest.capabilities.some(entry => entry.name === 'agent-pty.close')).toBe(false)
+  })
+
+  it('uses the owner-local Session header and ignores forwarded cwd', async () => {
+    const { registration } = mount({ cwd: process.cwd() })
+    const result = await registration.handlers['session.cwd']!(
+      { callerNodeId: 'ingress', sessionId: 'owner-local', signal: new AbortController().signal },
+      { sessionId: 'attacker-global-id', cwd: '/tmp/attacker' },
+    )
+    expect(result).toMatchObject({ ok: true, value: { sessionId: 'owner-local', cwd: process.cwd() } })
+  })
+
+  it('routes node-scoped Session ids through the ingress router and strips cwd', async () => {
+    const { routedCall, api } = mount({ cwd: process.cwd(), withRouter: true })
+    const body = Buffer.from(JSON.stringify({
+      sessionId: 'openclaw~s-1', cwd: '/tmp/attacker', path: '/owner/path',
+    }))
+    const req = {
+      method: 'POST', url: '/sidebar/api/fs.tree', headers: { host: '127.0.0.1:3080' },
+      [Symbol.asyncIterator]: async function* () { yield body },
+    }
+    let response = ''
+    const res = { writeHead: () => {}, end: (chunk: unknown) => { response += String(chunk ?? '') } }
+    await api.handler(req, res)
+    expect(JSON.parse(response)).toEqual({ ok: true, value: { remote: true } })
+    expect(routedCall()).toEqual({
+      namespace: BETTER_SIDEBAR_FEDERATION_NAMESPACE,
+      version: BETTER_SIDEBAR_FEDERATION_VERSION,
+      capability: 'fs.tree',
+      sessionId: 'openclaw~s-1',
+      payload: { path: '/owner/path' },
+    })
+  })
+
+  it('fails closed when the owner-local Session is absent instead of using process.cwd', async () => {
+    const { registration } = mount()
+    const result = await registration.handlers['session.cwd']!(
+      { callerNodeId: 'ingress', sessionId: 'missing', signal: new AbortController().signal },
+      { cwd: process.cwd() },
+    )
+    expect(result).toMatchObject({ ok: false, error: { code: 'not-found' } })
+  })
+})

--- a/tests/federation-extension.spec.ts
+++ b/tests/federation-extension.spec.ts
@@ -48,11 +48,13 @@ function mount(options: { cwd?: string; withRouter?: boolean } = {}) {
 }
 
 describe('better-sidebar Federation extension', () => {
-  it('registers an explicit read/write JSON capability catalog only', () => {
+  it('registers an explicit read/write JSON plus bounded binary capability catalog', () => {
     const { registration } = mount({ cwd: process.cwd() })
     expect(registration.manifest.namespace).toBe(BETTER_SIDEBAR_FEDERATION_NAMESPACE)
     expect(registration.manifest.version).toBe(BETTER_SIDEBAR_FEDERATION_VERSION)
-    expect(registration.manifest.capabilities.every(entry => entry.transport === 'json')).toBe(true)
+    expect(registration.manifest.capabilities.every(entry => entry.transport === 'json' || entry.transport === 'binary')).toBe(true)
+    expect(registration.manifest.capabilities).toContainEqual({ name: 'file.read', scope: 'session', risk: 'read', transport: 'binary' })
+    expect(registration.manifest.capabilities).toContainEqual({ name: 'html.read', scope: 'session', risk: 'read', transport: 'binary' })
     expect(registration.manifest.capabilities).toContainEqual({ name: 'fs.tree', scope: 'session', risk: 'read', transport: 'json' })
     expect(registration.manifest.capabilities).toContainEqual({ name: 'fs.write', scope: 'session', risk: 'write', transport: 'json' })
     expect(registration.manifest.capabilities.some(entry => entry.name === 'settings.update')).toBe(false)

--- a/tests/federation-extension.spec.ts
+++ b/tests/federation-extension.spec.ts
@@ -40,7 +40,20 @@ function mount(options: { cwd?: string; withRouter?: boolean } = {}) {
       }
       return () => {}
     },
-    get: () => undefined,
+    get: (name: string) => {
+      if (name === 'federatedExtensions') {
+        return {
+          register(value: Registration) {
+            registration = value
+            return () => { disposed = true }
+          },
+        }
+      }
+      if (name === 'federationExtensionRouter' && options.withRouter === true) {
+        return { async invokeJson(call: unknown) { routedCall = call; return { ok: true, value: { remote: true } } } }
+      }
+      return undefined
+    },
   }
   apply(ctx as never)
   if (registration === undefined) throw new Error('federation registration was not captured')

--- a/tests/federation-extension.spec.ts
+++ b/tests/federation-extension.spec.ts
@@ -13,6 +13,7 @@ function mount(options: { cwd?: string; withRouter?: boolean } = {}) {
   let routedCall: unknown
   const routes: Route[] = []
   const ctx = {
+    get root() { return ctx },
     webRuntime: { trustedHosts: [] },
     webServer: { register: (route: Route) => { routes.push(route); return () => {} }, registerUpgrade: () => () => {} },
     sessions: { get: (id: string) => id === 'owner-local' && options.cwd !== undefined ? { header: { cwd: options.cwd } } : undefined },
@@ -41,6 +42,7 @@ function mount(options: { cwd?: string; withRouter?: boolean } = {}) {
       return () => {}
     },
     get: (name: string) => {
+      if (name === 'sessions') return ctx.sessions
       if (name === 'federatedExtensions') {
         return {
           register(value: Registration) {


### PR DESCRIPTION
## Summary
- register an explicit session-scoped JSON capability manifest with `@fzhiyu/dsh-federation` when available
- route node-scoped sidebar API calls to the Session owner while keeping bare local IDs on the fast path
- derive cwd strictly from the owner-local Session and discard forwarded cwd
- exclude global settings, browser probe, terminal dependency and UUID-only agent terminal surfaces

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run tests/federation-extension.spec.ts` (4 passed)
- focused existing cwd smoke tests (6 passed)

## Existing unrelated failures
A full `pnpm test` currently has pre-existing locale-sensitive `side-card-section.spec.tsx` failures and one PTY timing timeout on this machine; the new focused suite is green.
