### PR TITLE
chore: add .prettierrc, .gitattributes and format scripts (zero diff on existing code)chore: add .prettierrc, .gitattributes and format scripts (zero diff …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.ps1 text eol=crlf
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+lib
+dist
+coverage
+pnpm-lock.yaml
+.pnpm-store
+*.min.js
+*.min.css

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "prepare": "tsdown",
     "test": "vitest run",
     "test:mount": "bash scripts/e2e-mount.sh",
-    "check:consumer-types": "bash scripts/check-consumer-types.sh"
+    "check:consumer-types": "bash scripts/check-consumer-types.sh",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "license": "MIT",
   "peerDependencies": {
@@ -162,6 +164,7 @@
     "cordis": "^4.0.0-rc.7",
     "jsdom": "^29.1.1",
     "lightningcss": "^1.32.0",
+    "prettier": "^3.9.6",
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "tsdown": "^0.22.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       lightningcss:
         specifier: ^1.32.0
         version: 1.33.0
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1813,6 +1816,11 @@ packages:
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -4086,6 +4094,8 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prettier@3.9.6: {}
 
   property-information@7.2.0: {}
 


### PR DESCRIPTION
为了在多贡献者并行协作时统一代码规范、避免不同 IDE 排版及跨平台换行符（CRLF vs LF）带来的伪冲突，我基于当前仓库现有的主导代码习惯配置了 Prettier 与 Git 规范。

> 💡 **特别说明（零侵入设计）**：
> 本 PR **仅包含 4 个基础配置文件**，**未对现有的任何业务源码进行全量格式化重写（0 业务代码 diff）**，以确保不会对社区其他所有正在进行的 Open PR 造成任何 Rebase 冲突干扰。

---

### 🛠️ 核心改动 (Key Changes)

1. **代码规范配置**：
   - 创建 `.prettierrc`（`semi: false`, `singleQuote: true`, `tabWidth: 2`, `printWidth: 120`, `endOfLine: 'lf'`），精准契合项目现有的无分号/单引号习惯；
   - 创建 `.prettierignore` 排除构建产物与依赖。
2. **跨平台换行符治理**：
   - 创建 `.gitattributes`，声明全局文本统一使用 LF 换行，保护二进制资源。
3. **便捷 Scripts**：
   - 在 `package.json` 中配置 `format` 与 `format:check` 命令，方便贡献者本地一键自查。

---

### 💬 共同探讨与后续规划 (Discussion & Future Plans)

我想在此和大家共同探讨两点：
1. **目前的规则细节是否符合核心团队的长期偏好？** 如果有任何细节想调整（如行宽、尾随逗号规则等），随时可以在此基础上微调；
2. **后续是否考虑引入轻量的 pre-commit hooks（如 `lint-staged`）？** 可以在本地 commit 前协助贡献者自动修好排版，让代码库随着日常迭代自然收敛至统一风格。

欢迎 Maintainer 提出任何想法和指导！❤️

---

### ✅ 验证情况 (Verification)
- `pnpm test`：✔ 57 test files, 579 passed
- `pnpm typecheck`：✔ 0 errors
- `pnpm build` & `pnpm check:consumer-types`：✔ Passed