### PR TITLE
fix(tab-bar): animate tab close to prevent layout flicker

### DIFF
--- a/src/client/TabBar.tsx
+++ b/src/client/TabBar.tsx
@@ -5,7 +5,7 @@
  * terminal). Tabs are draggable; dropping onto another tab inserts before it,
  * dropping on the strip background appends to this pane.
  */
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import clsx from 'clsx'
 import {
   IconCloseFill14, IconPlusOutline16, Menu,
@@ -72,7 +72,9 @@ export function TabBar(props: {
   } = props
   const [menuOpen, setMenuOpen] = useState(false)
   const [dragOver, setDragOver] = useState(false)
+  const [closingTabs, setClosingTabs] = useState<Set<string>>(new Set())
   const listRef = useRef<HTMLDivElement>(null)
+  const closingTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
 
   // Wheel over the strip scrolls the tab row horizontally (a plain mouse
   // wheel emits deltaY, which overflow-x alone never consumes). Bound as a
@@ -106,6 +108,30 @@ export function TabBar(props: {
     }
   }, [])
 
+  // Cleanup closing timers on unmount.
+  useEffect(() => {
+    return () => {
+      for (const timer of closingTimers.current.values()) clearTimeout(timer)
+      closingTimers.current.clear()
+    }
+  }, [])
+
+  // Close handler: two-phase — animate out, then remove from DOM.
+  const handleClose = useCallback((tabId: string) => {
+    if (closingTimers.current.has(tabId)) return // already closing
+    setClosingTabs(prev => new Set(prev).add(tabId))
+    const timer = setTimeout(() => {
+      closingTimers.current.delete(tabId)
+      setClosingTabs(prev => {
+        const next = new Set(prev)
+        next.delete(tabId)
+        return next
+      })
+      onClose(tabId)
+    }, 120) // matches CSS transition duration
+    closingTimers.current.set(tabId, timer)
+  }, [onClose])
+
   return (
     <div
       className={clsx(css.tabBar, dragOver && css.tabBarDrop)}
@@ -132,7 +158,7 @@ export function TabBar(props: {
         {tabs.map(tab => (
           <div
             key={tab.id}
-            className={clsx(css.tab, active === tab.id && css.tabActive)}
+            className={clsx(css.tab, active === tab.id && css.tabActive, closingTabs.has(tab.id) && css.tabClosing)}
             title={tab.title}
             draggable
             onDragStart={(event) => {
@@ -155,7 +181,7 @@ export function TabBar(props: {
               // Middle-click closes the tab (and suppresses autoscroll).
               if (event.button === 1) {
                 event.preventDefault()
-                onClose(tab.id)
+                handleClose(tab.id)
               }
             }}
           >
@@ -168,7 +194,7 @@ export function TabBar(props: {
               aria-label={t('close')}
               onClick={(event) => {
                 event.stopPropagation()
-                onClose(tab.id)
+                handleClose(tab.id)
               }}
             >
               <IconCloseFill14 />

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -554,6 +554,19 @@
   background: transparent;
   cursor: pointer;
   user-select: none;
+  transition: opacity 120ms ease-out, min-width 120ms ease-out, max-width 120ms ease-out;
+}
+
+/* Tab being closed: fade out and shrink before removal from DOM. */
+.tabClosing {
+  opacity: 0;
+  min-width: 0;
+  max-width: 0;
+  padding-left: 0;
+  padding-right: 0;
+  border-right-width: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .tab:hover {
@@ -2033,6 +2046,7 @@
   .toggleCluster,
   .toggleButton,
   .tab,
+  .tabClosing,
   .tabBarPlus,
   .paneCard,
   .explorerRow,


### PR DESCRIPTION
## Summary / 概述

当两个 pane 并列时，关闭一个 tab 会导致另一个 pane 闪烁。这是因为 tab 被立即从 DOM 移除，导致浏览器瞬间重排布局。

本 PR 添加了两阶段关闭动画：tab 先淡出+收缩（120ms CSS 过渡），然后再从 DOM 移除，让浏览器有时间平滑地重新分配空间。

## Changes / 变更

**`src/client/TabBar.tsx`**:
- 新增 `closingTabs` 状态追踪正在关闭的 tab
- 新增 `handleClose` 两阶段关闭函数：先添加动画类，120ms 后再调用实际的 `onClose`
- 关闭按钮和中键关闭都走 `handleClose` 路径
- 组件卸载时清理所有定时器

**`src/client/sidebar.module.css`**:
- `.tab` 新增 `transition` 属性（opacity/min-width/max-width，120ms）
- 新增 `.tabClosing` 类：opacity → 0, min-width/max-width → 0, 隐藏溢出，禁用交互
- Reduced motion 媒体查询中加入 `.tabClosing`

## Root cause / 根因

Tab 被关闭时，`onClose` 直接更新 React state，tab 立即从数组中移除。Flex 布局在下一帧重算，相邻 pane 的宽度瞬间变化，导致视觉闪烁。

## Fix / 修复

两阶段关闭：
1. 点击关闭 → tab 添加 `.tabClosing` 类 → 开始 120ms 过渡动画（淡出+收缩）
2. 动画结束后 → 调用 `onClose` → tab 从 state 移除 → 布局平滑重排

## Testing / 验证

- `pnpm typecheck` 通过
- `pnpm build` 通过
- 全套测试通过（2 个 pty 环境性失败与本次改动无关）
- 所有 tab 相关测试通过：state (68) + service (68) + builtins (18) + side-card-section (7) + orphaned-tab (3) + tab-bar-wheel (7) = **171 tests**