### PR TITLE
feat(settings): dsh-web-ui family settings card (hide shell section in family mode)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,6 +590,7 @@ interface OpenTabSeed {
 | **ModuleLoader 不跨插件** | 运行时 `require()` 虽支持跨 bundle，但被构建门挡；所有交互走 `ctx.betterSidebar` 方法调用 |
 | **host 半无此服务** | `ctx.betterSidebar` 只在 client 侧存在；host 半需要 better-sidebar 数据走 `/sidebar/api/*` HTTP 路由 |
 | **portal 限制** | 整面板 slot 由 ui-layout 独占，外部 tab 只能进入 better-sidebar 的 portal 内部，无法全屏替换 |
+| **家族设置卡** | 检测到 `webUiSettings` 服务（dsh-web-ui 家族：dsh-web-ui-settings / 聚合包）时，设置入口注册为 `web-ui.plugin.item` 卡（复用 `SideCardSection` 组件），并跳过 `settings.section` 与导航图标——家族模式只有一个设置入口。检测在 `apply()` 时点一次：聚合包行序保证 web-ui-settings 先行；混合独立安装无行序保证，漏检时齿轮与卡并存，刷新后收敛（见 `src/client/settings-entry.ts`） |
 | **id 冲突** | `registerTab` / `registerFileViewer` 对重复 id 抛错；建议用包前缀（`my-plugin:xxx`） |
 | **i18n 跟随** | 侧边栏界面文案跟随 DSH 的 `ctx.locale`（`@deepseek-ai/dsh-client-locale`）：词典注册在 `betterSidebar` 命名空间，语言偏好（Host-backed `locale.preference`）与浏览器语言不一致时以 DSH 为准并实时切换；locale 服务缺失时回退浏览器语言。插件自身的 `t()`（`src/client/locales.ts`）由 `apply()` 挂接服务；消费插件**不要**依赖此内部函数——标题等字段传字符串或 `() => string` 即可（i18n 友好）。⚠️ 渲染 DSH 的 `MarkdownText` 时必须传 `codeLabels={{ copyLabel: t('copy'), copiedLabel: t('copied') }}`——该组件 cordis-free，漏传则代码块复制按钮回退硬编码中文 |
 | **懒加载 chunk** | 内置重依赖（xterm/CodeMirror）在独立 bundle（`lib/client-<name>.js`）中，经 `/sidebar/bundle` 路由按需下发；每个脚本把 factory 赋到插件自有全局注册表 `globalThis.__dshChunks__[<name>]`，由 `src/client/chunk-loader.ts` 用自定义 require（externals 经 `__DSH_MODULES__` seed 分支解析）物化——**不经过** `__ModuleLoader__` 注册；**核心 bundle 禁止静态 import `src/client/chunks/*`**（会把库拖回启动路径）；对消费插件透明——懒加载只作用于内置 descriptor，`component` 契约（`(props) => ReactNode` 纯渲染函数）不变 |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - **🪟 双工作台**：右侧栏 + 底部面板；拖 Tab 拆分 / 合并分栏（可跨面板），移动端自动合并全宽抽屉
 - **🔁 会话隔离**：布局 / Tab / 面板按会话持久化，陈旧状态自动净化
 - **⚙️ 声明式设置**：设置页「侧边卡片」逐项独立开关，二级设置经齿轮弹窗
+- **🧩 家族集成**：与 dsh-web-ui 家族共存时，设置入口自动并入「Web UI 插件」组（better-sidebar 卡），「侧边卡片」齿轮让位；独立安装保持原样
 - **⚡ 按需加载**：启动只拉 ~325KB 核心，终端 / 编辑器等重依赖用到才按需拉取（[设计文档](docs/plans/2026-08-12-lazy-chunks-design.md)）
 - **🌏 多语言**：界面文案跟随 DSH 语言（zh / en）实时切换
 
@@ -40,6 +41,12 @@
   <a href="https://github.com/user-attachments/assets/946f7028-4967-461e-a750-d1b5056b62d0"><img width="45%" alt="服务化基座截图" src="https://github.com/user-attachments/assets/946f7028-4967-461e-a750-d1b5056b62d0" /></a>
   <a href="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e"><img width="45%" alt="添加插件截图" src="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e" /></a>
 </div>
+
+### v0.13.0
+
+**✨ 新功能**
+
+- 🧩 **dsh-web-ui 家族设置卡**：检测到 dsh-web-ui 家族（`webUiSettings` 服务，即安装了 dsh-web-ui-settings / 聚合包）时，设置入口自动改用家族「Web UI 插件」组内的 better-sidebar 卡（完整设置清单，与「侧边卡片」同一组件零漂移），并跳过 DSH 设置壳里的「侧边卡片」齿轮项——家族模式下只有一个设置入口；独立安装行为不变
 
 ### v0.12.3
 
@@ -140,7 +147,7 @@ dsh plugin --profile web add dsh-better-sidebar@latest
 5. 硬刷新浏览器（Cmd/Ctrl+Shift+R）即可看到效果（client 改动无需重启 DSH；host 半改动才需重启）
 ```
 
-更新：`git pull && pnpm install && pnpm build` → 硬刷新浏览器即可（client 改动热加载生效，无需重启 DSH；host 半改动才需重启）。切回 npm 通道时，把依赖改回 `"dsh-better-sidebar": "^0.12.3"` 再 `pnpm install`。
+更新：`git pull && pnpm install && pnpm build` → 硬刷新浏览器即可（client 改动热加载生效，无需重启 DSH；host 半改动才需重启）。切回 npm 通道时，把依赖改回 `"dsh-better-sidebar": "^0.13.0"` 再 `pnpm install`。
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -29,6 +29,7 @@
 - **🪟 Dual Workbench**: right sidebar + bottom panel; drag tabs to split / merge panes (cross-panel), mobile auto-merges into a full-width drawer
 - **🔁 Session Isolation**: layout / tabs / panels persisted per session, stale state auto-purged
 - **⚙️ Declarative Settings**: per-item toggles in the "Side Cards" settings section, secondary settings via the gear dialog
+- **🧩 Family integration**: with the dsh-web-ui family installed, the settings entry moves into the "Web UI Plugins" group (better-sidebar card) and the "Side card" gear row steps aside; standalone installs keep the original entry
 - **⚡ On-demand Loading**: only ~325KB core at startup; heavy deps (terminal / editor) load on demand ([design](docs/plans/2026-08-12-lazy-chunks-design.md))
 - **🌏 i18n**: UI text follows DSH's language (zh / en) with live switching
 
@@ -40,6 +41,12 @@
   <a href="https://github.com/user-attachments/assets/946f7028-4967-461e-a750-d1b5056b62d0"><img width="45%" alt="Service API base screenshot" src="https://github.com/user-attachments/assets/946f7028-4967-461e-a750-d1b5056b62d0" /></a>
   <a href="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e"><img width="45%" alt="Add Plugins screenshot" src="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e" /></a>
 </div>
+
+### v0.13.0
+
+**✨ New features**
+
+- 🧩 **dsh-web-ui family settings card**: when the dsh-web-ui family is detected (the `webUiSettings` service — dsh-web-ui-settings / the aggregate bundle installed), the settings entry automatically moves into the family "Web UI Plugins" group as a better-sidebar card (the full settings inventory, same component as the "Side card" section so the two can never drift), and the plugin's own "Side card" gear row in the DSH settings shell is skipped — exactly one settings entry in family mode; standalone installs keep the previous behavior
 
 ### v0.12.3
 
@@ -104,7 +111,7 @@ Then **hard-refresh the browser** (Cmd/Ctrl+Shift+R) to see the sidebar (DSH hot
 dsh plugin --profile web add dsh-better-sidebar@latest
 ```
 
-or bump the version in `~/.dsh/profiles/web/package.json` (e.g. `"^0.12.3"`) and run `pnpm install`. Then hard-refresh the browser (Cmd/Ctrl+Shift+R) — client changes do not need a DSH restart.
+or bump the version in `~/.dsh/profiles/web/package.json` (e.g. `"^0.13.0"`) and run `pnpm install`. Then hard-refresh the browser (Cmd/Ctrl+Shift+R) — client changes do not need a DSH restart.
 
 </details>
 
@@ -140,7 +147,7 @@ To debug local changes or track the dev branch, point the dependency at a local 
 5. Restart DSH and hard-refresh
 ```
 
-Update: `git pull && pnpm install && pnpm build` → just hard-refresh the browser (client changes hot-reload; only host-half changes need a DSH restart). To switch back to the npm channel, restore `"dsh-better-sidebar": "^0.12.3"` and re-run `pnpm install`.
+Update: `git pull && pnpm install && pnpm build` → just hard-refresh the browser (client changes hot-reload; only host-half changes need a DSH restart). To switch back to the npm channel, restore `"dsh-better-sidebar": "^0.13.0"` and re-run `pnpm install`.
 
 </details>
 

--- a/dsh.plugin.json
+++ b/dsh.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "dsh-external/dsh-better-sidebar",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "main": "./lib/index.js",
   "description": "VSCode 风格右侧侧边栏：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器，按会话隔离。暴露服务供其他插件注册侧边栏页面和文件预览器",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-better-sidebar",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "DSH web plugin: a VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per conversation session. Exposes a service for other plugins to register sidebar tabs and file viewers.",
   "type": "module",
   "repository": {

--- a/src/client/FamilySettingsCard.tsx
+++ b/src/client/FamilySettingsCard.tsx
@@ -1,0 +1,30 @@
+/**
+ * The better-sidebar card inside the dsh-web-ui family "Web UI 插件" settings
+ * group (the `web-ui.plugin.item` child slot declared by dsh-web-ui-settings).
+ *
+ * The family group is the settings entry when the family bundle is present:
+ * this card hosts the SAME declarative settings surface as the standalone
+ * "Side card" settings section (see {@link SideCardSection}), so the two
+ * entry points never drift — the card is a thin adapter that hands the
+ * shared store/service to the section component. The slot passes the
+ * `web-ui.plugin.item` runtime share at render time; this card only consumes
+ * the injected business face, exactly like the section does.
+ */
+import { createElement } from 'react'
+import type { SidebarStore } from './state.ts'
+import type { BetterSidebarService } from './service.ts'
+import { SideCardSection } from './SideCardSection.tsx'
+
+/** Injected business face: the shared store (prefs cache) + the sidebar service (registries). */
+export interface FamilySettingsCardInjected {
+  store: SidebarStore
+  service: BetterSidebarService
+}
+
+/**
+ * Render the better-sidebar settings inside the family plugin card.
+ * @param props - the injected store/service (the slot runtime share is ignored).
+ */
+export function FamilySettingsCard({ store, service }: FamilySettingsCardInjected) {
+  return createElement(SideCardSection, { store, service })
+}

--- a/src/client/SideCardSection.tsx
+++ b/src/client/SideCardSection.tsx
@@ -51,7 +51,6 @@ import {
 import clsx from 'clsx'
 // Type-only: pulls the settings shell's SlotMap merges ('settings.section').
 import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
-import type { PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
 import {
   clampWidthPercent,
   TITLE_BAR_STRIP_MAX,
@@ -80,8 +79,14 @@ export interface SideCardSectionInjected {
   service: BetterSidebarService
 }
 
-/** Full section props: the runtime share plus the injected face. */
-export type SideCardSectionProps = PropsRuntime<'settings.section'> & SideCardSectionInjected
+/**
+ * Full section props. The runtime share the settings shell passes
+ * (`PropsRuntime<'settings.section'>` — owner props, global standard props)
+ * is deliberately not part of the type: the section never reads it, and
+ * both entry points (the standalone shell section and the dsh-web-ui family
+ * card) render the same component with the injected face only.
+ */
+export type SideCardSectionProps = SideCardSectionInjected
 
 /** Map one wire failure to the inline message (the conflict gets friendly copy). */
 function messageOf(error: unknown): string {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -3,10 +3,12 @@
  * preferences through the plugin's own fenced settings route, mounts the
  * right sidebar portal (inside an error boundary so a rendering failure
  * shows an error strip instead of a blank panel), registers the turn-tail
- * interception, and contributes the Side card settings section to the DSH
- * Settings shell. Requires the runtime's slots and sessions services; the
- * bundle itself is a module-table consumer only (react + ui-primitives +
- * xterm, all provided or inlined).
+ * interception, and contributes the settings entry: the "Side card"
+ * section in the DSH Settings shell when installed standalone, or the
+ * better-sidebar card inside the dsh-web-ui family "Web UI 插件" group when
+ * the family bundle (web-ui-settings) is present. Requires the runtime's
+ * slots and sessions services; the bundle itself is a module-table consumer
+ * only (react + ui-primitives + xterm, all provided or inlined).
  */
 import { createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -20,11 +22,10 @@ import { RenderBoundary } from './RenderBoundary.tsx'
 import { registerOpenPathInterception, registerTurnTailInterception } from './intercept.tsx'
 import { registerLinkInterception } from './link-intercept.ts'
 import { registerImeGuard } from './ime-guard.ts'
-import { registerSettingsNavIcon } from './settings-nav-icon.ts'
 import { loadPrefs } from './prefs.ts'
-import { SideCardSection } from './SideCardSection.tsx'
+import { registerSettingsEntry } from './settings-entry.ts'
 import { api } from './api.ts'
-import { LOCALE_NS, attachLocale, t, zh, en } from './locales.ts'
+import { LOCALE_NS, attachLocale, zh, en } from './locales.ts'
 import css from './sidebar.module.css'
 import './layout.css'
 
@@ -214,28 +215,17 @@ export function apply(ctx: Context): void {
       'dsh-better-sidebar: IME composition guard',
     )
 
-    // DSH 0.1.x does not yet carry an icon through the settings.section
-    // registration contract: its shell renders a generic gear for every
-    // external section. Mark only this plugin's localized nav row so
-    // layout.css can paint the requested Side card SVG; the disposer clears
-    // the marker for HMR / plugin disable.
-    ctx.effect(
-      () => registerSettingsNavIcon(() => t('settingsNav')),
-      'dsh-better-sidebar: settings navigation icon',
-    )
-
-    // The "Side card" settings section: appears in the DSH Settings shell
-    // once the shell's declaration is on the ledger (slots.inject waits for
-    // it); the section reads/writes the prefs through the plugin's own
-    // fenced settings route, keeps the shared store in sync, and renders the
-    // declarative enable/disable inventory from the tab/viewer registry.
-    ctx.slots.inject('settings.section', () => ctx.slots.register({
-      name: 'settings.section',
-      id: 'better-sidebar',
-      order: 100,
-      label: () => t('settingsNav'),
-      inject: () => ({ store: sidebarStore, service }),
-    }, SideCardSection))
+    // The settings entry: the dsh-web-ui family "Web UI 插件" group card when
+    // the family bundle is present (webUiSettings service visible — its row
+    // leads the aggregate patch), otherwise the standalone "Side card"
+    // section in the DSH Settings shell. The family card reuses the section
+    // component, so the two entry points never drift; the family mode skips
+    // the shell section (and its nav icon) so there is exactly one entry.
+    registerSettingsEntry(ctx, {
+      store: sidebarStore,
+      service,
+      hasFamilySettings: ctx.get('webUiSettings') !== undefined,
+    })
   } catch (error) {
     fail('load', error)
   }

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -470,7 +470,7 @@ export function matchUrlTarget(tabs: readonly TabDescriptor[], url: URL): TabDes
  * The plugin version this service instance reports. Keep in lockstep with
  * `package.json`'s version — `tests/service.spec.ts` asserts the pair.
  */
-export const SIDEBAR_SERVICE_VERSION = '0.12.3'
+export const SIDEBAR_SERVICE_VERSION = '0.13.0'
 
 /**
  * Monotonic capability list consumers use to gate new API usage (features

--- a/src/client/settings-entry.ts
+++ b/src/client/settings-entry.ts
@@ -1,0 +1,86 @@
+/**
+ * Settings entry selection for dsh-better-sidebar.
+ *
+ * The plugin's preferences surface has two possible homes:
+ *
+ * - **Family mode** (`webUiSettings` present — the dsh-web-ui family bundle
+ *   with dsh-web-ui-settings is installed): the settings live in the family
+ *   "Web UI 插件" group as the `web-ui.plugin.item` card, and the plugin's
+ *   own "Side card" section in the DSH Settings shell (the generic gear nav
+ *   row) is NOT registered, so there is exactly one settings entry.
+ * - **Standalone mode**: the "Side card" section (`settings.section`) with
+ *   the localized nav icon, as before.
+ *
+ * Detection happens once at apply time via `ctx.get('webUiSettings')`. In
+ * the family bundle the aggregate patch rows are ordered so dsh-web-ui-
+ * settings applies first (its row leads the aggregate patch), which makes
+ * the service visible at better-sidebar apply time. Mixed standalone
+ * installs have no ordering guarantee: when the service is not yet
+ * registered, the section (gear) is registered as usual and the family card
+ * stays inert until the family slot is declared — both entries may appear,
+ * which is harmless duplication and resolves on the next reload.
+ */
+import type { Context } from '../context-types.ts'
+import { LOCALE_NS, t } from './locales.ts'
+import { registerSettingsNavIcon } from './settings-nav-icon.ts'
+import { SideCardSection } from './SideCardSection.tsx'
+import { FamilySettingsCard } from './FamilySettingsCard.tsx'
+import type { SidebarStore } from './state.ts'
+import type { BetterSidebarService } from './service.ts'
+
+/** Which settings entry the plugin registers. */
+export type SettingsEntryTarget = 'family-card' | 'section'
+
+/** Pick the settings entry for the current deployment (pure). */
+export function settingsEntryTarget(hasFamilySettings: boolean): SettingsEntryTarget {
+  return hasFamilySettings ? 'family-card' : 'section'
+}
+
+/** The business face both entry components need. */
+export interface SettingsEntryDeps {
+  store: SidebarStore
+  service: BetterSidebarService
+}
+
+/** The family card order inside the Web UI plugin group (aionui's band). */
+export const FAMILY_CARD_ORDER = 110
+
+/**
+ * Register the plugin's settings entry for this deployment.
+ * @param ctx - client root context (slots/effect).
+ * @param opts - the injected business face + the family detection result.
+ */
+export function registerSettingsEntry(
+  ctx: Context,
+  opts: SettingsEntryDeps & { hasFamilySettings: boolean },
+): void {
+  const { store, service, hasFamilySettings } = opts
+  if (settingsEntryTarget(hasFamilySettings) === 'family-card') {
+    // The family group card hosts the settings; no settings.section row.
+    ctx.slots.inject('web-ui.plugin.item', () => ctx.slots.register({
+      name: 'web-ui.plugin.item',
+      id: 'better-sidebar',
+      order: FAMILY_CARD_ORDER,
+      locale: LOCALE_NS,
+      label: () => t('settingsNav'),
+      inject: () => ({ store, service }),
+    }, FamilySettingsCard))
+    return
+  }
+  // Standalone: the "Side card" section in the DSH Settings shell. DSH 0.1.x
+  // does not yet carry an icon through the settings.section registration
+  // contract: its shell renders a generic gear for every external section.
+  // Mark only this plugin's localized nav row so layout.css can paint the
+  // requested Side card SVG; the disposer clears the marker on HMR disable.
+  ctx.effect(
+    () => registerSettingsNavIcon(() => t('settingsNav')),
+    'dsh-better-sidebar: settings navigation icon',
+  )
+  ctx.slots.inject('settings.section', () => ctx.slots.register({
+    name: 'settings.section',
+    id: 'better-sidebar',
+    order: 100,
+    label: () => t('settingsNav'),
+    inject: () => ({ store, service }),
+  }, SideCardSection))
+}

--- a/tests/family-settings-card.spec.tsx
+++ b/tests/family-settings-card.spec.tsx
@@ -1,0 +1,42 @@
+/**
+ * Family settings card render tests: the card is a thin adapter that hosts
+ * the SAME declarative SideCardSection surface, so the two settings entry
+ * points (standalone section vs family card) cannot drift. Rendered with
+ * renderToString like the section spec (mount effects do not run in SSR).
+ */
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { createElement } from 'react'
+import { createSidebarStore } from '../src/client/state.ts'
+import { createBetterSidebarService } from '../src/client/service.ts'
+import { FamilySettingsCard } from '../src/client/FamilySettingsCard.tsx'
+
+describe('FamilySettingsCard', () => {
+  it('renders the Side card settings surface with the registered inventory', () => {
+    const store = createSidebarStore()
+    const service = createBetterSidebarService(store)
+    service.registerTab({
+      id: 'explorer',
+      title: () => 'Explorer',
+      icon: () => createElement('svg', { 'data-icon': 'explorer' }),
+      order: 10,
+      component: () => null,
+    })
+    service.registerFileViewer({
+      id: 'image',
+      title: () => 'Image',
+      icon: () => createElement('svg', { 'data-icon': 'image' }),
+      exts: ['png', 'jpg'],
+      fetchStrategy: 'mediaUrl',
+      component: () => null,
+    })
+
+    const html = renderToString(createElement(FamilySettingsCard, { store, service }))
+    // The section intro and the declarative inventory all come through.
+    expect(html).toContain('Manage what the side card shows and how it behaves')
+    expect(html).toContain('data-icon="explorer"')
+    expect(html).toContain('>Explorer<')
+    expect(html).toContain('data-icon="image"')
+    expect(html).toContain('png · jpg')
+  })
+})

--- a/tests/settings-entry.spec.ts
+++ b/tests/settings-entry.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Settings entry selection tests: the pure target picker and the actual
+ * registration behavior through a fake slots/effect context. The family mode
+ * (web-ui-settings present) must register the `web-ui.plugin.item` card and
+ * NOT the shell section; standalone mode keeps the `settings.section` row
+ * and the nav-icon effect.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Context } from '../src/context-types.ts'
+import {
+  FAMILY_CARD_ORDER,
+  registerSettingsEntry,
+  settingsEntryTarget,
+  type SettingsEntryDeps,
+} from '../src/client/settings-entry.ts'
+import { createSidebarStore } from '../src/client/state.ts'
+import { createBetterSidebarService } from '../src/client/service.ts'
+
+function deps(): SettingsEntryDeps {
+  const store = createSidebarStore()
+  const service = createBetterSidebarService(store)
+  return { store, service }
+}
+
+/** Recorded registration options (the business face factory is called on read). */
+interface RecordedRegistration {
+  name: string
+  id?: string
+  order?: number
+  locale?: string
+  inject?: () => Record<string, unknown>
+}
+
+interface FakeSlots {
+  injections: string[]
+  registrations: RecordedRegistration[]
+  effects: number
+}
+
+function fakeCtx(): { ctx: Context; slots: FakeSlots } {
+  const slots: FakeSlots = { injections: [], registrations: [], effects: 0 }
+  const ctx = {
+    slots: {
+      inject(key: string, callback: () => () => void): () => void {
+        slots.injections.push(key)
+        // Simulate an already-declared slot: the factory runs immediately.
+        return callback()
+      },
+      register(options: RecordedRegistration, _component: unknown): () => void {
+        slots.registrations.push(options)
+        return () => {}
+      },
+    },
+    effect(_fn: () => void | (() => void)): void {
+      // Record the lifecycle hook without running it: the nav-icon body
+      // touches the DOM, which this node-env spec does not provide. The
+      // registration decision is what is under test.
+      slots.effects += 1
+    },
+    get(): undefined {
+      return undefined
+    },
+  } as unknown as Context
+  return { ctx, slots }
+}
+
+describe('settingsEntryTarget', () => {
+  it('picks the family card when the family settings group is present', () => {
+    expect(settingsEntryTarget(true)).toBe('family-card')
+  })
+
+  it('picks the standalone section otherwise', () => {
+    expect(settingsEntryTarget(false)).toBe('section')
+  })
+})
+
+describe('registerSettingsEntry', () => {
+  it('family mode: registers the web-ui.plugin.item card, no shell section, no nav icon', () => {
+    const { ctx, slots } = fakeCtx()
+    const { store, service } = deps()
+    registerSettingsEntry(ctx, { store, service, hasFamilySettings: true })
+
+    expect(slots.injections).toEqual(['web-ui.plugin.item'])
+    expect(slots.effects).toBe(0)
+    expect(slots.registrations).toHaveLength(1)
+    const card = slots.registrations[0]!
+    expect(card.name).toBe('web-ui.plugin.item')
+    expect(card.id).toBe('better-sidebar')
+    expect(card.order).toBe(FAMILY_CARD_ORDER)
+    expect(card.locale).toBe('betterSidebar')
+    // The injected business face hands the shared store/service through.
+    const face = card.inject?.() as { store?: unknown; service?: unknown }
+    expect(face.store).toBe(store)
+    expect(face.service).toBe(service)
+  })
+
+  it('standalone mode: registers the settings.section row plus the nav-icon effect', () => {
+    const { ctx, slots } = fakeCtx()
+    const { store, service } = deps()
+    registerSettingsEntry(ctx, { store, service, hasFamilySettings: false })
+
+    expect(slots.injections).toEqual(['settings.section'])
+    expect(slots.effects).toBe(1)
+    expect(slots.registrations).toHaveLength(1)
+    const section = slots.registrations[0]!
+    expect(section.name).toBe('settings.section')
+    expect(section.id).toBe('better-sidebar')
+    expect(section.order).toBe(100)
+    const face = section.inject?.() as { store?: unknown; service?: unknown }
+    expect(face.store).toBe(store)
+    expect(face.service).toBe(service)
+  })
+})


### PR DESCRIPTION
## 摘要

当 dsh-web-ui 家族（`webUiSettings` 服务在场，即安装 dsh-web-ui-settings / 聚合包）时：

- 设置入口自动注册为家族「Web UI 插件」组内的 better-sidebar 卡（`web-ui.plugin.item`），复用 `SideCardSection` 组件——两个入口永不漂移；
- 同时跳过 DSH 设置壳里的「侧边卡片」`settings.section` 与导航图标注册——家族模式只有一个设置入口；
- 独立安装行为完全不变（维持原「侧边卡片」齿轮项）。

配套：注册决策抽成 `src/client/settings-entry.ts`（纯函数 + fake-ctx 单测），新增家族卡渲染测试，bump 至 v0.13.0（AGENTS.md 已预告 0.13.0 为下一版本线）。

## 涉及文件

- `src/client/index.tsx`：设置入口改走 `registerSettingsEntry`
- `src/client/settings-entry.ts`（新）：家族/独立两条注册路径 + 纯决策函数
- `src/client/FamilySettingsCard.tsx`（新）：家族卡适配组件
- `src/client/SideCardSection.tsx`：props 类型改为仅注入面（组件本就只消费 store/service）
- `src/client/service.ts`、`package.json`、`dsh.plugin.json`：版本同步 0.13.0
- `README.md` / `README_EN.md` / `AGENTS.md`：家族共存说明
- `tests/settings-entry.spec.ts`、`tests/family-settings-card.spec.tsx`（新）

## 验证

- `pnpm typecheck` 通过
- `pnpm test`：584 passed / 5 skipped
- `pnpm build` + `pnpm check:consumer-types` 通过

## 检测时序说明

`ctx.get('webUiSettings')` 在 apply 时检测一次。家族聚合包的行序保证 web-ui-settings 先于 better-sidebar；混合独立安装无行序保证时，漏检则齿轮与卡并存（无害重复，下次刷新收敛），已在 AGENTS.md §7 记录。