### PR TITLE
feat(settings): mutual exclusion with the dsh-web-ui aionui-panel provider (v0.13.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -591,6 +591,7 @@ interface OpenTabSeed {
 | **host 半无此服务** | `ctx.betterSidebar` 只在 client 侧存在；host 半需要 better-sidebar 数据走 `/sidebar/api/*` HTTP 路由 |
 | **portal 限制** | 整面板 slot 由 ui-layout 独占，外部 tab 只能进入 better-sidebar 的 portal 内部，无法全屏替换 |
 | **id 冲突** | `registerTab` / `registerFileViewer` 对重复 id 抛错；建议用包前缀（`my-plugin:xxx`） |
+| **家族右面板互斥（v0.13.0+）** | 读取 `aionui-panel` 设置命名空间的 `rightPanel`：解析为 `'aionui-panel'` 时整个侧边栏不挂载（`settings.get` 路由返回 `externalDisable: true`，客户端挂载门 + 各类接管一并停用；`settings/document-updated` 推送实时生效，无 `remote` 服务的部署回退为启动时判定）。未安装 aionui 或提供方为其他值时不受影响 |
 | **i18n 跟随** | 侧边栏界面文案跟随 DSH 的 `ctx.locale`（`@deepseek-ai/dsh-client-locale`）：词典注册在 `betterSidebar` 命名空间，语言偏好（Host-backed `locale.preference`）与浏览器语言不一致时以 DSH 为准并实时切换；locale 服务缺失时回退浏览器语言。插件自身的 `t()`（`src/client/locales.ts`）由 `apply()` 挂接服务；消费插件**不要**依赖此内部函数——标题等字段传字符串或 `() => string` 即可（i18n 友好）。⚠️ 渲染 DSH 的 `MarkdownText` 时必须传 `codeLabels={{ copyLabel: t('copy'), copiedLabel: t('copied') }}`——该组件 cordis-free，漏传则代码块复制按钮回退硬编码中文 |
 | **懒加载 chunk** | 内置重依赖（xterm/CodeMirror）在独立 bundle（`lib/client-<name>.js`）中，经 `/sidebar/bundle` 路由按需下发；每个脚本把 factory 赋到插件自有全局注册表 `globalThis.__dshChunks__[<name>]`，由 `src/client/chunk-loader.ts` 用自定义 require（externals 经 `__DSH_MODULES__` seed 分支解析）物化——**不经过** `__ModuleLoader__` 注册；**核心 bundle 禁止静态 import `src/client/chunks/*`**（会把库拖回启动路径）；对消费插件透明——懒加载只作用于内置 descriptor，`component` 契约（`(props) => ReactNode` 纯渲染函数）不变 |
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@
   <a href="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e"><img width="45%" alt="添加插件截图" src="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e" /></a>
 </div>
 
+### v0.13.0
+
+**✨ 新功能**
+
+- 🔀 **与 dsh-web-ui 家族右侧面板互斥**：读取 `aionui-panel` 设置命名空间的提供方选择——当选择「使用 aionui-panel」时，整个 better-sidebar（右侧栏 / 底部面板 / 浮动入口 / 各类接管）不再挂载；选择 DSH-better-sidebar（或未安装 aionui）时正常。设置页保存后实时生效（settings-document 推送），无需刷新
+
 ### v0.12.3
 
 **✨ 新功能**
@@ -140,7 +146,7 @@ dsh plugin --profile web add dsh-better-sidebar@latest
 5. 硬刷新浏览器（Cmd/Ctrl+Shift+R）即可看到效果（client 改动无需重启 DSH；host 半改动才需重启）
 ```
 
-更新：`git pull && pnpm install && pnpm build` → 硬刷新浏览器即可（client 改动热加载生效，无需重启 DSH；host 半改动才需重启）。切回 npm 通道时，把依赖改回 `"dsh-better-sidebar": "^0.12.3"` 再 `pnpm install`。
+更新：`git pull && pnpm install && pnpm build` → 硬刷新浏览器即可（client 改动热加载生效，无需重启 DSH；host 半改动才需重启）。切回 npm 通道时，把依赖改回 `"dsh-better-sidebar": "^0.13.0"` 再 `pnpm install`。
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -41,6 +41,12 @@
   <a href="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e"><img width="45%" alt="Add Plugins screenshot" src="https://github.com/user-attachments/assets/d4385b7e-aab4-425d-a5c4-2da5da81a34e" /></a>
 </div>
 
+### v0.13.0
+
+**✨ New features**
+
+- 🔀 **Mutual exclusion with the dsh-web-ui family right panel**: reads the `aionui-panel` settings namespace's provider choice — when "Use aionui-panel" is selected, the whole better-sidebar (right sidebar / bottom panel / floating entry / all takeovers) does not mount; with DSH-better-sidebar (or no aionui installed) it behaves as before. Takes effect live after a settings save (settings-document push), no reload needed
+
 ### v0.12.3
 
 **✨ New features**
@@ -104,7 +110,7 @@ Then **hard-refresh the browser** (Cmd/Ctrl+Shift+R) to see the sidebar (DSH hot
 dsh plugin --profile web add dsh-better-sidebar@latest
 ```
 
-or bump the version in `~/.dsh/profiles/web/package.json` (e.g. `"^0.12.3"`) and run `pnpm install`. Then hard-refresh the browser (Cmd/Ctrl+Shift+R) — client changes do not need a DSH restart.
+or bump the version in `~/.dsh/profiles/web/package.json` (e.g. `"^0.13.0"`) and run `pnpm install`. Then hard-refresh the browser (Cmd/Ctrl+Shift+R) — client changes do not need a DSH restart.
 
 </details>
 
@@ -140,7 +146,7 @@ To debug local changes or track the dev branch, point the dependency at a local 
 5. Restart DSH and hard-refresh
 ```
 
-Update: `git pull && pnpm install && pnpm build` → just hard-refresh the browser (client changes hot-reload; only host-half changes need a DSH restart). To switch back to the npm channel, restore `"dsh-better-sidebar": "^0.12.3"` and re-run `pnpm install`.
+Update: `git pull && pnpm install && pnpm build` → just hard-refresh the browser (client changes hot-reload; only host-half changes need a DSH restart). To switch back to the npm channel, restore `"dsh-better-sidebar": "^0.13.0"` and re-run `pnpm install`.
 
 </details>
 

--- a/dsh.plugin.json
+++ b/dsh.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "dsh-external/dsh-better-sidebar",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "main": "./lib/index.js",
   "description": "VSCode 风格右侧侧边栏：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器，按会话隔离。暴露服务供其他插件注册侧边栏页面和文件预览器",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-better-sidebar",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "DSH web plugin: a VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per conversation session. Exposes a service for other plugins to register sidebar tabs and file viewers.",
   "type": "module",
   "repository": {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -203,7 +203,7 @@ export const api = {
     })),
   /** Read the side card preferences (plugin-global, no session scope). */
   settingsGet: () =>
-    call<{ value?: unknown; revision?: number }>('settings.get', {}),
+    call<{ value?: unknown; revision?: number; externalDisable?: boolean }>('settings.get', {}),
   /** Merge a patch into the side card preferences (revision-guarded). */
   settingsUpdate: (patch: Record<string, unknown>, expectedRevision?: number) =>
     call<{ value?: unknown; revision?: number }>('settings.update', {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -21,7 +21,7 @@ import { registerOpenPathInterception, registerTurnTailInterception } from './in
 import { registerLinkInterception } from './link-intercept.ts'
 import { registerImeGuard } from './ime-guard.ts'
 import { registerSettingsNavIcon } from './settings-nav-icon.ts'
-import { loadPrefs } from './prefs.ts'
+import { loadExternalDisable, loadPrefs } from './prefs.ts'
 import { SideCardSection } from './SideCardSection.tsx'
 import { api } from './api.ts'
 import { LOCALE_NS, attachLocale, t, zh, en } from './locales.ts'
@@ -98,7 +98,30 @@ export function apply(ctx: Context): void {
       let disposed = false
       let root: Root | undefined
       let host: HTMLDivElement | undefined
-      void (async () => {
+      let mounted = false
+      const unmount = (): void => {
+        if (!mounted) return
+        mounted = false
+        root?.unmount()
+        root = undefined
+        host?.remove()
+        host = undefined
+      }
+      const mount = (): void => {
+        if (mounted || disposed) return
+        try {
+          host = document.createElement('div')
+          host.setAttribute('data-dsh-better-sidebar', '')
+          document.body.appendChild(host)
+          root = createRoot(host)
+          root.render(createElement(RenderBoundary, { className: css.boundaryError }, createElement(Sidebar, { ctx, store: sidebarStore })))
+          mounted = true
+        } catch (error) {
+          fail('mount', error)
+        }
+      }
+      const sync = async (): Promise<void> => {
+        if (disposed) return
         // Resolve the user's side card prefs BEFORE the first session seeds,
         // so a brand-new conversation opens (or stays closed) at the chosen
         // width from first paint. A settings route failure falls back to the
@@ -110,20 +133,26 @@ export function apply(ctx: Context): void {
         ])
         if (prefs !== null) sidebarStore.setPrefs(prefs)
         if (disposed) return
-        try {
-          host = document.createElement('div')
-          host.setAttribute('data-dsh-better-sidebar', '')
-          document.body.appendChild(host)
-          root = createRoot(host)
-          root.render(createElement(RenderBoundary, { className: css.boundaryError }, createElement(Sidebar, { ctx, store: sidebarStore })))
-        } catch (error) {
-          fail('mount', error)
-        }
-      })()
+        // Mutual exclusion with the dsh-web-ui family right panel: while the
+        // aionui-panel provider is selected, the sidebar must not mount at
+        // all. Re-evaluated on every settings-document update (live switch).
+        const suspended = await loadExternalDisable(api)
+        if (disposed) return
+        sidebarStore.setSuspended(suspended)
+        if (suspended) unmount()
+        else mount()
+      }
+      void sync()
+      // Live re-evaluation: the runtime broadcasts settings-document updates
+      // (the aionui card saves through the same document). Best effort —
+      // deployments without the 'remote' service fall back to boot-time
+      // evaluation only.
+      const remote = ctx.get('remote') as { $on?: (event: string, listener: () => void) => () => void } | undefined
+      const offRemote = remote?.$on?.('settings/document-updated', () => { void sync() })
       return () => {
         disposed = true
-        root?.unmount()
-        host?.remove()
+        offRemote?.()
+        unmount()
       }
     }, 'dsh-better-sidebar: sidebar mount')
 
@@ -168,6 +197,7 @@ export function apply(ctx: Context): void {
           }
           return registerLinkInterception({
             takeoverEnabled: (url) => {
+              if (sidebarStore.getSuspended()) return false
               const prefs = sidebarStore.getPrefs()
               if (prefs.browserInterceptLinks === false) return false
               const protocolOn = url.protocol === 'https:'

--- a/src/client/intercept.tsx
+++ b/src/client/intercept.tsx
@@ -76,8 +76,10 @@ export function registerTurnTailInterception(ctx: Context, store: SidebarStore):
     name: 'conversation.chat.turnTail',
     // Decline the takeover while the editor tab type is disabled in the side
     // card settings: the produced-files row falls back to the default
-    // deliverables behavior instead of offering chips that cannot open.
+    // deliverables behavior instead of offering chips that cannot open. Also
+    // while the sidebar is externally disabled (aionui-panel chosen).
     select: (owner) => {
+      if (store.getSuspended()) return null
       if (store.getPrefs().tabsEnabled['editor'] === false) return null
       return selectProducedFiles(owner)
     },
@@ -99,7 +101,8 @@ export function registerTurnTailInterception(ctx: Context, store: SidebarStore):
  */
 export function registerOpenPathInterception(ctx: Context, store: SidebarStore): () => void {
   return wrapOpenPath(ctx.workspaces, {
-    takeoverEnabled: () => store.getPrefs().interceptOpenPath !== false
+    takeoverEnabled: () => !store.getSuspended()
+      && store.getPrefs().interceptOpenPath !== false
       && store.getPrefs().tabsEnabled['editor'] !== false,
     currentSessionId: () => ctx.sessions.list.getSnapshot().current,
     openInSidebar: (path, sessionId) => { openSidebarFile(ctx, store, sessionId, path) },

--- a/src/client/prefs.ts
+++ b/src/client/prefs.ts
@@ -139,3 +139,22 @@ export async function loadPrefs(settings: SidebarSettingsClient): Promise<Sideba
     return { ...SIDEBAR_PREFS_DEFAULTS }
   }
 }
+
+/**
+ * Read the external-disable flag from the same settings route: the
+ * dsh-web-ui family's aionui-panel provider choice. True only when the host
+ * resolved `aionui-panel.rightPanel` to 'aionui-panel' — while true the
+ * sidebar must not mount (the two right panels are mutually exclusive). Any
+ * failure (route rejected, aionui absent, malformed response) reads false,
+ * so a missing family never hides the sidebar.
+ * @param settings - the settings wire face (the plugin api by default).
+ * @returns the external-disable flag (false on any failure).
+ */
+export async function loadExternalDisable(settings: SidebarSettingsClient): Promise<boolean> {
+  try {
+    const view = await settings.settingsGet()
+    return view.externalDisable === true
+  } catch {
+    return false
+  }
+}

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -470,7 +470,7 @@ export function matchUrlTarget(tabs: readonly TabDescriptor[], url: URL): TabDes
  * The plugin version this service instance reports. Keep in lockstep with
  * `package.json`'s version — `tests/service.spec.ts` asserts the pair.
  */
-export const SIDEBAR_SERVICE_VERSION = '0.12.3'
+export const SIDEBAR_SERVICE_VERSION = '0.13.0'
 
 /**
  * Monotonic capability list consumers use to gate new API usage (features

--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -974,6 +974,26 @@ export class SidebarStore {
   private readonly persistTimers = new Map<string, number>()
   /** User-facing side card prefs seeding brand-new session states (defaults until the settings RPC resolves). */
   private prefs: SidebarPrefs = { ...SIDEBAR_PREFS_DEFAULTS }
+  /**
+   * External disable (the dsh-web-ui family's aionui-panel provider choice):
+   * while true the sidebar must not mount at all. Not part of the snapshot —
+   * nothing renders on it; the mount gate and the intercept predicates read
+   * it directly.
+   */
+  private suspended = false
+
+  /**
+   * Set the external-disable flag (from the settings route) and remember it
+   * for the mount gate and the intercept predicates.
+   */
+  setSuspended(suspended: boolean): void {
+    this.suspended = suspended
+  }
+
+  /** Whether the sidebar is externally disabled (aionui-panel chosen). */
+  getSuspended(): boolean {
+    return this.suspended
+  }
 
   /**
    * Replace the side card prefs (the settings RPC result / settings page

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,14 @@ type ApiMethod = (payload: unknown) => Promise<unknown> | unknown
 export interface SidebarSettingsFace {
   /** The current resolved value + revision (undefined while the settings service is absent). */
   get(): { value?: unknown; revision?: number }
+  /**
+   * Whether the dsh-web-ui family's aionui-panel has been selected as the
+   * right-panel provider (the `aionui-panel` settings namespace resolves
+   * `rightPanel: 'aionui-panel'`). While true the sidebar must not mount —
+   * the two right panels are mutually exclusive. False when the namespace is
+   * absent (no aionui installed) or the provider is anything else.
+   */
+  externalDisable(): boolean
   /** Merge a patch (revision-guarded) and return the fresh resolved view. */
   update(patch: Record<string, unknown>, expectedRevision?: number): Promise<{ value?: unknown; revision?: number }>
 }
@@ -362,7 +370,9 @@ function buildApi(
     // silently overwritten (mirror of the settings seam's own guard).
     'settings.get': () => {
       const settings = getSettings()
-      return settings?.get() ?? { value: undefined, revision: undefined }
+      return settings === undefined
+        ? { value: undefined, revision: undefined, externalDisable: false }
+        : { ...settings.get(), externalDisable: settings.externalDisable() }
     },
     'settings.update': async (payload) => {
       const settings = getSettings()
@@ -524,8 +534,20 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         ? { value: undefined, revision: undefined }
         : { value: descriptor.value, revision: descriptor.revision }
     }
+    // Mutual exclusion with the dsh-web-ui family right panel: the aionui
+    // panel's provider choice (`aionui-panel.rightPanel`) is the authority.
+    // While it resolves to 'aionui-panel', this sidebar must not mount. The
+    // namespace is read through the settings seam like any other registered
+    // section; absent namespace (no aionui installed) = not disabled.
+    const externalDisable = (): boolean => {
+      const descriptor = sctx.settings.describe({ redactSecrets: true })
+        .find(candidate => candidate.ns === 'aionui-panel')
+      const value = descriptor?.value as { rightPanel?: unknown } | undefined
+      return value?.rightPanel === 'aionui-panel'
+    }
     settingsFace = {
       get: viewOf,
+      externalDisable,
       update: async (patch, expectedRevision) => {
         await sctx.settings.update(ns, patch, expectedRevision)
         return viewOf()

--- a/tests/prefs.spec.ts
+++ b/tests/prefs.spec.ts
@@ -1,20 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { loadPrefs, type SidebarSettingsClient } from '../src/client/prefs.ts'
+import { loadExternalDisable, loadPrefs, type SidebarSettingsClient } from '../src/client/prefs.ts'
 import { allLeaves, createSidebarStore, defaultWidthFor, makeDefaultState } from '../src/client/state.ts'
 import { SIDEBAR_PREFS_DEFAULTS } from '../src/prefs-shared.ts'
 
+/** A fake settings wire face whose settingsGet resolves to one raw value. */
+const wire = (value: unknown): SidebarSettingsClient => ({
+  settingsGet: async () => ({ value, revision: 1 }),
+  settingsUpdate: async () => ({ value, revision: 2 }),
+})
+
+/** A fake wire carrying an explicit externalDisable flag. */
+const wireWithDisable = (externalDisable: boolean): SidebarSettingsClient => ({
+  settingsGet: async () => ({ value: {}, revision: 1, externalDisable }),
+  settingsUpdate: async () => ({ value: {}, revision: 2 }),
+})
+
+const rejecting = (): SidebarSettingsClient => ({
+  settingsGet: async () => { throw new Error('route rejected') },
+  settingsUpdate: async () => { throw new Error('route rejected') },
+})
+
 describe('side card preferences', () => {
-  /** A fake settings wire face whose settingsGet resolves to one raw value. */
-  const wire = (value: unknown): SidebarSettingsClient => ({
-    settingsGet: async () => ({ value, revision: 1 }),
-    settingsUpdate: async () => ({ value, revision: 2 }),
-  })
-
-  const rejecting = (): SidebarSettingsClient => ({
-    settingsGet: async () => { throw new Error('route rejected') },
-    settingsUpdate: async () => { throw new Error('route rejected') },
-  })
-
   it('falls back to the defaults when the settings route rejects', async () => {
     expect(await loadPrefs(rejecting())).toEqual(SIDEBAR_PREFS_DEFAULTS)
   })
@@ -293,5 +299,20 @@ describe('side card preferences', () => {
     // The 'none' seed starts with an empty pane (no default tab).
     expect(makeDefaultState(400, true, 'none').splits.kind).toBe('leaf')
     expect((makeDefaultState(400, true, 'none').splits as { tabs: unknown[] }).tabs).toHaveLength(0)
+  })
+})
+
+describe('external disable (aionui-panel provider choice)', () => {
+  it('reads true when the host reports the aionui provider active', async () => {
+    expect(await loadExternalDisable(wireWithDisable(true))).toBe(true)
+  })
+
+  it('reads false when the host reports no external disable', async () => {
+    expect(await loadExternalDisable(wireWithDisable(false))).toBe(false)
+  })
+
+  it('reads false when the flag is absent or the wire rejects', async () => {
+    expect(await loadExternalDisable(wire({}))).toBe(false)
+    expect(await loadExternalDisable(rejecting())).toBe(false)
   })
 })

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -476,11 +476,15 @@ describe('session cwd resolution over the API route', () => {
 
 describe('side card settings routes', () => {
   /** A minimal settings seam: register/describe/update with the revision guard. */
-  const createFakeSettings = () => {    const namespaces = new Map<string, {
+  const createFakeSettings = (pre?: Record<string, Record<string, unknown>>) => {
+    const namespaces = new Map<string, {
       schema: unknown
       value: Record<string, unknown> | undefined
       revision: number
     }>()
+    for (const [ns, value] of Object.entries(pre ?? {})) {
+      namespaces.set(ns, { schema: (input: unknown) => input, value, revision: 0 })
+    }
     const resolve = (entry: { schema: unknown; value: Record<string, unknown> | undefined }): unknown => {
       const schema = entry.schema as (input: unknown) => unknown
       return entry.value === undefined ? schema(undefined) : schema(entry.value)
@@ -557,7 +561,21 @@ describe('side card settings routes', () => {
     const route = mountWithSettings(undefined)
     const result = await invoke(route, 'settings.get', {})
     expect(result.ok).toBe(true)
-    expect(result.value).toEqual({ value: undefined, revision: undefined })
+    expect(result.value).toEqual({ value: undefined, revision: undefined, externalDisable: false })
+  })
+
+  it('reports externalDisable false when the aionui namespace is absent', async () => {
+    const route = mountWithSettings(createFakeSettings())
+    const result = await invoke(route, 'settings.get', {})
+    expect(result.ok).toBe(true)
+    expect((result.value as { externalDisable?: boolean }).externalDisable).toBe(false)
+  })
+
+  it('reports externalDisable true while the aionui provider is selected', async () => {
+    const route = mountWithSettings(createFakeSettings({ 'aionui-panel': { rightPanel: 'aionui-panel' } }))
+    const result = await invoke(route, 'settings.get', {})
+    expect(result.ok).toBe(true)
+    expect((result.value as { externalDisable?: boolean }).externalDisable).toBe(true)
   })
 
   it('reads the resolved prefs and writes a patch through the seam', async () => {
@@ -591,6 +609,7 @@ describe('side card settings routes', () => {
         pluginSettings: {},
       },
       revision: 0,
+      externalDisable: false,
     })
 
     const written = await invoke(route, 'settings.update', { patch: { openByDefault: true } })


### PR DESCRIPTION
## 摘要

dsh-web-ui 家族的右侧面板二选一（aionui-panel 即将弃用 / DSH-better-sidebar，默认后者）需要**互斥**：当用户选择「使用 aionui-panel」时，better-sidebar 整体不再挂载（右侧栏 / 底部面板 / 浮动入口 / 各类接管全部停用）；选择 DSH-better-sidebar 或未安装 aionui 时行为不变。

实现为**读取路线**（不新增任何用户设置项，避免设置值被滥用）：

- host：`settings.get` 路由返回 `externalDisable`——读取 `aionui-panel` 设置命名空间的 `rightPanel`，解析为 `'aionui-panel'` 时为 true（命名空间不存在 = false）；
- client：挂载门在 `externalDisable` 为 true 时不挂载；订阅 `settings/document-updated`（`ctx.get('remote')`，尽力而为；无 `remote` 服务的部署回退为启动时判定）实时重评；
- 三类接管（外链 / 打开路径 / turn-tail）在挂起时同步让位；
- `SidebarStore` 增加 `suspended` 状态（不进快照，仅挂载门与接管谓词读取）。

版本 bump 至 v0.13.0。

## 涉及文件（14）

- `src/index.ts`：`SidebarSettingsFace.externalDisable()` + settings.get 响应
- `src/client/prefs.ts`：`loadExternalDisable`
- `src/client/index.tsx`：挂载门 + 实时重评（mount/unmount/sync）
- `src/client/state.ts`：`setSuspended` / `getSuspended`
- `src/client/intercept.tsx`、`src/client/index.tsx`：接管让位
- `src/client/api.ts`：settingsGet 响应类型
- `tests/prefs.spec.ts`、`tests/smoke.spec.ts`：externalDisable 单测（含 aionui 命名空间注入场景）
- 版本/文档：package.json、dsh.plugin.json、service.ts、README.md、README_EN.md、AGENTS.md

## 验证

- `pnpm typecheck` 通过
- `pnpm test`：584 passed / 5 skipped（含新增 externalDisable 场景）
- `pnpm build` + `pnpm pack` 通过

## 联动

dsh-web-ui 聚合包将依赖 `dsh-better-sidebar@^0.13.0`（另开 PR）；本地全 tarball 安装冒烟将验证「选 aionui → better-sidebar 消失」。