### PR TITLE
fix(sidebar): unstick interrupted panel drags so the bottom panel keeps tracking layout

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -549,8 +549,8 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     if (dragCommitted.current) return
     stopDragScheduling()
     applyDrag(
-      Math.min(state?.width ?? 0, window.innerWidth),
-      state?.bottomOpen === true ? Math.min(state.bottomHeight, window.innerHeight) : 0,
+      !narrow && state?.panelOpen === true ? Math.min(state?.width ?? 0, window.innerWidth) : 0,
+      !narrow && state?.bottomOpen === true ? Math.min(state.bottomHeight, window.innerHeight) : 0,
     )
     reset()
   }

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -535,6 +535,26 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     pendingDrag.current = null
   }
 
+  /** Set once a drag's pointerup handler commits — premature capture loss
+   *  (pointercancel / lostpointercapture without pointerup) must then be told
+   *  apart from a normal release. */
+  const dragCommitted = useRef(false)
+  /** Abort a drag whose pointer stream was interrupted (pointercancel, or
+   *  capture lost before pointerup): no pointerup will arrive, so without
+   *  this the dragging state would stick true and center-column measurement
+   *  would stay paused forever — the bottom panel freezes at stale edges and
+   *  stops tracking sidebar/app-rail layout changes. Reverts the DOM and the
+   *  layout variables to the store's committed sizes. */
+  const abortDrag = (reset: () => void): void => {
+    if (dragCommitted.current) return
+    stopDragScheduling()
+    applyDrag(
+      Math.min(state?.width ?? 0, window.innerWidth),
+      state?.bottomOpen === true ? Math.min(state.bottomHeight, window.innerHeight) : 0,
+    )
+    reset()
+  }
+
   // Layout push: the app shell gives up the panel's width/height while the
   // panels are open (0 while collapsed), so the conversation and input bar
   // are squeezed instead of covered. The margins are capped at the viewport
@@ -784,6 +804,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
               onPointerDown={(event) => {
                 event.preventDefault()
                 event.currentTarget.setPointerCapture(event.pointerId)
+                dragCommitted.current = false
                 widthDrag.current = { startX: event.clientX, startWidth: state.width }
                 setDraggingWidth(true)
               }}
@@ -796,12 +817,15 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
               }}
               onPointerUp={(event) => {
                 if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+                dragCommitted.current = true
                 event.currentTarget.releasePointerCapture(event.pointerId)
                 const { startX, startWidth } = widthDrag.current
                 stopDragScheduling()
                 store.reduce(s => setWidth(s, startWidth + (startX - event.clientX)))
                 setDraggingWidth(false)
               }}
+              onPointerCancel={() => { abortDrag(() => setDraggingWidth(false)) }}
+              onLostPointerCapture={() => { abortDrag(() => setDraggingWidth(false)) }}
             />
           )}
         <div className={css.panelBody}>
@@ -833,6 +857,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
             onPointerDown={(event) => {
               event.preventDefault()
               event.currentTarget.setPointerCapture(event.pointerId)
+              dragCommitted.current = false
               cornerDrag.current = {
                 startX: event.clientX,
                 startY: event.clientY,
@@ -850,12 +875,15 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
             }}
             onPointerUp={(event) => {
               if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+              dragCommitted.current = true
               event.currentTarget.releasePointerCapture(event.pointerId)
               const { startX, startY, startWidth, startHeight } = cornerDrag.current
               stopDragScheduling()
               store.reduce(s => setBottomHeight(setWidth(s, startWidth + (startX - event.clientX)), startHeight + (startY - event.clientY)))
               setDraggingCorner(false)
             }}
+            onPointerCancel={() => { abortDrag(() => setDraggingCorner(false)) }}
+            onLostPointerCapture={() => { abortDrag(() => setDraggingCorner(false)) }}
           />
         )}
       </div>
@@ -895,6 +923,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
           onPointerDown={(event) => {
             event.preventDefault()
             event.currentTarget.setPointerCapture(event.pointerId)
+            dragCommitted.current = false
             bottomDrag.current = { startY: event.clientY, startHeight: state.bottomHeight }
             setDraggingBottom(true)
           }}
@@ -906,12 +935,15 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
           }}
           onPointerUp={(event) => {
             if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+            dragCommitted.current = true
             event.currentTarget.releasePointerCapture(event.pointerId)
             const { startY, startHeight } = bottomDrag.current
             stopDragScheduling()
             store.reduce(s => setBottomHeight(s, startHeight + (startY - event.clientY)))
             setDraggingBottom(false)
           }}
+          onPointerCancel={() => { abortDrag(() => setDraggingBottom(false)) }}
+          onLostPointerCapture={() => { abortDrag(() => setDraggingBottom(false)) }}
         />
         {/*
           The bottom panel's own close control at its tab strip's right end


### PR DESCRIPTION
## Summary

The bottom panel (terminal workbench) can permanently stop tracking layout changes — most visibly it no longer expands when the right sidebar is collapsed — until a full page reload.

## Root cause

Each drag strip (width / corner / bottom height) starts a drag in `onPointerDown` and ends it in `onPointerUp`, which is guarded by `hasPointerCapture`. If the pointer stream ends **without** `pointerup` reaching the strip — a `pointercancel` (e.g. a macOS trackpad gesture interrupting the drag) or a premature pointer-capture loss — `setDragging*(false)` never runs and the dragging state sticks `true` forever.

While any drag is active, `draggingRef` pauses center-column measurement (`measureCenter`), so `centerRect` goes stale. Every later render keeps writing the bottom panel's inline `left`/`right` from that stale geometry: the panel freezes and stops following the sidebar/app-rail layout.

Reproduced live in the DSH Web GUI: real CDP drag on the width strip, then `releasePointerCapture` before mouse-up → `data-dsh-sidebar-dragging` stays on `body` permanently, and collapsing the right sidebar leaves the bottom panel at its old right edge.

## Fix

- Each drag is marked uncommitted on `pointerdown` and committed in `pointerup` before capture is released.
- New `onPointerCancel` / `onLostPointerCapture` handlers abort an **uncommitted** drag: revert the DOM and the `--dsh-sidebar-*` layout variables to the store's committed sizes (via the existing `applyDrag`) and clear the dragging state, which resumes measurement and re-syncs the bottom panel.
- Normal releases are unaffected: the committed flag makes the late `lostpointercapture` after `pointerup` a no-op.

Verified live after patching: complete drags still commit; an interrupted drag reverts cleanly and clears the drag state; collapsing/expanding the right sidebar again makes the bottom panel track the center column (full width when collapsed).

## Notes

- `pnpm run typecheck` passes.
- `pnpm test`: 606 passed; the 4 failures in the settings general-rows test also fail on unmodified `main` (pre-existing, unrelated).