### PR TITLE
fix(html): declare UTF-8 preview encoding (#170)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -695,7 +695,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         const type = mediaTypeForPath(absolute)
         const body = await readFile(absolute)
         res.writeHead(200, {
-          'content-type': type,
+          'content-type': type === 'text/html' ? 'text/html; charset=utf-8' : type,
           'cache-control': 'no-cache',
           'x-content-type-options': 'nosniff',
           'referrer-policy': 'no-referrer',

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve as resolvePath } from 'node:path'
 import { SettingsConflictError, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import { apply, mediaTypeForPath } from '../src/index.ts'
+import { encodeHtmlUrl } from '../src/html-route.ts'
 import * as git from '../src/git.ts'
 import { listDirectory } from '../src/fs-tree.ts'
 import { defaultShell, PtyManager, type SidebarPty } from '../src/pty-manager.ts'
@@ -92,6 +93,58 @@ describe('host plugin smoke', () => {
     expect(upgrades.map(route => route.path)).toEqual(['/sidebar/ws/terminal', '/sidebar/ws/agent-terminals'])
     // Teardown runs without throwing (pty manager has nothing open).
     for (const cleanup of effects) cleanup()
+  })
+
+  it('serves HTML previews as UTF-8 without changing the file bytes', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dsh-sidebar-html-utf8-'))
+    const path = join(directory, 'fragment.html')
+    const source = Buffer.from('<div>排序算法可视化</div>', 'utf8')
+    writeFileSync(path, source)
+    const routes: SidebarWebRoute[] = []
+    const effects: Array<() => void | (() => void)> = []
+    const ctx: FakeContext = {
+      webRuntime: { trustedHosts: [] },
+      webServer: {
+        register: (route) => { routes.push(route); return () => {} },
+        registerUpgrade: () => () => {},
+      },
+      sessions: { get: () => ({ header: { cwd: directory } }) },
+      tools: { register: () => () => {} },
+      effect: (fn) => {
+        const cleanup = fn()
+        if (typeof cleanup === 'function') effects.push(cleanup)
+      },
+      inject: () => () => {},
+      get: () => undefined,
+    }
+    try {
+      apply(ctx as never)
+      const route = routes.find(candidate => candidate.path === '/sidebar/html')!
+      const req = {
+        method: 'GET',
+        url: encodeHtmlUrl('s-html', path),
+        headers: { host: '127.0.0.1:3080' },
+      } as never
+      const response: { status?: number; headers?: Record<string, string>; chunks: Buffer[] } = { chunks: [] }
+      const res = {
+        writeHead: (status: number, headers?: Record<string, string>) => {
+          response.status = status
+          response.headers = headers
+        },
+        end: (chunk?: string | Buffer) => {
+          if (chunk !== undefined) response.chunks.push(Buffer.from(chunk))
+        },
+      } as never
+
+      await route.handler(req, res)
+
+      expect(response.status).toBe(200)
+      expect(Buffer.concat(response.chunks)).toEqual(source)
+      expect(response.headers?.['content-type']).toBe('text/html; charset=utf-8')
+    } finally {
+      for (const cleanup of effects) cleanup()
+      rmSync(directory, { recursive: true, force: true })
+    }
   })
 
   it('runs git status/log/branches against this repository', async () => {


### PR DESCRIPTION
## Summary

- declare `charset=utf-8` on HTML documents served by `/sidebar/html`
- preserve the original file bytes and leave non-HTML relative assets unchanged
- add a host-route regression test using a UTF-8 Chinese HTML fragment without `<head>` or `<meta charset>`

Closes #170.

## Reproduction

The regression test requests a real fragment file containing `排序算法可视化` through the registered `/sidebar/html` route. Before the fix it failed with:

```text
Expected: "text/html; charset=utf-8"
Received: "text/html"
```

The response body already matched the file's UTF-8 bytes, isolating the bug to the missing response charset rather than file reading or sandbox behavior.

## Validation

- `pnpm vitest run tests/smoke.spec.ts -t "serves HTML previews as UTF-8"`
- `pnpm vitest run tests/html-route.spec.ts tests/sandbox-views.spec.tsx` (33 passed)
- `pnpm typecheck`
- `pnpm build`
- full `pnpm test`: 605 passed, 3 skipped, 8 existing Windows-environment failures (node-pty AttachConsole, English assertions under a Chinese locale, and CRLF checkout expectations)

## AI Coding Disclosure

Incomplete task

- [x] 部分 AI 辅助：AI 帮助编写或修改了部分编程改动。

使用的 AI 模型：GPT-5

使用的编码 Agent 工具：Codex


Supersedes #189; the original PR was automatically closed when its fork was accidentally deleted.