### PR TITLE
feat(explorer): emit local path drag references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 ## ✨ 功能一览
 
 - **🗂️ 文件工作台**：资源管理器（懒加载目录树；软链接按目标类型展示——目录软链接可展开、失效链接标红）+ CodeMirror 编辑器；图片 / Markdown（含 Mermaid 图表，strict 安全渲染 + 点击放大）/ HTML / PDF / Office 内联预览
+- **路径拖拽引用**：把可见的工作区根目录、文件夹或文件行拖入兼容的 DSH 输入框，即可插入工作区相对路径；拖拽载荷使用 `application/x-dsh-local-path`，并提供 `text/plain` 回退
 - **🌐 内嵌浏览器**：多开网页 tab，后退 / 前进 / 刷新；内容运行在沙箱 iframe；外链默认按协议分流——HTTP 在侧边栏打开、HTTPS 走系统浏览器（设置页可分别调整）
 - **💻 真实终端**：xterm.js + node-pty 真实 shell，断线重连回放；可选为模型注入 `terminal_*` 工具
 - **🌿 Git 面板**：真 diff + VSCode 式 diff tab、历史、右键暂存 / 提交 / 还原

--- a/README_EN.md
+++ b/README_EN.md
@@ -22,6 +22,7 @@
 ## ✨ Features
 
 - **🗂️ File Workbench**: file explorer (lazy-loading tree; symlinks show their target kind — directory links expand, dangling links flagged) + CodeMirror editor; inline preview for images / Markdown (incl. Mermaid diagrams, strict-mode safe rendering + click-to-zoom) / HTML / PDF / Office
+- **Path drag references**: drag the visible workspace root, a folder, or a file row into a compatible DSH composer to insert its workspace-relative path; the payload uses `application/x-dsh-local-path` with a `text/plain` fallback
 - **🌐 Embedded Browser**: multiple web tabs with back / forward / refresh; content runs in a sandboxed iframe; external links are routed by protocol by default — HTTP opens in the sidebar, HTTPS goes to the system browser (both adjustable in settings)
 - **💻 Real Terminal**: xterm.js + node-pty real shell, reconnect with transcript replay; optionally injects `terminal_*` tools for the model
 - **🌿 Git Panel**: real diff + VSCode-style diff tabs, history, right-click to stage / commit / revert

--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -15,7 +15,7 @@
  * relative or absolute path (with a brief "copied" label replacing the
  * button after a successful write).
  */
-import { useCallback, useEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type DragEvent, type MouseEvent, type ReactNode } from 'react'
 import clsx from 'clsx'
 import {
   IconCodeOutline16, IconCopyOutline16, IconDownloadOutline16, IconFolderClose16, IconFolderOpen16,
@@ -23,6 +23,7 @@ import {
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { api, downloadUrl, type FsEntry } from './api.ts'
 import { relativeTo } from './paths.ts'
+import { setLocalPathDragData } from './path-drag.ts'
 import { t } from './locales.ts'
 import css from './sidebar.module.css'
 
@@ -136,6 +137,11 @@ export function FileTree(props: {
     setRowMenu({ path, isDir, x: event.clientX, y: event.clientY })
   }
 
+  /** Publish the row path without interfering with its click/key/menu actions. */
+  const dragPath = (event: DragEvent, path: string): void => {
+    setLocalPathDragData(event.dataTransfer, relativeTo(cwd ?? '', path))
+  }
+
   /** Download a file through the host route (raw bytes, binary-safe). */
   const downloadFile = (path: string): void => {
     const url = downloadUrl({ sessionId, cwd }, path)
@@ -170,6 +176,7 @@ export function FileTree(props: {
             <div
               role="button"
               tabIndex={0}
+              draggable
               className={clsx(css.explorerRow, css.explorerDir, entry.hidden && css.explorerHidden)}
               style={{ paddingLeft: depth * 22 + 6 }}
               onClick={() => { onToggle(entry.path) }}
@@ -180,6 +187,7 @@ export function FileTree(props: {
                 }
               }}
               onContextMenu={(event) => { openRowMenu(event, entry.path, true) }}
+              onDragStart={(event) => { dragPath(event, entry.path) }}
             >
               {isOpen ? <IconFolderOpen16 size={14} /> : <IconFolderClose16 size={14} />}
               <span className={css.explorerName}>{entry.name}</span>
@@ -195,6 +203,7 @@ export function FileTree(props: {
           key={entry.path}
           role="button"
           tabIndex={0}
+          draggable
           className={clsx(css.explorerRow, entry.hidden && css.explorerHidden, entry.broken && css.explorerBroken)}
           style={{ paddingLeft: depth * 22 + 6 }}
           title={entry.broken ? `${entry.path} — ${t('brokenSymlink')}` : entry.path}
@@ -206,6 +215,7 @@ export function FileTree(props: {
             }
           }}
           onContextMenu={(event) => { openRowMenu(event, entry.path, false) }}
+          onDragStart={(event) => { dragPath(event, entry.path) }}
         >
           <IconCodeOutline16 size={14} />
           <span className={css.explorerName}>{entry.name}</span>
@@ -224,8 +234,10 @@ export function FileTree(props: {
         <>
           <div
             className={css.explorerRow}
+            draggable
             style={{ paddingLeft: 6 }}
             onContextMenu={(event) => { openRowMenu(event, root, true) }}
+            onDragStart={(event) => { dragPath(event, root) }}
           >
             <IconFolderOpen16 size={14} />
             <span className={css.explorerName}>{baseName(root)}</span>

--- a/src/client/path-drag.ts
+++ b/src/client/path-drag.ts
@@ -1,0 +1,12 @@
+/** Standard cross-plugin MIME for workspace-relative local path drags. */
+export const LOCAL_PATH_MIME = 'application/x-dsh-local-path'
+
+/**
+ * Publish one workspace-relative path for maintained-sidebar drag consumers.
+ * text/plain keeps the gesture useful in ordinary text drop targets.
+ */
+export function setLocalPathDragData(dataTransfer: DataTransfer, relativePath: string): void {
+  dataTransfer.effectAllowed = 'copy'
+  dataTransfer.setData(LOCAL_PATH_MIME, relativePath)
+  dataTransfer.setData('text/plain', relativePath)
+}

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -41,7 +41,8 @@ export function relativeTo(cwd: string, path: string): string {
   const norm = (value: string): string => value.replace(/\\/g, '/')
   const nBase = norm(base)
   const nPath = norm(path)
-  if (nPath === nBase) return '.'
-  if (nPath.toLowerCase().startsWith(`${nBase.toLowerCase()}/`)) return nPath.slice(nBase.length + 1)
+  const comparablePath = nPath.replace(/\/+$/, '')
+  if (comparablePath === nBase) return '.'
+  if (comparablePath.toLowerCase().startsWith(`${nBase.toLowerCase()}/`)) return comparablePath.slice(nBase.length + 1)
   return path
 }

--- a/tests/file-tree.spec.tsx
+++ b/tests/file-tree.spec.tsx
@@ -1,0 +1,134 @@
+/**
+ * FileTree local-path drag contract: every visible path row is draggable and
+ * publishes the workspace-relative path through the shared DSH MIME type and
+ * text/plain without changing the row's existing actions.
+ */
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+
+const fsTree = vi.fn(async (_scope: unknown, dir: string) => ({
+  entries: dir === 'C:\\work'
+    ? [
+        { name: 'src', path: 'C:\\work\\src', isDir: true, hidden: false, isSymlink: false, broken: false },
+        { name: 'README.md', path: 'C:\\work\\README.md', isDir: false, hidden: false, isSymlink: false, broken: false },
+      ]
+    : [],
+}))
+
+vi.mock('../src/client/api.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/client/api.ts')>()
+  return { ...original, api: { ...original.api, fsTree } }
+})
+
+import { FileTree } from '../src/client/FileTree.tsx'
+import { LOCAL_PATH_MIME, setLocalPathDragData } from '../src/client/path-drag.ts'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+function transferRecorder(): { dataTransfer: DataTransfer; values: Map<string, string> } {
+  const values = new Map<string, string>()
+  return {
+    values,
+    dataTransfer: {
+      setData: (type: string, value: string) => { values.set(type, value) },
+      effectAllowed: 'uninitialized',
+    } as unknown as DataTransfer,
+  }
+}
+
+function dragStart(row: Element): Map<string, string> {
+  const { dataTransfer, values } = transferRecorder()
+  const event = new Event('dragstart', { bubbles: true })
+  Object.defineProperty(event, 'dataTransfer', { value: dataTransfer })
+  act(() => { row.dispatchEvent(event) })
+  return values
+}
+
+async function mountTree(): Promise<{ container: HTMLDivElement; unmount: () => void }> {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(createElement(FileTree, {
+      sessionId: 'session-1',
+      cwd: 'C:\\work',
+      expanded: [],
+      onToggle: () => {},
+      onOpenFile: () => {},
+      onReferenceFile: () => {},
+      refreshTick: 0,
+    }))
+    await Promise.resolve()
+  })
+  return {
+    container,
+    unmount: () => {
+      act(() => { root.unmount() })
+      container.remove()
+    },
+  }
+}
+
+describe('local path drag payload', () => {
+  it('writes the standard custom MIME and text/plain payload', () => {
+    const { dataTransfer, values } = transferRecorder()
+    setLocalPathDragData(dataTransfer, 'src/FileTree.tsx')
+    expect(LOCAL_PATH_MIME).toBe('application/x-dsh-local-path')
+    expect(values).toEqual(new Map([
+      ['application/x-dsh-local-path', 'src/FileTree.tsx'],
+      ['text/plain', 'src/FileTree.tsx'],
+    ]))
+  })
+
+  it('makes the visible root, directory, and file rows draggable with relative payloads', async () => {
+    const { container, unmount } = await mountTree()
+    try {
+      const rows = Array.from(container.querySelectorAll('[draggable="true"]'))
+      expect(rows.map(row => row.textContent)).toEqual(expect.arrayContaining(['work@', 'src@', 'README.md@']))
+
+      const root = rows.find(row => row.textContent === 'work@')!
+      const directory = rows.find(row => row.textContent === 'src@')!
+      const file = rows.find(row => row.textContent === 'README.md@')!
+      expect(dragStart(root).get(LOCAL_PATH_MIME)).toBe('.')
+      expect(dragStart(directory).get(LOCAL_PATH_MIME)).toBe('src')
+      expect(dragStart(file).get('text/plain')).toBe('README.md')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('preserves file click, directory keyboard toggle, context menu, and @ actions', async () => {
+    const onToggle = vi.fn()
+    const onOpenFile = vi.fn()
+    const onReferenceFile = vi.fn()
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(createElement(FileTree, {
+        sessionId: 'session-1', cwd: 'C:\\work', expanded: [], refreshTick: 0,
+        onToggle, onOpenFile, onReferenceFile,
+      }))
+      await Promise.resolve()
+    })
+    try {
+      const rows = Array.from(container.querySelectorAll('[draggable="true"]'))
+      const directory = rows.find(row => row.textContent === 'src@')!
+      const file = rows.find(row => row.textContent === 'README.md@')!
+      act(() => { file.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+      act(() => { directory.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })) })
+      act(() => { file.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 8 })) })
+      act(() => { file.querySelector('button')!.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+      expect(onOpenFile).toHaveBeenCalledWith('C:\\work\\README.md')
+      expect(onToggle).toHaveBeenCalledWith('C:\\work\\src')
+      expect(document.body.querySelector('[role="menu"]')).not.toBeNull()
+      expect(onReferenceFile).toHaveBeenCalledWith('C:\\work\\README.md')
+    } finally {
+      act(() => { root.unmount() })
+      container.remove()
+    }
+  })
+})

--- a/tests/file-tree.spec.tsx
+++ b/tests/file-tree.spec.tsx
@@ -9,13 +9,15 @@ import { createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 import { act } from 'react-dom/test-utils'
 
-const fsTree = vi.fn(async (_scope: unknown, dir: string) => ({
-  entries: dir === 'C:\\work'
-    ? [
-        { name: 'src', path: 'C:\\work\\src', isDir: true, hidden: false, isSymlink: false, broken: false },
-        { name: 'README.md', path: 'C:\\work\\README.md', isDir: false, hidden: false, isSymlink: false, broken: false },
-      ]
-    : [],
+const { fsTree } = vi.hoisted(() => ({
+  fsTree: vi.fn(async (_scope: unknown, dir: string) => ({
+    entries: dir === 'C:\\work'
+      ? [
+          { name: 'src', path: 'C:\\work\\src', isDir: true, hidden: false, isSymlink: false, broken: false },
+          { name: 'README.md', path: 'C:\\work\\README.md', isDir: false, hidden: false, isSymlink: false, broken: false },
+        ]
+      : [],
+  })),
 }))
 
 vi.mock('../src/client/api.ts', async (importOriginal) => {
@@ -87,11 +89,14 @@ describe('local path drag payload', () => {
     const { container, unmount } = await mountTree()
     try {
       const rows = Array.from(container.querySelectorAll('[draggable="true"]'))
-      expect(rows.map(row => row.textContent)).toEqual(expect.arrayContaining(['work@', 'src@', 'README.md@']))
+      const byName = (name: string): Element => rows.find(row => row.textContent?.startsWith(`${name}@`))!
+      expect(rows.some(row => row.textContent?.startsWith('work@'))).toBe(true)
+      expect(rows.some(row => row.textContent?.startsWith('src@'))).toBe(true)
+      expect(rows.some(row => row.textContent?.startsWith('README.md@'))).toBe(true)
 
-      const root = rows.find(row => row.textContent === 'work@')!
-      const directory = rows.find(row => row.textContent === 'src@')!
-      const file = rows.find(row => row.textContent === 'README.md@')!
+      const root = byName('work')
+      const directory = byName('src')
+      const file = byName('README.md')
       expect(dragStart(root).get(LOCAL_PATH_MIME)).toBe('.')
       expect(dragStart(directory).get(LOCAL_PATH_MIME)).toBe('src')
       expect(dragStart(file).get('text/plain')).toBe('README.md')
@@ -116,8 +121,8 @@ describe('local path drag payload', () => {
     })
     try {
       const rows = Array.from(container.querySelectorAll('[draggable="true"]'))
-      const directory = rows.find(row => row.textContent === 'src@')!
-      const file = rows.find(row => row.textContent === 'README.md@')!
+      const directory = rows.find(row => row.textContent?.startsWith('src@'))!
+      const file = rows.find(row => row.textContent?.startsWith('README.md@'))!
       act(() => { file.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
       act(() => { directory.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })) })
       act(() => { file.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 4, clientY: 8 })) })

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -10,6 +10,12 @@ describe('path helpers', () => {
     expect(relativeTo('/Users/me/code/', '/Users/me/code/src/a/b.ts')).toBe('src/a/b.ts')
   })
 
+  it('keeps volume and share root drags non-empty when both paths end in separators', () => {
+    expect(relativeTo('/', '/')).toBe('.')
+    expect(relativeTo('C:\\', 'C:\\')).toBe('.')
+    expect(relativeTo('\\\\server\\share\\', '\\\\server\\share\\')).toBe('.')
+  })
+
   it('falls back to the path unchanged when it lies outside the cwd', () => {
     expect(relativeTo('/Users/me/code', '/Users/other/x.ts')).toBe('/Users/other/x.ts')
     expect(relativeTo('/Users/me/code', '/Users/me/codex/y.ts')).toBe('/Users/me/codex/y.ts')


### PR DESCRIPTION
## Summary
- make visible workspace root, directory, and file rows draggable
- emit application/x-dsh-local-path plus text/plain workspace-relative payloads
- normalize POSIX, drive, and UNC root drags to a non-empty dot path
- preserve click, keyboard, context-menu, and at-reference actions

## Verification
- pnpm test -- tests/paths.spec.ts tests/file-tree.spec.tsx (12 passed)
- pnpm typecheck
- pnpm build

The full pnpm test run also completed 601 tests but has unrelated Windows/Node 24 baseline failures in node-pty, localized SideCard snapshots, and CRLF-sensitive git smoke assertions.