### PR TITLE
feat(editor): LLM 会话内改文件后预览自动刷新（produced files 信号，stacked on #215）

### DIFF
--- a/src/client/EditorHost.tsx
+++ b/src/client/EditorHost.tsx
@@ -351,6 +351,29 @@ export function EditorHost(props: {
     prevSaveState.current = current
   }, [toolbar?.saveState, toolbar?.mode])
 
+  // Auto-refresh when the conversation's closing turn produced the previewed
+  // file (issue #167 extension): the turn-tail interception records produced
+  // paths into the store; a matching path silently reloads. Edit mode is
+  // left alone for the same draft reason as B.
+  const toolbarRef = useRef(toolbar)
+  toolbarRef.current = toolbar
+  const handledProducedSeq = useRef(0)
+  useEffect(() => {
+    const onStore = (): void => {
+      const last = store.getLastProduced()
+      if (last === null || last.sessionId !== scope.sessionId) return
+      if (last.seq === handledProducedSeq.current) return
+      handledProducedSeq.current = last.seq
+      if (toolbarRef.current?.mode === 'edit') return
+      const hit = last.paths.some(produced => resolveSidebarPath(scope.cwd, produced) === path)
+      if (!hit) return
+      setReloadSeq(sequence => sequence + 1)
+    }
+    const off = store.subscribe(onStore)
+    onStore()
+    return off
+  }, [store, scope.sessionId, scope.cwd, path])
+
   const treeOpen = treeOpenOf(tab)
   /** Persist the panel flag on the tab (survives reloads with the layout). */
   const toggleTree = (): void => { patchMeta(ctx, tab, { treeOpen: !treeOpen }) }

--- a/src/client/intercept.tsx
+++ b/src/client/intercept.tsx
@@ -6,6 +6,7 @@
  * deliverables entry; when nothing was produced the selector returns null
  * and the original row renders unchanged.
  */
+import { useEffect } from 'react'
 import { IconCodeOutline16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { Context } from '../context-types.ts'
 import { firstLeaf, revealPaths, togglePanel, type SidebarStore } from './state.ts'
@@ -75,8 +76,13 @@ export function SidebarProducedFiles(props: {
   openInSidebar: (path: string) => void
   /** Reveal the produced files in the explorer ("Show in folder" twin). */
   onShowInFolder: (files: readonly string[]) => void
+  recordProduced: (paths: readonly string[]) => void
 }) {
-  const { matched, openInSidebar, onShowInFolder } = props
+  const { matched, openInSidebar, onShowInFolder, recordProduced } = props
+  // Publish the produced paths to the sidebar store exactly once per mount:
+  // the row only mounts for turns that produced files, so this IS the
+  // "turn ended with file writes" signal the editor's auto-refresh consumes.
+  useEffect(() => { recordProduced(matched) }, [recordProduced, matched])
   const shown = matched.slice(0, 6)
   const hidden = matched.length - shown.length
   return (
@@ -146,6 +152,7 @@ export function registerTurnTailInterception(ctx: Context, store: SidebarStore):
     inject: (sessionId: string) => ({
       openInSidebar: (path: string) => { openSidebarFile(ctx, store, sessionId, path) },
       onShowInFolder: (files: readonly string[]) => { revealInExplorer(ctx, store, sessionId, files) },
+      recordProduced: (paths: readonly string[]) => { store.recordProduced(sessionId, paths) },
     }),
   }, SidebarProducedFiles))
 }

--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -1431,6 +1431,15 @@ export class SidebarStore {
     prefs: { ...SIDEBAR_PREFS_DEFAULTS },
   }
   private readonly listeners = new Set<() => void>()
+  /**
+   * The latest turn's produced-file notification (issue #167 auto-refresh):
+   * recorded by the turn-tail interception when a closing turn produced
+   * files, consumed by EditorHost to silently reload a matching preview.
+   * Not part of the snapshot — a transient event, not view state; consumers
+   * read the getter from a store subscription.
+   */
+  private lastProduced: { sessionId: string; paths: readonly string[]; seq: number } | null = null
+  private producedSeq = 0
   /** Per-session persist debounce timers (v0.12.0+: one per session, so a
    *  targeted open never cancels another session's pending write). */
   private readonly persistTimers = new Map<string, number>()
@@ -1455,6 +1464,22 @@ export class SidebarStore {
   /** Whether the sidebar is externally disabled (aionui-panel chosen). */
   getSuspended(): boolean {
     return this.suspended
+  }
+
+  /**
+   * Record one turn's produced-file notification (the turn-tail interception
+   * calls this when its row mounts, i.e. only for turns that produced files).
+   * The seq is monotonic so consumers can ignore repeats.
+   */
+  recordProduced(sessionId: string, paths: readonly string[]): void {
+    this.producedSeq += 1
+    this.lastProduced = { sessionId, paths: [...paths], seq: this.producedSeq }
+    this.notify()
+  }
+
+  /** The latest produced-file notification, or null before the first one. */
+  getLastProduced(): { sessionId: string; paths: readonly string[]; seq: number } | null {
+    return this.lastProduced
   }
 
   /**

--- a/tests/editor-refresh.spec.tsx
+++ b/tests/editor-refresh.spec.tsx
@@ -58,6 +58,7 @@ function MockTextViewer({ initialMode = 'preview', dirty = false, onToolbarState
 
 function setup(initialMode: 'preview' | 'edit' = 'preview', dirty = false): {
   ctx: Context
+  store: ReturnType<typeof createSidebarStore>
   fileTab: () => SidebarTab
 } {
   const store = createSidebarStore()
@@ -86,16 +87,16 @@ function setup(initialMode: 'preview' | 'edit' = 'preview', dirty = false): {
   const fileTab = (): SidebarTab =>
     allLeaves(store.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs)
       .find(tab => tab.path === '/tmp/a.ts')!
-  return { ctx, fileTab }
+  return { ctx, store, fileTab }
 }
 
-function mount(ctx: Context, tab: () => SidebarTab): { container: HTMLDivElement; unmount: () => void } {
+function mount(ctx: Context, store: ReturnType<typeof createSidebarStore>, tab: () => SidebarTab): { container: HTMLDivElement; unmount: () => void } {
   const container = document.createElement('div')
   document.body.append(container)
   const root = createRoot(container)
   act(() => {
     root.render(createElement(EditorHost, {
-      ctx, store: ctx.betterSidebar as never, scope: { sessionId: 'editor-home-session' },
+      ctx, store, scope: { sessionId: 'editor-home-session', cwd: '/tmp' },
       tab: tab(), expanded: [], revealed: [], onToggleDir: () => {}, onReferenceFile: () => {},
     }))
   })
@@ -124,8 +125,8 @@ beforeEach(() => {
 
 describe('EditorHost refresh (issue #167)', () => {
   it('A: the refresh button renders for a toolbar-reporting viewer and re-runs the load', async () => {
-    const { ctx, fileTab } = setup()
-    const { container, unmount } = mount(ctx, fileTab)
+    const { ctx, store, fileTab } = setup()
+    const { container, unmount } = mount(ctx, store, fileTab)
     try {
       // The initial load ran once; settle the async fsRead.
       await act(async () => { await Promise.resolve() })
@@ -141,8 +142,8 @@ describe('EditorHost refresh (issue #167)', () => {
   })
 
   it('B: returning from edit to preview reloads (fresh content shows after save)', async () => {
-    const { ctx, fileTab } = setup('edit')
-    const { container, unmount } = mount(ctx, fileTab)
+    const { ctx, store, fileTab } = setup('edit')
+    const { container, unmount } = mount(ctx, store, fileTab)
     try {
       await act(async () => { await Promise.resolve() })
       expect(reads()).toBe(1)
@@ -157,8 +158,8 @@ describe('EditorHost refresh (issue #167)', () => {
   })
 
   it('B: a dirty draft suppresses the edit→preview reload (the draft would be dropped)', async () => {
-    const { ctx, fileTab } = setup('edit', true)
-    const { container, unmount } = mount(ctx, fileTab)
+    const { ctx, store, fileTab } = setup('edit', true)
+    const { container, unmount } = mount(ctx, store, fileTab)
     try {
       await act(async () => { await Promise.resolve() })
       expect(reads()).toBe(1)
@@ -173,8 +174,8 @@ describe('EditorHost refresh (issue #167)', () => {
   })
 
   it('C: a preview-mode save reloads on the saved edge', async () => {
-    const { ctx, fileTab } = setup('preview')
-    const { container, unmount } = mount(ctx, fileTab)
+    const { ctx, store, fileTab } = setup('preview')
+    const { container, unmount } = mount(ctx, store, fileTab)
     try {
       await act(async () => { await Promise.resolve() })
       expect(reads()).toBe(1)
@@ -182,6 +183,49 @@ describe('EditorHost refresh (issue #167)', () => {
       click(save)
       await act(async () => { await Promise.resolve() })
       expect(reads()).toBe(2)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('auto-refresh: a produced-file notification for the previewed path silently reloads', async () => {
+    const { ctx, store, fileTab } = setup('preview')
+    const { container, unmount } = mount(ctx, store, fileTab)
+    try {
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(1)
+      act(() => { store.recordProduced('editor-home-session', ['a.ts']) })
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(2)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('auto-refresh: a different session or an unrelated path is ignored', async () => {
+    const { ctx, store, fileTab } = setup('preview')
+    const { container, unmount } = mount(ctx, store, fileTab)
+    try {
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(1)
+      act(() => { store.recordProduced('other-session', ['a.ts']) })
+      act(() => { store.recordProduced('editor-home-session', ['b.ts']) })
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(1)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('auto-refresh: edit mode suppresses the reload (draft protection)', async () => {
+    const { ctx, store, fileTab } = setup('edit')
+    const { container, unmount } = mount(ctx, store, fileTab)
+    try {
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(1)
+      act(() => { store.recordProduced('editor-home-session', ['a.ts']) })
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(1)
     } finally {
       unmount()
     }


### PR DESCRIPTION
## 目标（issue #167 延伸）

LLM 在会话内改完文件后，侧边栏预览自动刷新。用户确认 DSH 已提供"本轮修改了哪些文件"能力（会话结束时聊天区显示 produced files），因此**不做磁盘指纹对比**——直接消费该信号。

## 信号源决策

三个候选查证后选定（决策文档：fractal/docs/决策/2026-08-19-侧边栏预览LLM自动刷新信号源决策.md）：

| 候选 | 结论 |
|------|------|
| 客户端轮询 history + 节点投影 | 需复刻 conversation-assembler 投影（重）、至多 2s 延迟 |
| host turn/end 事件 + 广播通道 | 改动横跨 host/client 两半（最重） |
| **turn-tail slot 复用（选定）** | 本插件**已注册** `conversation.chat.turnTail` slot，其行仅在 produced 非空回合挂载——挂载即信号，零轮询零 host 改动 |

## 实现

- `state.ts`：store 加 `recordProduced(sessionId, paths)` / `getLastProduced()`（单调 seq，通知订阅者；不进 SidebarSnapshot——瞬态事件非视图状态）；
- `intercept.tsx`：`SidebarProducedFiles` 挂载时把 `matched`（produced paths）发布到 store；
- `EditorHost.tsx`：订阅 store——会话匹配 + 路径归一化（`resolveSidebarPath`）命中当前预览文件 + 非编辑模式 → 静默重载（复用 #215 的 `reloadSeq` 入口）。

## 依赖

**Stacked on #215**（本 PR 依赖其 `reloadSeq` 重载入口与草稿抑制语义；合并顺序：#215 先行）。

## 验证

- `tests/editor-refresh.spec.tsx` 新增 3 用例：produced 命中自动重载 / 异会话与不相关路径忽略 / 编辑模式抑制（草稿保护）；
- 全量 625 通过（8 个失败为既有 Windows 平台问题：pty-deps/side-card AttachConsole，无关）。

## 边界

- 无 produced 文件的回合不触发（slot 不挂载）；
- 多会话隔离：`lastProduced.sessionId` 与编辑器 scope 匹配才刷新；
- 子代理产出的文件不在本链路（produced-files 投影的既有边界，未扩展）。
