### PR TITLE
fix(layout): 兼容 DSH Desktop 外壳，侧栏/底部面板不再遮挡会话 (#208)

### DIFF
--- a/src/client/layout.css
+++ b/src/client/layout.css
@@ -20,15 +20,27 @@
  * layout tracks the pointer.
  */
 #root {
+  /* DSH Desktop's advanced shell sets `#root { width: 100% }`; with an
+     explicit width, margin-right overflows additively instead of squeezing,
+     so the fixed panels cover the conversation (upstream issue #208).
+     Fold the push into the width: calc(100% - W) + margin W == 100% on
+     every shell. */
+  width: calc(100% - var(--dsh-sidebar-width, 0px));
   margin-right: var(--dsh-sidebar-width, 0px);
-  transition: margin-right var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+  transition: margin-right var(--ds-transition-duration-slow) var(--ds-ease-in-out),
+    width var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
 
-/* The AppFrame's grid items are sidebarCol, centerCol, detailsCol (children
-   1-3 of #root > div[data-slot="root"] > div) — nth-child(2) is the center
-   column. A stretched grid item shrinks by its margins, so the conversation
-   content (output + input bar) lifts without touching the sidebars. */
-#root > div[data-slot="root"] > div > div:nth-child(2) {
+/* The conversation's grid cell: the [data-slot="conversation"] wrapper sits
+   DIRECTLY inside the center column on the stock AppFrame AND inside
+   <main class="dshDesktopConversationSurface"> on the DSH Desktop advanced
+   frame — where the frame's children differ (caption row first, semantic
+   elements), so the old nth-child(2) anchor hit the wrong cell and the
+   bottom panel covered the input bar (upstream issue #208). :has() anchors
+   the true parent on both shells. A stretched grid item shrinks by its
+   margins, so the conversation content (output + input bar) lifts without
+   touching the sidebars. */
+#root :has(> [data-slot="conversation"]) {
   margin-bottom: var(--dsh-sidebar-height, 0px);
   transition: margin-bottom var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
@@ -47,7 +59,7 @@ body[data-dsh-sidebar-collapsed] [data-slot="conversation.session.header"] > hea
 }
 
 body[data-dsh-sidebar-dragging] #root,
-body[data-dsh-sidebar-dragging] #root > div[data-slot="root"] > div > div:nth-child(2) {
+body[data-dsh-sidebar-dragging] #root :has(> [data-slot="conversation"]) {
   transition: none;
 }
 
@@ -72,7 +84,7 @@ body[data-dsh-sidebar-dragging] #root > div[data-slot="root"] > div > div:nth-ch
 
 @media (prefers-reduced-motion: reduce) {
   #root,
-  #root > div[data-slot="root"] > div > div:nth-child(2) {
+  #root :has(> [data-slot="conversation"]) {
     transition: none;
   }
 }


### PR DESCRIPTION
### 问题
启用侧栏后，右侧面板与底部面板会盖住会话内容与输入框（见 #208）。
Web 版正常，DSH Desktop 桌面版复现。

### 根因
桌面版外壳 (dsh-plugin-desktop) 注入 `html, body, #root { width: 100%; height: 100% }`，
显式 width 使 margin-right 从「挤压」变为「加性溢出」，#root 保持全宽，
右侧固定面板直接覆盖会话。同时桌面版 AdvancedFrame 的子元素结构不同
（macOS 首格是标题栏 caption row，会话在 `<main class="dshDesktopConversationSurface">`），
原 `nth-child(2)` 锚点命中错误元素，底部面板的高度挤压失效，盖住输入框。

### 修复（仅 src/client/layout.css）
1. `#root` 增加 `width: calc(100% - var(--dsh-sidebar-width, 0px))`，
   margin + width 折叠后两套外壳总宽均为 100%，挤压语义恢复；
   width 加入过渡，展开/收起动画不变。
2. 中间列锚点改为 `#root :has(> [data-slot="conversation"])` ——
   会话 slot 容器在两套外壳下都直接挂在中间列/会话面上，:has 同时命中
   标准 AppFrame 与桌面 AdvancedFrame（Electron 43 / 现代浏览器均支持）。

### 验证
- DSH Desktop 2.0.1 (macOS)：侧栏展开后 #root 宽度 = 视口 − 侧栏宽，
  不再遮挡会话与输入框；底部面板只挤压会话列。
- Web 版行为不变（width 折叠结果与原先 margin 挤压相同）。

环境：DSH Desktop 2.0.1 · dsh-web-frontend 0.1.0-rc.7 · macOS
