### PR TITLE
feat(git): Git 面板历史提交图 lane 渲染

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,6 +703,7 @@ better-sidebar 自己的内置 tab 和 viewer 就是参考实现（"吃狗粮"�
 - **`tests/builtins.spec.ts`**：内置注册清单断言（7 tab + 6 viewer + 声明式元数据）
 - **`src/client/plugins-tabs.ts`** / **`src/client/plugins-viewers.ts`**：推荐插件目录（名字/url/简介/安装脚本，分别对应 Tab 注册与文件预览注册），在设置页两个「添加插件」弹窗展示（共享类型在 `plugins-shared.ts`）；插件作者可按扩展点加一条数据（弹窗内「跳转」直达仓库、「复制」把安装命令写入剪贴板，粘贴到 DSH 所在环境的终端执行）——数据完整性由 `tests/plugin-list.spec.ts` 守护
 - **`src/client/FileTree.tsx`** / **`src/client/TreePanel.tsx`** / **`src/fs-search.ts`**：受控文件树组件（纯树体，文件行右键菜单含「在新 Tab 中打开」「在侧边打开」，仅宿主编排提供回调时渲染）/ 树面板（搜索框 + 刷新 + FileTree，文件窗口的内嵌 dock 使用）与 host 侧递归文件名搜索（`fs.search` 路由，预算兜底 + 跳过 `.git`/symlink 目录；测试 `tests/fs-search.spec.ts`、组件测试 `tests/editor-host.spec.tsx`）
-- **`docs/plans/2026-08-11-service-registry-design.md`** / **`docs/plans/2026-08-11-declarative-sidebar-settings-design.md`** / **`docs/plans/2026-08-14-add-plugins-modal-design.md`**：设计文档（含实施偏差记录）
+- **`src/client/git-graph.ts`** / **`src/client/GitGraph.tsx`**：Git 面板历史提交图（lane 图）的纯布局算法（`computeGraphRows`：lane 分配 / 菱形汇入弧 / 分叉弧 / 列回收，输入 host 的 `git.log-graph` 拓扑序数据）与逐行 SVG 渲染（视觉移植自仓库本地参考目录 `docs/prototypes/gitgraph-lines` 的原型 demo，未纳入版本库；lane 色走 `--gg-lane-N` 自定义属性，默认映射 DSH 语义令牌）；host 数据链在 `src/git.ts`（`graphLog`/`parseGraphLines`）、`src/index.ts`（`git.log-graph` 路由）、`src/client/api.ts`（`gitLogGraph`/`GitGraphEntry`）；测试 `tests/git-graph.spec.ts`、`tests/git.spec.ts`
+- **`docs/plans/2026-08-11-service-registry-design.md`** / **`docs/plans/2026-08-11-declarative-sidebar-settings-design.md`** / **`docs/plans/2026-08-14-add-plugins-modal-design.md`** / **`docs/plans/2026-08-19-git-graph-lanes-design.md`**：设计文档（含实施偏差记录）
 
 调试时直接读这些文件即可看到所有 API 的真实用法。

--- a/docs/plans/2026-08-19-git-graph-lanes-design.md
+++ b/docs/plans/2026-08-19-git-graph-lanes-design.md
@@ -58,6 +58,7 @@ Git 面板的历史列表目前是纯文本行（hash + subject + refs + author/
 - **merge 规则修正**：初版把「携带本提交父哈希的 lane」也当汇入弧，导致父提交 lane 在其子提交行错误结束；按 topo 序语义改为仅菱形（同哈希）汇入（见 2.1 表）。
 - **fork 目标优先级**：初版允许复用「本行 merge 释放列」，会画成同列先汇入再分叉的 V 形；改为本行排除、下一行起可复用。
 - **host/API 半**为工作区既有 WIP（`graphLog` / `git.log-graph` / `gitLogGraph`），review 后随本 PR 一并提交（同一特性、互相依赖），并补上缺失的解析器测试。
+- **变高历史行（评审反馈）**：带 tag chips 的行（`gitLogLine2` 换行）比 40px 的 lane SVG 高，行内出现空白间距。修复：`GitGraphSvg` 增加 `height` prop，路径几何全部按实际行高参数化（`pathForkOut` 增加 `height` 参数、`mid = height / 2`）；`GitView` 的 `HistoryRow` 组件用 ResizeObserver 自测行高并传给 SVG，lane 线始终贯穿整行（相邻行高度不同也能平滑衔接）。
 
 ## 4. 参考实现
 

--- a/docs/plans/2026-08-19-git-graph-lanes-design.md
+++ b/docs/plans/2026-08-19-git-graph-lanes-design.md
@@ -58,7 +58,7 @@ Git 面板的历史列表目前是纯文本行（hash + subject + refs + author/
 - **merge 规则修正**：初版把「携带本提交父哈希的 lane」也当汇入弧，导致父提交 lane 在其子提交行错误结束；按 topo 序语义改为仅菱形（同哈希）汇入（见 2.1 表）。
 - **fork 目标优先级**：初版允许复用「本行 merge 释放列」，会画成同列先汇入再分叉的 V 形；改为本行排除、下一行起可复用。
 - **host/API 半**为工作区既有 WIP（`graphLog` / `git.log-graph` / `gitLogGraph`），review 后随本 PR 一并提交（同一特性、互相依赖），并补上缺失的解析器测试。
-- **变高历史行（评审反馈）**：带 tag chips 的行（`gitLogLine2` 换行）比 40px 的 lane SVG 高，行内出现空白间距。修复：`GitGraphSvg` 增加 `height` prop，路径几何全部按实际行高参数化（`pathForkOut` 增加 `height` 参数、`mid = height / 2`）；`GitView` 的 `HistoryRow` 组件用 ResizeObserver 自测行高并传给 SVG，lane 线始终贯穿整行（相邻行高度不同也能平滑衔接）。
+- **变高历史行（评审反馈，两轮）**：带 tag chips 的行（`gitLogLine2` 换行）比 40px 的 lane SVG 高，行内出现空白间距。第一版用 ResizeObserver 测量行高回填给 SVG——形成「行高 ↔ SVG 高度」的反馈循环（行被 SVG 撑高 → 再测量 → 再撑高），被评审驳回。最终方案**纯 CSS、零测量、零循环**：图 wrapper `position: absolute; top:0; bottom:0` 不参与行高（行高只由正文决定），SVG 用 `viewBox="0 0 W ROW_H"` + `preserveAspectRatio="none"` 把名义几何 y 向拉伸到块的实际高度（竖线保持竖直、x 像素精确，弧线圆角轻微变形可接受），圆点改为 CSS 元素（`top: 50%`）保持正圆垂直居中；正文 `margin-left = graphWidth + 8` 让开图区。`vector-effect="non-scaling-stroke"` 防止 y 拉伸把描边变粗。
 
 ## 4. 参考实现
 

--- a/docs/plans/2026-08-19-git-graph-lanes-design.md
+++ b/docs/plans/2026-08-19-git-graph-lanes-design.md
@@ -1,0 +1,66 @@
+# Git 面板历史提交图（lane 图）设计
+
+> 日期：2026-08-19
+> 状态：已实现（v0.14 开发分支 `feat/git-graph-lanes`）
+> 范围：`dsh-better-sidebar` 插件，Git 面板（`GitView.tsx`）历史列表的提交图渲染
+> 参考：`docs/prototypes/gitgraph-lines`（git graph 风格 node line 渲染 demo，移植其 lane/弧线/圆点视觉语言）
+
+## 1. 背景与问题
+
+Git 面板的历史列表目前是纯文本行（hash + subject + refs + author/date）。仓库**已存在一半基础设施**（工作区未提交 WIP，随本 PR 一并纳入）：
+
+- host：`src/git.ts` 的 `graphLog`（`git log --topo-order`，`%P` 输出完整父哈希）+ `parseGraphLines`
+- host 路由：`src/index.ts` 的 `git.log-graph`
+- client API：`src/client/api.ts` 的 `gitLogGraph` 与 `GitGraphEntry`
+
+缺的是**客户端 lane 布局 + SVG 渲染**——即 `docs/prototypes/gitgraph-lines` demo 的核心内容。该 demo 为嵌套调用链（`ChainStep`）生成 git graph 行序列（lane 竖线 / 汇入弧 / 分叉弧 / 圆点形态），但其输入模型（subChain / parallelGroup / branchKey）与真实 git 提交（parent 哈希链）完全不同，不能直接复用，需要**移植视觉语言、重写布局算法**。
+
+## 2. 方案
+
+### 2.1 纯布局模块 `src/client/git-graph.ts`
+
+输入：`GitGraphEntry[]`（`--topo-order`，新→旧，每行带完整 `parents` 哈希）。输出：每行的 `dotCol` / lane 快照 / `below` 续线集 / `merges`（汇入弧）/ `forks`（分叉弧）+ 图宽。
+
+**Lane 模型**（lane = 携带一个"等待显示"的提交完整哈希的列；topo 序保证父提交总在子提交之后）：
+
+| 规则 | 说明 |
+|---|---|
+| **dot lane** | 携带本提交哈希的最左列（菱形时最左胜出）；否则最左空闲列；否则右缘新列 |
+| **first parent** | 直下延续 dot lane；根提交（无 parents）结束该 lane |
+| **汇入弧（merge arc）** | 仅菱形合并：多列携带**同一哈希**时，非 dot 列在本行以「竖线 + 圆角」弧汇入圆点并释放。**携带本提交父哈希的 lane 不汇入**——父提交在后面（topo 序），其 lane 保持直行 |
+| **分叉弧（fork arc）** | 每个非 first parent：优先复用已携带该哈希的既有 lane（同一父的后来兄弟）；否则最左空闲列；否则右缘新列。**merge 释放的列不在同一行复用**（避免「V 形弹跳」），从下一行起可回收 |
+| **列回收** | lane 结束（圆点显示或汇入）后列号立即释放复用，图宽只随活跃分支数增长（同 git graph 工具） |
+
+**配色**：`laneColor(col) = var(--gg-lane-N)`（N = col % 6）——CSS 自定义属性定义在 `sidebar.module.css`，默认值全部映射 DSH 语义令牌（`--dsw-alias-brand-primary` / `state-success-primary` / `state-warn-primary` / `state-error-primary` / `state-business-primary` / `label-secondary`），遵守 §8 皮肤兼容规则（无硬编码颜色，皮肤覆盖令牌即换色）。列号固定取色 → 同一列全生命周期颜色稳定，回收后不变。
+
+**几何**：`CELL_W=24` / `ROW_H=40` / `CURVE_R=12`（原型 22/34/11 按双行历史行微调）。路径生成 `pathV` / `pathMergeIn` / `pathForkOut` 与原型逐行对齐。
+
+### 2.2 React 渲染组件 `src/client/GitGraph.tsx`
+
+`GitGraphSvg({ row, prev, graphWidth })` 把一行几何渲染为内联 `<svg>`：
+
+- 每列按 `prev.lanes.has(col)`（上方连续）+ `row.below.has(col)`（下方连续）+ 是否 merge/fork 列决定绘制：dot 列上下分段、merge 列画整条 `pathMergeIn`（含竖线+弧）、fork 列画 `pathForkOut`（含既有列的上段竖线）、直行 lane 画整高竖线；
+- 圆点：实心圆（r=5.2），fill = 所在列 lane 色。**不画外环**（dot 列线已按 mid 分段，无穿越遮挡问题；也避免 hover 背景与环色不匹配）。
+
+### 2.3 GitView 接入
+
+- `refresh` / `loadMoreLog` 改用 `api.gitLogGraph`（分页语义与普通 log 一致，`--skip` 在 topo 排序后应用，已实测）；
+- `useMemo(computeGraphRows(logEntries))` 累积分页重算布局；每行左侧渲染 `GitGraphSvg`，正文（hash/subject/refs/author）保持原结构不变，行点击/右键菜单行为不变；
+- 分页边界：每页独立布局，首行无承诺 lane 时落到列 0；越过折叠的 lane 悬垂（below 集持续直行）——与 gitk 分页行为一致。
+
+### 2.4 测试
+
+- `tests/git-graph.spec.ts`：纯几何断言——直线主链、分支/合并分叉、菱形合并（汇入弧）、章鱼合并（3+ parents）、列回收（同行不复用 + 后续复用）、既有 lane 复用、列色循环；
+- `tests/git.spec.ts`：补 `parseGraphLines` 解析测试（merge 行双 parent、根提交空 parents、短 hash 派生）。
+
+## 3. 实施偏差记录
+
+- **merge 规则修正**：初版把「携带本提交父哈希的 lane」也当汇入弧，导致父提交 lane 在其子提交行错误结束；按 topo 序语义改为仅菱形（同哈希）汇入（见 2.1 表）。
+- **fork 目标优先级**：初版允许复用「本行 merge 释放列」，会画成同列先汇入再分叉的 V 形；改为本行排除、下一行起可复用。
+- **host/API 半**为工作区既有 WIP（`graphLog` / `git.log-graph` / `gitLogGraph`），review 后随本 PR 一并提交（同一特性、互相依赖），并补上缺失的解析器测试。
+
+## 4. 参考实现
+
+- `docs/prototypes/gitgraph-lines/src/{layout,svg,paths,constants}.ts`：原型 lane 算法与 SVG 视觉（本设计的移植源；`docs/prototypes/` 为本地参考目录，**未纳入版本库**）
+- `src/client/GitView.tsx`：历史行结构与交互（点击/右键菜单/分页）
+- `src/git.ts` / `src/index.ts` / `src/client/api.ts`：host 半 graphLog 数据链

--- a/src/client/GitGraph.tsx
+++ b/src/client/GitGraph.tsx
@@ -9,18 +9,39 @@
  * sidebar.module.css, defaulting to DSH semantic tokens — so every skin
  * controls the palette without any hardcoded color in the markup.
  *
- * The row height is a prop (defaults to `ROW_H`): history rows grow when
- * tag chips wrap, and the SVG must span the ACTUAL row height so the lane
- * lines stay continuous and no blank gap appears below the graph. The
- * caller measures the row (ResizeObserver) and passes the height here.
+ * ## Height follows the row (no measurement, no feedback loop)
+ *
+ * History rows vary in height (tag chips wrap to a second line). The graph
+ * must span the row's ACTUAL height, so:
+ *
+ * - the wrapper is `position: absolute; top: 0; bottom: 0` — it never takes
+ *   part in the row's height, which is decided by the commit body alone
+ *   (no ResizeObserver round-trip, no "row grows → svg grows" loop);
+ * - the SVG fills the wrapper and uses `viewBox="0 0 W ROW_H"` +
+ *   `preserveAspectRatio="none"`: the y axis stretches to the row's real
+ *   height while the x axis keeps exact pixel positions (vertical lane
+ *   lines stay perfectly vertical, arc corners round slightly — the same
+ *   tradeoff VSCode Git Graph accepts for variable rows);
+ * - the dot is a CSS element (top: 50%), so it stays a perfect circle and
+ *   vertically centered regardless of the row height.
  */
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { colX, laneColor, pathForkOut, pathMergeIn, pathV, ROW_H, type GitGraphRow } from './git-graph.ts'
 import css from './sidebar.module.css'
 
-/** A stroke path in one lane color. */
+/** A stroke path in one lane color (non-scaling stroke: the y stretch of the
+ *  viewBox must not thicken the strokes). */
 function LanePath(props: { d: string; color: string }): ReactNode {
-  return <path d={props.d} fill="none" stroke={props.color} strokeWidth={2.2} strokeLinecap="round" />
+  return (
+    <path
+      d={props.d}
+      fill="none"
+      stroke={props.color}
+      strokeWidth={2.2}
+      strokeLinecap="round"
+      vectorEffect="non-scaling-stroke"
+    />
+  )
 }
 
 export function GitGraphSvg(props: {
@@ -29,11 +50,9 @@ export function GitGraphSvg(props: {
   prev?: GitGraphRow
   /** Total graph width in px (shared across rows of one page). */
   graphWidth: number
-  /** The row's ACTUAL height in px (defaults to the nominal ROW_H). */
-  height?: number
 }): ReactNode {
-  const { row, prev, graphWidth, height = ROW_H } = props
-  const mid = height / 2
+  const { row, prev, graphWidth } = props
+  const mid = ROW_H / 2
   const dotX = colX(row.dotCol)
   const mergeCols = new Set(row.merges.map(m => m.col))
   const forkCols = new Set(row.forks.map(f => f.col))
@@ -47,7 +66,7 @@ export function GitGraphSvg(props: {
     const isFork = forkCols.has(col)
     if (col === row.dotCol) {
       if (above) paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
-      if (below) paths.push(<LanePath key={`v:${col}:b`} d={pathV(x, mid, height)} color={color} />)
+      if (below) paths.push(<LanePath key={`v:${col}:b`} d={pathV(x, mid, ROW_H)} color={color} />)
     } else if (isMerge) {
       // The merge path already covers the vertical descent + the corner into
       // the dot (identical to the prototype's pathMergeIn).
@@ -55,26 +74,33 @@ export function GitGraphSvg(props: {
     } else if (isFork) {
       // An existing lane the fork joins also had a vertical above the dot row.
       if (above) paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
-      paths.push(<LanePath key={`f:${col}`} d={pathForkOut(dotX, x, mid, height)} color={color} />)
+      paths.push(<LanePath key={`f:${col}`} d={pathForkOut(dotX, x, mid)} color={color} />)
     } else if (above && below) {
-      paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, height)} color={color} />)
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, ROW_H)} color={color} />)
     } else if (above) {
       paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
     } else if (below) {
-      paths.push(<LanePath key={`v:${col}`} d={pathV(x, mid, height)} color={color} />)
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, mid, ROW_H)} color={color} />)
     }
   })
 
+  // The dot is a CSS circle so it never distorts under the viewBox y-stretch.
+  const dotStyle: CSSProperties = {
+    left: dotX - 5.2,
+    background: laneColor(row.dotCol),
+  }
+
   return (
-    <svg
-      className={css.gitLogGraph}
-      width={graphWidth}
-      height={height}
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-    >
-      {paths}
-      <circle cx={dotX} cy={mid} r={5.2} fill={laneColor(row.dotCol)} />
-    </svg>
+    <div className={css.gitLogGraph} style={{ width: graphWidth }}>
+      <svg
+        viewBox={`0 0 ${graphWidth} ${ROW_H}`}
+        preserveAspectRatio="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        {paths}
+      </svg>
+      <span className={css.gitLogDot} style={dotStyle} />
+    </div>
   )
 }

--- a/src/client/GitGraph.tsx
+++ b/src/client/GitGraph.tsx
@@ -1,0 +1,73 @@
+/**
+ * The commit-graph lane SVG for one history row — a React renderer over the
+ * pure geometry from `git-graph.ts` (see that module for the lane model).
+ *
+ * The paths are the gitgraph-lines prototype's exact shapes: full-height
+ * vertical lanes, merge arcs that curve INTO the dot (a lane ending here),
+ * fork arcs that curve OUT of the dot (a lane starting here), and the dot
+ * itself. Colors are `var(--gg-lane-N)` custom properties — defined in
+ * sidebar.module.css, defaulting to DSH semantic tokens — so every skin
+ * controls the palette without any hardcoded color in the markup.
+ */
+import type { ReactNode } from 'react'
+import { colX, laneColor, pathForkOut, pathMergeIn, pathV, ROW_H, type GitGraphRow } from './git-graph.ts'
+import css from './sidebar.module.css'
+
+/** A stroke path in one lane color. */
+function LanePath(props: { d: string; color: string }): ReactNode {
+  return <path d={props.d} fill="none" stroke={props.color} strokeWidth={2.2} strokeLinecap="round" />
+}
+
+export function GitGraphSvg(props: {
+  row: GitGraphRow
+  /** The previous row, for the "above" continuity of each lane. */
+  prev?: GitGraphRow
+  /** Total graph width in px (shared across rows of one page). */
+  graphWidth: number
+}): ReactNode {
+  const { row, prev, graphWidth } = props
+  const mid = ROW_H / 2
+  const dotX = colX(row.dotCol)
+  const mergeCols = new Set(row.merges.map(m => m.col))
+  const forkCols = new Set(row.forks.map(f => f.col))
+  const paths: ReactNode[] = []
+
+  row.lanes.forEach((color, col) => {
+    const x = colX(col)
+    const above = prev !== undefined && prev.lanes.has(col)
+    const below = row.below.has(col)
+    const isMerge = mergeCols.has(col)
+    const isFork = forkCols.has(col)
+    if (col === row.dotCol) {
+      if (above) paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
+      if (below) paths.push(<LanePath key={`v:${col}:b`} d={pathV(x, mid, ROW_H)} color={color} />)
+    } else if (isMerge) {
+      // The merge path already covers the vertical descent + the corner into
+      // the dot (identical to the prototype's pathMergeIn).
+      paths.push(<LanePath key={`m:${col}`} d={pathMergeIn(x, dotX, mid)} color={color} />)
+    } else if (isFork) {
+      // An existing lane the fork joins also had a vertical above the dot row.
+      if (above) paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
+      paths.push(<LanePath key={`f:${col}`} d={pathForkOut(dotX, x, mid)} color={color} />)
+    } else if (above && below) {
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, ROW_H)} color={color} />)
+    } else if (above) {
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
+    } else if (below) {
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, mid, ROW_H)} color={color} />)
+    }
+  })
+
+  return (
+    <svg
+      className={css.gitLogGraph}
+      width={graphWidth}
+      height={ROW_H}
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      {paths}
+      <circle cx={dotX} cy={mid} r={5.2} fill={laneColor(row.dotCol)} />
+    </svg>
+  )
+}

--- a/src/client/GitGraph.tsx
+++ b/src/client/GitGraph.tsx
@@ -8,6 +8,11 @@
  * itself. Colors are `var(--gg-lane-N)` custom properties — defined in
  * sidebar.module.css, defaulting to DSH semantic tokens — so every skin
  * controls the palette without any hardcoded color in the markup.
+ *
+ * The row height is a prop (defaults to `ROW_H`): history rows grow when
+ * tag chips wrap, and the SVG must span the ACTUAL row height so the lane
+ * lines stay continuous and no blank gap appears below the graph. The
+ * caller measures the row (ResizeObserver) and passes the height here.
  */
 import type { ReactNode } from 'react'
 import { colX, laneColor, pathForkOut, pathMergeIn, pathV, ROW_H, type GitGraphRow } from './git-graph.ts'
@@ -24,9 +29,11 @@ export function GitGraphSvg(props: {
   prev?: GitGraphRow
   /** Total graph width in px (shared across rows of one page). */
   graphWidth: number
+  /** The row's ACTUAL height in px (defaults to the nominal ROW_H). */
+  height?: number
 }): ReactNode {
-  const { row, prev, graphWidth } = props
-  const mid = ROW_H / 2
+  const { row, prev, graphWidth, height = ROW_H } = props
+  const mid = height / 2
   const dotX = colX(row.dotCol)
   const mergeCols = new Set(row.merges.map(m => m.col))
   const forkCols = new Set(row.forks.map(f => f.col))
@@ -40,7 +47,7 @@ export function GitGraphSvg(props: {
     const isFork = forkCols.has(col)
     if (col === row.dotCol) {
       if (above) paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
-      if (below) paths.push(<LanePath key={`v:${col}:b`} d={pathV(x, mid, ROW_H)} color={color} />)
+      if (below) paths.push(<LanePath key={`v:${col}:b`} d={pathV(x, mid, height)} color={color} />)
     } else if (isMerge) {
       // The merge path already covers the vertical descent + the corner into
       // the dot (identical to the prototype's pathMergeIn).
@@ -48,13 +55,13 @@ export function GitGraphSvg(props: {
     } else if (isFork) {
       // An existing lane the fork joins also had a vertical above the dot row.
       if (above) paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
-      paths.push(<LanePath key={`f:${col}`} d={pathForkOut(dotX, x, mid)} color={color} />)
+      paths.push(<LanePath key={`f:${col}`} d={pathForkOut(dotX, x, mid, height)} color={color} />)
     } else if (above && below) {
-      paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, ROW_H)} color={color} />)
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, height)} color={color} />)
     } else if (above) {
       paths.push(<LanePath key={`v:${col}`} d={pathV(x, 0, mid)} color={color} />)
     } else if (below) {
-      paths.push(<LanePath key={`v:${col}`} d={pathV(x, mid, ROW_H)} color={color} />)
+      paths.push(<LanePath key={`v:${col}`} d={pathV(x, mid, height)} color={color} />)
     }
   })
 
@@ -62,7 +69,7 @@ export function GitGraphSvg(props: {
     <svg
       className={css.gitLogGraph}
       width={graphWidth}
-      height={ROW_H}
+      height={height}
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
     >

--- a/src/client/GitView.tsx
+++ b/src/client/GitView.tsx
@@ -8,7 +8,7 @@
  * revert, cherry-pick, copy paths/hashes). Refresh is manual + on mount/
  * focus (no file watcher — KISS).
  */
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type MouseEvent, type ReactNode } from 'react'
 import {
   Button, IconBranchOutline16, IconCodeOutline16, IconCopyOutline16, IconRefreshOutline16,
   IconTrashOutline16, Input, Menu, Modal, writeClipboard,
@@ -16,7 +16,7 @@ import {
 import type { GitGraphEntry, GitStatusEntry, GitStatusResult, SessionScope } from './api.ts'
 import { api } from './api.ts'
 import { GitGraphSvg } from './GitGraph.tsx'
-import { computeGraphRows, ROW_H, type GitGraphRow } from './git-graph.ts'
+import { computeGraphRows } from './git-graph.ts'
 import { relativeTo } from './paths.ts'
 import { relativeTime, t } from './locales.ts'
 import type { SidebarTab } from './state.ts'
@@ -80,67 +80,6 @@ interface ConfirmState {
 /** History batch size: the log loads lazily in pages so a long history never
  *  floods the panel at once (the end of the log is reached by paging). */
 const LOG_BATCH = 20
-
-/**
- * One history row: the commit-graph lane SVG on the left, the commit body on
- * the right. The SVG must span the row's ACTUAL height — rows grow when tag
- * chips wrap to a second line, and a fixed-height graph would leave a blank
- * gap below the lanes — so the row measures itself (ResizeObserver) and
- * passes the height to {@link GitGraphSvg}, keeping the lane lines
- * continuous across variable-height rows.
- */
-function HistoryRow(props: {
-  row: GitGraphRow
-  prev?: GitGraphRow
-  graphWidth: number
-  onOpen: (entry: GitGraphEntry) => void
-  onMenu: (event: MouseEvent, entry: GitGraphEntry) => void
-}) {
-  const { row, prev, graphWidth, onOpen, onMenu } = props
-  const ref = useRef<HTMLDivElement | null>(null)
-  const [height, setHeight] = useState(ROW_H)
-  useLayoutEffect(() => {
-    const el = ref.current
-    if (el === null) return
-    const update = (): void => { setHeight(Math.max(ROW_H, el.getBoundingClientRect().height)) }
-    update()
-    const observer = new ResizeObserver(update)
-    observer.observe(el)
-    return () => { observer.disconnect() }
-  }, [])
-  const entry = row.entry
-  return (
-    <div
-      ref={ref}
-      role="button"
-      tabIndex={0}
-      className={css.gitLogRow}
-      title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
-      onClick={() => { onOpen(entry) }}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onOpen(entry)
-        }
-      }}
-      onContextMenu={(event) => { onMenu(event, entry) }}
-    >
-      <GitGraphSvg row={row} prev={prev} graphWidth={graphWidth} height={height} />
-      <div className={css.gitLogBody}>
-        <span className={css.gitLogLine1}>
-          <span className={css.gitLogHash}>{entry.hash}</span>
-          <span className={css.gitLogSubject}>{entry.subject}</span>
-        </span>
-        <span className={css.gitLogLine2}>
-          {refNames(entry.refs).map(name => (
-            <span key={name} className={css.gitLogRef}>{name}</span>
-          ))}
-          <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
-        </span>
-      </div>
-    </div>
-  )
-}
 
 export function GitView(props: {
   scope: SessionScope
@@ -425,16 +364,44 @@ export function GitView(props: {
 
           <div className={css.gitSection}>
             <div className={css.gitSectionHeader}><span>{t('history')}</span></div>
-            {graph.rows.map((row, index) => (
-              <HistoryRow
-                key={row.rowKey}
-                row={row}
-                prev={index > 0 ? graph.rows[index - 1] : undefined}
-                graphWidth={graph.graphWidth}
-                onOpen={(entry) => { openCommitDiff(entry) }}
-                onMenu={(event, entry) => { openHistoryMenu(event, entry) }}
-              />
-            ))}
+            {graph.rows.map((row, index) => {
+              const entry = row.entry
+              return (
+                <div
+                  key={row.rowKey}
+                  role="button"
+                  tabIndex={0}
+                  className={css.gitLogRow}
+                  title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
+                  onClick={() => { openCommitDiff(entry) }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      openCommitDiff(entry)
+                    }
+                  }}
+                  onContextMenu={(event) => { openHistoryMenu(event, entry) }}
+                >
+                  <GitGraphSvg
+                    row={row}
+                    prev={index > 0 ? graph.rows[index - 1] : undefined}
+                    graphWidth={graph.graphWidth}
+                  />
+                  <div className={css.gitLogBody} style={{ marginLeft: graph.graphWidth + 8 }}>
+                    <span className={css.gitLogLine1}>
+                      <span className={css.gitLogHash}>{entry.hash}</span>
+                      <span className={css.gitLogSubject}>{entry.subject}</span>
+                    </span>
+                    <span className={css.gitLogLine2}>
+                      {refNames(entry.refs).map(name => (
+                        <span key={name} className={css.gitLogRef}>{name}</span>
+                      ))}
+                      <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
             {!logEnded && (
               <button
                 type="button"

--- a/src/client/GitView.tsx
+++ b/src/client/GitView.tsx
@@ -8,13 +8,15 @@
  * revert, cherry-pick, copy paths/hashes). Refresh is manual + on mount/
  * focus (no file watcher — KISS).
  */
-import { useCallback, useEffect, useState, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type MouseEvent, type ReactNode } from 'react'
 import {
   Button, IconBranchOutline16, IconCodeOutline16, IconCopyOutline16, IconRefreshOutline16,
   IconTrashOutline16, Input, Menu, Modal, writeClipboard,
 } from '@deepseek-ai/dsh-client-ui-primitives'
-import type { GitLogEntry, GitStatusEntry, GitStatusResult, SessionScope } from './api.ts'
+import type { GitGraphEntry, GitStatusEntry, GitStatusResult, SessionScope } from './api.ts'
 import { api } from './api.ts'
+import { GitGraphSvg } from './GitGraph.tsx'
+import { computeGraphRows } from './git-graph.ts'
 import { relativeTo } from './paths.ts'
 import { relativeTime, t } from './locales.ts'
 import type { SidebarTab } from './state.ts'
@@ -90,7 +92,7 @@ export function GitView(props: {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [branchNames, setBranchNames] = useState<string[]>([])
-  const [logEntries, setLogEntries] = useState<GitLogEntry[]>([])
+  const [logEntries, setLogEntries] = useState<GitGraphEntry[]>([])
   const [commitMsg, setCommitMsg] = useState('')
   const [busy, setBusy] = useState(false)
   const [commitError, setCommitError] = useState<string | null>(null)
@@ -101,7 +103,7 @@ export function GitView(props: {
   /** The open file-row context menu (cursor position for the portaled Menu). */
   const [fileMenu, setFileMenu] = useState<{ entry: GitStatusEntry; staged: boolean; x: number; y: number } | null>(null)
   /** The open history-row context menu. */
-  const [historyMenu, setHistoryMenu] = useState<{ entry: GitLogEntry; x: number; y: number } | null>(null)
+  const [historyMenu, setHistoryMenu] = useState<{ entry: GitGraphEntry; x: number; y: number } | null>(null)
   /** The pending destructive action awaiting confirmation. */
   const [confirm, setConfirm] = useState<ConfirmState | null>(null)
 
@@ -112,8 +114,9 @@ export function GitView(props: {
       const [statusResult, branchResult, logResult] = await Promise.all([
         api.gitStatus(scope),
         api.gitBranch(scope).catch(() => ({ current: '', names: [] as string[] })),
-        // The first history page only; the rest arrives via "load more".
-        api.gitLog(scope, LOG_BATCH, 0).catch(() => [] as GitLogEntry[]),
+        // The first history page only; the rest arrives via "load more". The
+        // graph flavor carries parent hashes (topo-ordered) for the lane layout.
+        api.gitLogGraph(scope, LOG_BATCH, 0).catch(() => [] as GitGraphEntry[]),
       ])
       setStatus(statusResult)
       setBranchNames(branchResult.names)
@@ -133,7 +136,7 @@ export function GitView(props: {
     if (logLoadingMore || logEnded) return
     setLogLoadingMore(true)
     try {
-      const next = await api.gitLog(scope, LOG_BATCH, logEntries.length)
+      const next = await api.gitLogGraph(scope, LOG_BATCH, logEntries.length)
       setLogEntries(entries => [...entries, ...next])
       if (next.length < LOG_BATCH) setLogEnded(true)
     } catch (reason) {
@@ -154,7 +157,7 @@ export function GitView(props: {
   }
 
   /** The diff tab for one commit (one tab per commit). */
-  const openCommitDiff = (entry: GitLogEntry): void => {
+  const openCommitDiff = (entry: GitGraphEntry): void => {
     onOpenDiff({
       id: `diff:c:${entry.hashFull}`,
       type: 'diff',
@@ -242,7 +245,7 @@ export function GitView(props: {
     setFileMenu({ entry, staged, x: event.clientX, y: event.clientY })
   }
 
-  const openHistoryMenu = (event: MouseEvent, entry: GitLogEntry): void => {
+  const openHistoryMenu = (event: MouseEvent, entry: GitGraphEntry): void => {
     event.preventDefault()
     event.stopPropagation()
     setHistoryMenu({ entry, x: event.clientX, y: event.clientY })
@@ -250,6 +253,9 @@ export function GitView(props: {
 
   const stagedEntries = (status?.entries ?? []).filter(isStagedEntry)
   const unstagedEntries = (status?.entries ?? []).filter(isUnstagedEntry)
+
+  /** The lane layout over the accumulated log pages (recomputed on append). */
+  const graph = useMemo(() => computeGraphRows(logEntries), [logEntries])
 
   const renderEntry = (entry: GitStatusEntry, staged: boolean): ReactNode => {
     return (
@@ -358,32 +364,39 @@ export function GitView(props: {
 
           <div className={css.gitSection}>
             <div className={css.gitSectionHeader}><span>{t('history')}</span></div>
-            {logEntries.map(entry => (
+            {graph.rows.map((row, index) => (
               <div
-                key={entry.hashFull}
+                key={row.rowKey}
                 role="button"
                 tabIndex={0}
                 className={css.gitLogRow}
-                title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
-                onClick={() => { openCommitDiff(entry) }}
+                title={`${row.entry.author} · ${row.entry.date}\n${row.entry.hashFull}`}
+                onClick={() => { openCommitDiff(row.entry) }}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter' || event.key === ' ') {
                     event.preventDefault()
-                    openCommitDiff(entry)
+                    openCommitDiff(row.entry)
                   }
                 }}
-                onContextMenu={(event) => { openHistoryMenu(event, entry) }}
+                onContextMenu={(event) => { openHistoryMenu(event, row.entry) }}
               >
-                <span className={css.gitLogLine1}>
-                  <span className={css.gitLogHash}>{entry.hash}</span>
-                  <span className={css.gitLogSubject}>{entry.subject}</span>
-                </span>
-                <span className={css.gitLogLine2}>
-                  {refNames(entry.refs).map(ref => (
-                    <span key={ref} className={css.gitLogRef}>{ref}</span>
-                  ))}
-                  <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
-                </span>
+                <GitGraphSvg
+                  row={row}
+                  prev={index > 0 ? graph.rows[index - 1] : undefined}
+                  graphWidth={graph.graphWidth}
+                />
+                <div className={css.gitLogBody}>
+                  <span className={css.gitLogLine1}>
+                    <span className={css.gitLogHash}>{row.entry.hash}</span>
+                    <span className={css.gitLogSubject}>{row.entry.subject}</span>
+                  </span>
+                  <span className={css.gitLogLine2}>
+                    {refNames(row.entry.refs).map(ref => (
+                      <span key={ref} className={css.gitLogRef}>{ref}</span>
+                    ))}
+                    <span className={css.gitLogMeta}>{row.entry.author} · {relativeTime(row.entry.date)}</span>
+                  </span>
+                </div>
               </div>
             ))}
             {!logEnded && (

--- a/src/client/GitView.tsx
+++ b/src/client/GitView.tsx
@@ -8,7 +8,7 @@
  * revert, cherry-pick, copy paths/hashes). Refresh is manual + on mount/
  * focus (no file watcher — KISS).
  */
-import { useCallback, useEffect, useMemo, useState, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react'
 import {
   Button, IconBranchOutline16, IconCodeOutline16, IconCopyOutline16, IconRefreshOutline16,
   IconTrashOutline16, Input, Menu, Modal, writeClipboard,
@@ -16,7 +16,7 @@ import {
 import type { GitGraphEntry, GitStatusEntry, GitStatusResult, SessionScope } from './api.ts'
 import { api } from './api.ts'
 import { GitGraphSvg } from './GitGraph.tsx'
-import { computeGraphRows } from './git-graph.ts'
+import { computeGraphRows, ROW_H, type GitGraphRow } from './git-graph.ts'
 import { relativeTo } from './paths.ts'
 import { relativeTime, t } from './locales.ts'
 import type { SidebarTab } from './state.ts'
@@ -80,6 +80,67 @@ interface ConfirmState {
 /** History batch size: the log loads lazily in pages so a long history never
  *  floods the panel at once (the end of the log is reached by paging). */
 const LOG_BATCH = 20
+
+/**
+ * One history row: the commit-graph lane SVG on the left, the commit body on
+ * the right. The SVG must span the row's ACTUAL height — rows grow when tag
+ * chips wrap to a second line, and a fixed-height graph would leave a blank
+ * gap below the lanes — so the row measures itself (ResizeObserver) and
+ * passes the height to {@link GitGraphSvg}, keeping the lane lines
+ * continuous across variable-height rows.
+ */
+function HistoryRow(props: {
+  row: GitGraphRow
+  prev?: GitGraphRow
+  graphWidth: number
+  onOpen: (entry: GitGraphEntry) => void
+  onMenu: (event: MouseEvent, entry: GitGraphEntry) => void
+}) {
+  const { row, prev, graphWidth, onOpen, onMenu } = props
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [height, setHeight] = useState(ROW_H)
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (el === null) return
+    const update = (): void => { setHeight(Math.max(ROW_H, el.getBoundingClientRect().height)) }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => { observer.disconnect() }
+  }, [])
+  const entry = row.entry
+  return (
+    <div
+      ref={ref}
+      role="button"
+      tabIndex={0}
+      className={css.gitLogRow}
+      title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
+      onClick={() => { onOpen(entry) }}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpen(entry)
+        }
+      }}
+      onContextMenu={(event) => { onMenu(event, entry) }}
+    >
+      <GitGraphSvg row={row} prev={prev} graphWidth={graphWidth} height={height} />
+      <div className={css.gitLogBody}>
+        <span className={css.gitLogLine1}>
+          <span className={css.gitLogHash}>{entry.hash}</span>
+          <span className={css.gitLogSubject}>{entry.subject}</span>
+        </span>
+        <span className={css.gitLogLine2}>
+          {refNames(entry.refs).map(name => (
+            <span key={name} className={css.gitLogRef}>{name}</span>
+          ))}
+          <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
+        </span>
+      </div>
+    </div>
+  )
+}
 
 export function GitView(props: {
   scope: SessionScope
@@ -365,39 +426,14 @@ export function GitView(props: {
           <div className={css.gitSection}>
             <div className={css.gitSectionHeader}><span>{t('history')}</span></div>
             {graph.rows.map((row, index) => (
-              <div
+              <HistoryRow
                 key={row.rowKey}
-                role="button"
-                tabIndex={0}
-                className={css.gitLogRow}
-                title={`${row.entry.author} · ${row.entry.date}\n${row.entry.hashFull}`}
-                onClick={() => { openCommitDiff(row.entry) }}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault()
-                    openCommitDiff(row.entry)
-                  }
-                }}
-                onContextMenu={(event) => { openHistoryMenu(event, row.entry) }}
-              >
-                <GitGraphSvg
-                  row={row}
-                  prev={index > 0 ? graph.rows[index - 1] : undefined}
-                  graphWidth={graph.graphWidth}
-                />
-                <div className={css.gitLogBody}>
-                  <span className={css.gitLogLine1}>
-                    <span className={css.gitLogHash}>{row.entry.hash}</span>
-                    <span className={css.gitLogSubject}>{row.entry.subject}</span>
-                  </span>
-                  <span className={css.gitLogLine2}>
-                    {refNames(row.entry.refs).map(ref => (
-                      <span key={ref} className={css.gitLogRef}>{ref}</span>
-                    ))}
-                    <span className={css.gitLogMeta}>{row.entry.author} · {relativeTime(row.entry.date)}</span>
-                  </span>
-                </div>
-              </div>
+                row={row}
+                prev={index > 0 ? graph.rows[index - 1] : undefined}
+                graphWidth={graph.graphWidth}
+                onOpen={(entry) => { openCommitDiff(entry) }}
+                onMenu={(event, entry) => { openHistoryMenu(event, entry) }}
+              />
             ))}
             {!logEnded && (
               <button

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -58,6 +58,12 @@ export interface GitLogEntry {
   refs: string
 }
 
+/** One git log row with parent hashes (graph view). `parents` are FULL
+ *  40-char hashes, first-parent first; a root commit has `parents: []`. */
+export interface GitGraphEntry extends GitLogEntry {
+  parents: string[]
+}
+
 /** Text read result. */
 export interface FsTextResult { kind: 'text'; content: string; truncated: boolean }
 /** Binary read result (no content; images load through the media route).
@@ -160,6 +166,13 @@ export const api = {
   /** Recent commit history, lazily pageable (skip/count; defaults 0/30). */
   gitLog: (scope: SessionScope, count?: number, skip?: number, signal?: AbortSignal) =>
     call<GitLogEntry[]>('git.log', scopePayload(scope, {
+      ...(count !== undefined ? { count } : {}),
+      ...(skip !== undefined ? { skip } : {}),
+    }), signal),
+  /** Recent commit history WITH parent hashes (topo-ordered, for the graph
+   *  view's lane layout); pageable like {@link gitLog}. */
+  gitLogGraph: (scope: SessionScope, count?: number, skip?: number, signal?: AbortSignal) =>
+    call<GitGraphEntry[]>('git.log-graph', scopePayload(scope, {
       ...(count !== undefined ? { count } : {}),
       ...(skip !== undefined ? { skip } : {}),
     }), signal),

--- a/src/client/git-graph.ts
+++ b/src/client/git-graph.ts
@@ -43,7 +43,10 @@
  */
 import type { GitGraphEntry } from './api.ts'
 
-/** Geometry (aligned with the gitgraph-lines prototype: CELL_W/ROW_H/CURVE_R). */
+/** Geometry (aligned with the gitgraph-lines prototype: CELL_W/ROW_H/CURVE_R).
+ *  ROW_H is the DEFAULT row height; the renderer passes the actual row height
+ *  (history rows grow when tag chips wrap) and the path functions derive
+ *  `mid` from it. */
 export const CELL_W = 24
 export const ROW_H = 40
 export const CURVE_R = 12
@@ -61,7 +64,9 @@ export function colX(col: number): number {
   return col * CELL_W + CELL_W / 2
 }
 
-/** One merge arc: a lane's vertical descent + rounded corner into the dot. */
+/** One merge arc: a lane's vertical descent + rounded corner into the dot.
+ *  `mid` = the row's vertical center (height / 2), so the geometry adapts to
+ *  any row height. */
 export function pathMergeIn(fromX: number, dotX: number, mid: number): string {
   if (fromX === dotX) return `M ${fromX} 0 L ${fromX} ${mid}`
   const sign = dotX > fromX ? 1 : -1
@@ -69,12 +74,14 @@ export function pathMergeIn(fromX: number, dotX: number, mid: number): string {
   return ['M', fromX, 0, 'L', fromX, mid - r, 'Q', fromX, mid, fromX + sign * r, mid, 'L', dotX, mid].join(' ')
 }
 
-/** One fork arc: from the dot horizontally out + rounded corner down. */
-export function pathForkOut(dotX: number, toX: number, mid: number): string {
-  if (dotX === toX) return `M ${dotX} ${mid} L ${toX} ${ROW_H}`
+/** One fork arc: from the dot horizontally out + rounded corner down to the
+ *  row bottom (`height` — history rows vary in height when tag chips wrap,
+ *  so the geometry must not hardcode ROW_H). */
+export function pathForkOut(dotX: number, toX: number, mid: number, height: number): string {
+  if (dotX === toX) return `M ${dotX} ${mid} L ${toX} ${height}`
   const sign = toX > dotX ? 1 : -1
-  const r = Math.min(CURVE_R, Math.abs(toX - dotX), ROW_H - mid)
-  return ['M', dotX, mid, 'L', toX - sign * r, mid, 'Q', toX, mid, toX, mid + r, 'L', toX, ROW_H].join(' ')
+  const r = Math.min(CURVE_R, Math.abs(toX - dotX), height - mid)
+  return ['M', dotX, mid, 'L', toX - sign * r, mid, 'Q', toX, mid, toX, mid + r, 'L', toX, height].join(' ')
 }
 
 /** A straight vertical line segment. */

--- a/src/client/git-graph.ts
+++ b/src/client/git-graph.ts
@@ -1,0 +1,192 @@
+/**
+ * Git commit graph lane layout — the client half of the history graph.
+ *
+ * Ports the visual language of `docs/prototypes/gitgraph-lines` (lane
+ * columns, merge arcs, fork arcs, dots, column recycling) from the
+ * call-chain renderer to REAL git commits: input is the topo-ordered
+ * `git log --topo-order` rows (newest first) that the host's
+ * `git.log-graph` route already returns, each carrying its FULL parent
+ * hashes. The layout is pure computation (no DOM), so it is unit-testable
+ * in Node and renderable by any SVG consumer.
+ *
+ * ## Lane model
+ *
+ * A lane is a column that "carries" the full hash of a commit still waiting
+ * to be displayed below (topo order guarantees a commit appears after all
+ * its children). Per row (one commit):
+ *
+ * - **dot lane** — the column carrying this commit's hash, else the first
+ *   free column (paging boundary / new branch). The commit's FIRST parent
+ *   continues straight down the same lane; a root commit ends the lane.
+ * - **merge arcs** — when several lanes carry the SAME hash (a diamond: two
+ *   children forked to one common parent), the commit is displayed on the
+ *   LEFTMOST of them and every other lane ends here with a vertical +
+ *   rounded corner arc INTO the dot. A lane carrying one of this commit's
+ *   parents but not the commit itself never merges here — the parent is
+ *   displayed later (topo order), so its lane keeps a straight line down.
+ * - **fork arcs** — every NON-first parent leaves the dot on a horizontal +
+ *   rounded corner arc into a lane: an existing lane already carrying that
+ *   hash (a later sibling of the same parent), the leftmost free column, or
+ *   a brand-new column at the right edge. A column freed by a merge becomes
+ *   reusable from the NEXT row on (never in the same row the merge arc used
+ *   it — no V-shaped bounce).
+ * - **straight lanes** — any other column keeps a full-height vertical line
+ *   (its commit still waits below the fold).
+ * - **column recycling** — a lane ends the moment its commit is displayed or
+ *   merged, and its column is immediately reusable, so the graph never grows
+ *   wider than the active branch count (same as git graph tools).
+ *
+ * Lane colors are a pure function of the column index (`var(--gg-lane-N)`
+ * CSS custom properties defined in sidebar.module.css, defaulting to DSH
+ * semantic tokens so every skin controls them), which keeps each column's
+ * color stable across its whole life and across recycling.
+ */
+import type { GitGraphEntry } from './api.ts'
+
+/** Geometry (aligned with the gitgraph-lines prototype: CELL_W/ROW_H/CURVE_R). */
+export const CELL_W = 24
+export const ROW_H = 40
+export const CURVE_R = 12
+
+/** Distinct lane hues: CSS custom property per column slot (0-based). */
+export const LANE_VARS = ['--gg-lane-0', '--gg-lane-1', '--gg-lane-2', '--gg-lane-3', '--gg-lane-4', '--gg-lane-5'] as const
+
+/** The lane color reference for one column (`var(--gg-lane-N)`, cycling). */
+export function laneColor(col: number): string {
+  return `var(${LANE_VARS[col % LANE_VARS.length]})`
+}
+
+/** Column index → the dot's x coordinate. */
+export function colX(col: number): number {
+  return col * CELL_W + CELL_W / 2
+}
+
+/** One merge arc: a lane's vertical descent + rounded corner into the dot. */
+export function pathMergeIn(fromX: number, dotX: number, mid: number): string {
+  if (fromX === dotX) return `M ${fromX} 0 L ${fromX} ${mid}`
+  const sign = dotX > fromX ? 1 : -1
+  const r = Math.min(CURVE_R, Math.abs(dotX - fromX), mid)
+  return ['M', fromX, 0, 'L', fromX, mid - r, 'Q', fromX, mid, fromX + sign * r, mid, 'L', dotX, mid].join(' ')
+}
+
+/** One fork arc: from the dot horizontally out + rounded corner down. */
+export function pathForkOut(dotX: number, toX: number, mid: number): string {
+  if (dotX === toX) return `M ${dotX} ${mid} L ${toX} ${ROW_H}`
+  const sign = toX > dotX ? 1 : -1
+  const r = Math.min(CURVE_R, Math.abs(toX - dotX), ROW_H - mid)
+  return ['M', dotX, mid, 'L', toX - sign * r, mid, 'Q', toX, mid, toX, mid + r, 'L', toX, ROW_H].join(' ')
+}
+
+/** A straight vertical line segment. */
+export function pathV(x: number, y1: number, y2: number): string {
+  return ['M', x, y1, 'L', x, y2].join(' ')
+}
+
+/** One laid-out history row (one commit) with its lane snapshot and edges. */
+export interface GitGraphRow {
+  entry: GitGraphEntry
+  /** Full hash — unique per commit (also the React key). */
+  rowKey: string
+  /** Column of the commit dot. */
+  dotCol: number
+  /** Every column drawn in this row → its lane color reference. */
+  lanes: Map<number, string>
+  /** Columns whose lane continues BELOW this row (straight). */
+  below: Set<number>
+  /** Merge arcs: lane column → dot (the lane ends here). */
+  merges: { col: number; color: string }[]
+  /** Fork arcs: dot → lane column (the lane starts / is fed here). */
+  forks: { col: number; color: string }[]
+}
+
+export interface GitGraphLayout {
+  rows: GitGraphRow[]
+  /** Total graph width in px ((maxCol + 1) * CELL_W + right padding). */
+  graphWidth: number
+}
+
+/**
+ * Lay out topo-ordered commits (newest first) into a lane graph. See the
+ * module doc for the lane rules; the algorithm is a standard git-graph
+ * lane assignment (matching GitKraken / VSCode Git Graph shapes).
+ */
+export function computeGraphRows(entries: readonly GitGraphEntry[]): GitGraphLayout {
+  const lanes: (string | null)[] = []
+  const rows: GitGraphRow[] = []
+  let maxCol = 0
+
+  for (const entry of entries) {
+    const hash = entry.hashFull
+    const parents = entry.parents
+
+    // ① dot lane: the column already promising this hash (leftmost wins in a
+    //    diamond), else the first free column, else a brand-new column.
+    let dotCol = lanes.indexOf(hash)
+    if (dotCol === -1) {
+      dotCol = lanes.indexOf(null)
+      if (dotCol === -1) {
+        lanes.push(null)
+        dotCol = lanes.length - 1
+      }
+    }
+
+    // ② merge arcs: columns (≠ dot) carrying THIS commit's hash — a diamond
+    //    join where several children forked to one common parent; the commit
+    //    is displayed on the leftmost of them and the rest end here, arcing
+    //    into the dot. Free them right away so the fork targets below can
+    //    recycle the columns. (A lane carrying one of this commit's parents
+    //    is NOT a merge — the parent is displayed later, its lane continues.)
+    const merges: { col: number; color: string }[] = []
+    const mergeCols = new Set<number>()
+    for (let i = 0; i < lanes.length; i += 1) {
+      if (i === dotCol || lanes[i] === null) continue
+      if (lanes[i] === hash) {
+        merges.push({ col: i, color: laneColor(i) })
+        mergeCols.add(i)
+      }
+    }
+    for (const c of mergeCols) lanes[c] = null
+
+    // ③ fork targets for the non-first parents: an existing lane already
+    //    carrying the hash (a later sibling of the same parent), the leftmost
+    //    free column, or a brand-new column at the right edge. Columns freed
+    //    by a merge in THIS row stay unused until the next row, so a merge
+    //    arc and a fork never share one column (no V-shaped bounce).
+    const forks: { col: number; color: string }[] = []
+    for (const p of parents.slice(1)) {
+      let col = lanes.findIndex((h, i) => i !== dotCol && !mergeCols.has(i) && h === p)
+      if (col === -1) {
+        col = lanes.findIndex((h, i) => i !== dotCol && !mergeCols.has(i) && h === null)
+      }
+      if (col === -1) {
+        lanes.push(null)
+        col = lanes.length - 1
+      }
+      forks.push({ col, color: laneColor(col) })
+      lanes[col] = p
+    }
+
+    // ④ the dot lane continues with the first parent (a root commit ends it).
+    lanes[dotCol] = parents[0] ?? null
+
+    // ⑤ snapshot: drawn columns, continuing-below set, geometry.
+    const rowLanes = new Map<number, string>()
+    for (let i = 0; i < lanes.length; i += 1) {
+      if (lanes[i] !== null) rowLanes.set(i, laneColor(i))
+    }
+    rowLanes.set(dotCol, laneColor(dotCol))
+    for (const m of merges) rowLanes.set(m.col, m.color)
+    for (const f of forks) rowLanes.set(f.col, f.color)
+    const below = new Set<number>()
+    for (let i = 0; i < lanes.length; i += 1) {
+      if (lanes[i] !== null) below.add(i)
+    }
+    for (const c of rowLanes.keys()) {
+      if (c > maxCol) maxCol = c
+    }
+
+    rows.push({ entry, rowKey: hash, dotCol, lanes: rowLanes, below, merges, forks })
+  }
+
+  return { rows, graphWidth: (maxCol + 1) * CELL_W + 6 }
+}

--- a/src/client/git-graph.ts
+++ b/src/client/git-graph.ts
@@ -44,9 +44,11 @@
 import type { GitGraphEntry } from './api.ts'
 
 /** Geometry (aligned with the gitgraph-lines prototype: CELL_W/ROW_H/CURVE_R).
- *  ROW_H is the DEFAULT row height; the renderer passes the actual row height
- *  (history rows grow when tag chips wrap) and the path functions derive
- *  `mid` from it. */
+ *  ROW_H is the NOMINAL row height the path geometry is authored in: the SVG
+ *  is rendered with `viewBox="0 0 W ROW_H"` + `preserveAspectRatio="none"`
+ *  and CSS `top:0;bottom:0` fills the row's ACTUAL height (which varies when
+ *  tag chips wrap), so the y axis stretches to match the row while the x
+ *  axis keeps its exact pixel positions. */
 export const CELL_W = 24
 export const ROW_H = 40
 export const CURVE_R = 12
@@ -64,9 +66,7 @@ export function colX(col: number): number {
   return col * CELL_W + CELL_W / 2
 }
 
-/** One merge arc: a lane's vertical descent + rounded corner into the dot.
- *  `mid` = the row's vertical center (height / 2), so the geometry adapts to
- *  any row height. */
+/** One merge arc: a lane's vertical descent + rounded corner into the dot. */
 export function pathMergeIn(fromX: number, dotX: number, mid: number): string {
   if (fromX === dotX) return `M ${fromX} 0 L ${fromX} ${mid}`
   const sign = dotX > fromX ? 1 : -1
@@ -75,13 +75,13 @@ export function pathMergeIn(fromX: number, dotX: number, mid: number): string {
 }
 
 /** One fork arc: from the dot horizontally out + rounded corner down to the
- *  row bottom (`height` — history rows vary in height when tag chips wrap,
- *  so the geometry must not hardcode ROW_H). */
-export function pathForkOut(dotX: number, toX: number, mid: number, height: number): string {
-  if (dotX === toX) return `M ${dotX} ${mid} L ${toX} ${height}`
+ *  nominal row bottom (ROW_H; stretched to the actual row height by the
+ *  SVG's viewBox). */
+export function pathForkOut(dotX: number, toX: number, mid: number): string {
+  if (dotX === toX) return `M ${dotX} ${mid} L ${toX} ${ROW_H}`
   const sign = toX > dotX ? 1 : -1
-  const r = Math.min(CURVE_R, Math.abs(toX - dotX), height - mid)
-  return ['M', dotX, mid, 'L', toX - sign * r, mid, 'Q', toX, mid, toX, mid + r, 'L', toX, height].join(' ')
+  const r = Math.min(CURVE_R, Math.abs(toX - dotX), ROW_H - mid)
+  return ['M', dotX, mid, 'L', toX - sign * r, mid, 'Q', toX, mid, toX, mid + r, 'L', toX, ROW_H].join(' ')
 }
 
 /** A straight vertical line segment. */

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2034,19 +2034,43 @@
   cursor: default;
 }
 
-/* A history row: line 1 = hash + subject, line 2 = ref badges + author/date
-   (badges live on the second line so they never crowd the subject). */
+/* A history row: the commit-graph lane SVG on the left, body on the right
+   (line 1 = hash + subject, line 2 = ref badges + author/date). The lane
+   colors come from the `--gg-lane-N` custom properties below — defaults are
+   DSH semantic tokens, so every skin controls the palette (skin-compat rule:
+   no hardcoded colors). */
 .gitLogRow {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 5px 12px;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 2px 12px 2px 6px;
   cursor: pointer;
   border-radius: 8px;
 }
 
 .gitLogRow:hover {
   background: var(--dsw-alias-interactive-bg-hover);
+}
+
+/* The lane SVG (see src/client/git-graph.ts for the geometry). */
+.gitLogGraph {
+  flex: none;
+  display: block;
+  --gg-lane-0: var(--dsw-alias-brand-primary);
+  --gg-lane-1: var(--dsw-alias-state-success-primary);
+  --gg-lane-2: var(--dsw-alias-state-warn-primary);
+  --gg-lane-3: var(--dsw-alias-state-error-primary);
+  --gg-lane-4: var(--dsw-alias-state-business-primary);
+  --gg-lane-5: var(--dsw-alias-label-secondary);
+}
+
+.gitLogBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .gitLogLine1 {

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2040,9 +2040,9 @@
    DSH semantic tokens, so every skin controls the palette (skin-compat rule:
    no hardcoded colors). */
 .gitLogRow {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 8px;
   min-height: 40px;
   padding: 2px 12px 2px 6px;
   cursor: pointer;
@@ -2053,16 +2053,42 @@
   background: var(--dsw-alias-interactive-bg-hover);
 }
 
-/* The lane SVG (see src/client/git-graph.ts for the geometry). */
+/* The commit-graph lane (see src/client/git-graph.ts for the geometry):
+   absolutely positioned so it NEVER takes part in the row's height — the
+   body alone decides it (rows grow when tag chips wrap). top/bottom stretch
+   the graph to the row's actual height; the svg inside uses
+   viewBox + preserveAspectRatio="none" so the nominal 40px geometry is
+   y-stretched to match (vertical lanes stay straight, x positions exact). */
 .gitLogGraph {
-  flex: none;
-  display: block;
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
   --gg-lane-0: var(--dsw-alias-brand-primary);
   --gg-lane-1: var(--dsw-alias-state-success-primary);
   --gg-lane-2: var(--dsw-alias-state-warn-primary);
   --gg-lane-3: var(--dsw-alias-state-error-primary);
   --gg-lane-4: var(--dsw-alias-state-business-primary);
   --gg-lane-5: var(--dsw-alias-label-secondary);
+}
+
+.gitLogGraph svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* The commit dot: a CSS circle (top: 50%) so it stays a perfect circle and
+   vertically centered no matter how tall the row is (an SVG circle would
+   distort under the viewBox y-stretch). */
+.gitLogDot {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10.4px;
+  height: 10.4px;
+  border-radius: 50%;
+  pointer-events: none;
 }
 
 .gitLogBody {

--- a/src/git.ts
+++ b/src/git.ts
@@ -39,6 +39,13 @@ export interface GitLogEntry {
   refs: string
 }
 
+/** One `git log` row with parent hashes (for the graph view's lane layout).
+ *  `parents` are FULL 40-char hashes, first-parent first (git's `%P` order),
+ *  so a merge commit carries 2+ entries and a root commit carries none. */
+export interface GitGraphEntry extends GitLogEntry {
+  parents: string[]
+}
+
 /** One git failure (stderr text as the message). */
 export class GitCommandError extends Error {
   constructor(
@@ -85,6 +92,33 @@ export function parseLogLines(output: string): GitLogEntry[] {
       date: date ?? '',
       hashFull: hashFull ?? hash,
       refs: refs ?? '',
+    })
+  }
+  return rows
+}
+
+/**
+ * Parse `git log --pretty=format:%H%x1f%P%x1f%s%x1f%an%x1f%ai%x1f%D` rows
+ * (graph flavor): the second field is `%P` — the FULL parent hashes, space
+ * separated, first-parent first. A root commit has an empty parent field →
+ * `parents: []`. The row's own hash is `%H` (full); the short hash for
+ * display is derived as the first 7 chars (git's default short length).
+ */
+export function parseGraphLines(output: string): GitGraphEntry[] {
+  const rows: GitGraphEntry[] = []
+  for (const line of output.split('\n')) {
+    if (line === '') continue
+    const [hashFull, parentsRaw, subject, author, date, refs] = line.split('\x1f')
+    if (hashFull === undefined || parentsRaw === undefined || subject === undefined) continue
+    const parents = parentsRaw === '' ? [] : parentsRaw.split(' ').filter(hash => hash !== '')
+    rows.push({
+      hash: hashFull.slice(0, 7),
+      hashFull,
+      subject,
+      author: author ?? '',
+      date: date ?? '',
+      refs: refs ?? '',
+      parents,
     })
   }
   return rows
@@ -199,6 +233,21 @@ export async function log(cwd: string, count = 30, skip = 0): Promise<GitLogEntr
     '--pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D',
   ])
   return parseLogLines(raw)
+}
+
+/**
+ * Recent commit history with parent hashes (newest first), pageable via
+ * skip/count. `--topo-order` guarantees no parent appears before its child
+ * (the lane layout algorithm's precondition), at the cost of a less strictly
+ * chronological order when branches diverge — which is the conventional
+ * arrangement for a commit graph (parallel branches stay visually grouped).
+ */
+export async function graphLog(cwd: string, count = 30, skip = 0): Promise<GitGraphEntry[]> {
+  const raw = await runGit(cwd, [
+    'log', '-n', String(count), '--skip', String(skip), '--topo-order', '--decorate=short',
+    '--pretty=format:%H%x1f%P%x1f%s%x1f%an%x1f%ai%x1f%D',
+  ])
+  return parseGraphLines(raw)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,17 @@ function buildApi(
         : undefined
       return git.log(cwd, count, skip)
     },
+    'git.log-graph': async (payload) => {
+      const { cwd } = cwdOf(payload)
+      const record = payload as { count?: unknown; skip?: unknown }
+      const count = typeof record.count === 'number' && Number.isInteger(record.count) && record.count > 0
+        ? record.count
+        : undefined
+      const skip = typeof record.skip === 'number' && Number.isInteger(record.skip) && record.skip >= 0
+        ? record.skip
+        : undefined
+      return git.graphLog(cwd, count, skip)
+    },
     'git.commit-diff': async (payload) => {
       const { cwd } = cwdOf(payload)
       return { diff: await git.commitDiff(cwd, requireString(payload, 'hash')) }

--- a/tests/git-graph.spec.ts
+++ b/tests/git-graph.spec.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from 'vitest'
 import type { GitGraphEntry } from '../src/client/api.ts'
 import {
-  CELL_W, colX, computeGraphRows, laneColor, pathForkOut, pathMergeIn, pathV,
+  CELL_W, ROW_H, colX, computeGraphRows, laneColor, pathForkOut, pathMergeIn, pathV,
 } from '../src/client/git-graph.ts'
 
 /** A minimal graph log entry; hashes double as the full hashes. */
@@ -146,21 +146,18 @@ describe('path geometry', () => {
 
   it('spans a vertical line between arbitrary y bounds', () => {
     expect(pathV(12, 0, 20)).toBe('M 12 0 L 12 20')
-    expect(pathV(12, 20, 56)).toBe('M 12 20 L 12 56')
+    expect(pathV(12, 20, ROW_H)).toBe(`M 12 20 L 12 ${ROW_H}`)
   })
 
   it('ends a merge arc at the dot mid', () => {
-    const d = pathMergeIn(12, 36, 28) // taller row: mid = 28
-    expect(d.endsWith('L 36 28')).toBe(true)
+    const d = pathMergeIn(12, 36, ROW_H / 2)
+    expect(d.endsWith(`L 36 ${ROW_H / 2}`)).toBe(true)
     expect(d).toContain('M 12 0')
   })
 
-  it('forks down to the ACTUAL row height (tag chips make rows taller)', () => {
-    // nominal 40px row
-    expect(pathForkOut(12, 36, 20, 40).endsWith('L 36 40')).toBe(true)
-    // a row that grew to 56px (wrapped chips): the fork must reach the bottom
-    expect(pathForkOut(12, 36, 28, 56).endsWith('L 36 56')).toBe(true)
+  it('forks down to the nominal row bottom (y-stretch to the real row height happens in the SVG viewBox)', () => {
+    expect(pathForkOut(12, 36, ROW_H / 2).endsWith(`L 36 ${ROW_H}`)).toBe(true)
     // same-column fork: a plain vertical to the row bottom
-    expect(pathForkOut(12, 12, 28, 56)).toBe('M 12 28 L 12 56')
+    expect(pathForkOut(12, 12, ROW_H / 2)).toBe(`M 12 ${ROW_H / 2} L 12 ${ROW_H}`)
   })
 })

--- a/tests/git-graph.spec.ts
+++ b/tests/git-graph.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Lane-layout tests for the history graph (src/client/git-graph.ts) — the
+ * pure geometry that feeds the GitGraphSvg renderer. The input is the
+ * topo-ordered `git log` rows the host already returns; each test below
+ * hand-builds a small commit DAG and asserts the classic git-graph shapes
+ * (straight main line, branch/merge forks, diamond joins, octopus merges,
+ * root commits, column recycling).
+ */
+import { describe, expect, it } from 'vitest'
+import type { GitGraphEntry } from '../src/client/api.ts'
+import { CELL_W, computeGraphRows, laneColor } from '../src/client/git-graph.ts'
+
+/** A minimal graph log entry; hashes double as the full hashes. */
+function commit(hash: string, parents: string[], refs = ''): GitGraphEntry {
+  return {
+    hash,
+    hashFull: hash,
+    subject: `commit ${hash}`,
+    author: 'Alice',
+    date: '2024-01-01 00:00:00 +0000',
+    refs,
+    parents,
+  }
+}
+
+describe('computeGraphRows', () => {
+  it('lays a linear history out on a single lane (straight line)', () => {
+    const { rows, graphWidth } = computeGraphRows([
+      commit('c1', ['c2']),
+      commit('c2', ['c3']),
+      commit('c3', []),
+    ])
+    expect(rows.map(r => r.dotCol)).toEqual([0, 0, 0])
+    expect(rows[0]!.below.has(0)).toBe(true)
+    expect(rows[1]!.below.has(0)).toBe(true)
+    expect(rows[2]!.below.size).toBe(0) // root: the lane ends
+    expect(rows.every(r => r.merges.length === 0 && r.forks.length === 0)).toBe(true)
+    expect(graphWidth).toBe(1 * CELL_W + 6)
+  })
+
+  it('forks a second parent out and joins a diamond back with a merge arc', () => {
+    const { rows } = computeGraphRows([
+      commit('a', ['b']),      // main tip
+      commit('b', ['c']),      //
+      commit('c', ['d', 'e']), // merge: d continues col 0, e forks to col 1
+      commit('d', ['f']),      // col 0 continues
+      commit('e', ['f']),      // col 1 also carries f → diamond
+      commit('f', []),         // displayed on the leftmost lane; col 1 arcs in
+    ])
+    expect(rows.map(r => r.dotCol)).toEqual([0, 0, 0, 0, 1, 0])
+    // the merge row forks its second parent to a new lane
+    expect(rows[2]!.forks.map(f => f.col)).toEqual([1])
+    // the branch lane stays a straight vertical through the sibling rows
+    expect(rows[3]!.below.has(1)).toBe(true)
+    expect(rows[3]!.merges.length).toBe(0)
+    // e's parent f is NOT a merge at e's row — the lane continues (f is later)
+    expect(rows[4]!.merges.length).toBe(0)
+    expect(rows[4]!.below.has(0)).toBe(true)
+    // the diamond join: col 1 carries the same hash as the dot → merge arc
+    expect(rows[5]!.dotCol).toBe(0)
+    expect(rows[5]!.merges.map(m => m.col)).toEqual([1])
+    expect(rows[5]!.below.has(1)).toBe(false)
+  })
+
+  it('forks every extra parent of an octopus merge, then joins them all', () => {
+    const { rows } = computeGraphRows([
+      commit('a', ['b', 'c', 'd']),
+      commit('b', ['e']),
+      commit('c', ['e']),
+      commit('d', ['e']),
+      commit('e', []),
+    ])
+    expect(rows[0]!.dotCol).toBe(0)
+    expect(rows[0]!.forks.map(f => f.col)).toEqual([1, 2])
+    expect(rows[1]!.dotCol).toBe(0)
+    expect(rows[2]!.dotCol).toBe(1)
+    expect(rows[3]!.dotCol).toBe(2)
+    // e is displayed on the leftmost of the three lanes carrying it; the
+    // other two end with merge arcs into the dot
+    expect(rows[4]!.dotCol).toBe(0)
+    expect(rows[4]!.merges.map(m => m.col).sort()).toEqual([1, 2])
+    expect(rows[4]!.below.size).toBe(0) // root: everything ends
+  })
+
+  it('does not reuse a merge-freed column in the same row, but recycles it later', () => {
+    const { rows } = computeGraphRows([
+      commit('a', ['b']),          // 0
+      commit('b', ['c', 'd']),     // 1: d forks to col 1
+      commit('c', ['e']),          // 2: col 0 continues
+      commit('d', ['e']),          // 3: col 1 also carries e
+      commit('e', ['f', 'g']),     // 4: e joins at col 0 (col 1 merges in), g forks
+      commit('f', ['h']),          // 5
+      commit('g', ['h']),          // 6
+      commit('h', ['i']),          // 7: col 2 merges in
+      commit('i', ['j', 'k']),     // 8: k recycles the column freed at row e
+      commit('j', []),             // 9
+      commit('k', []),             // 10
+    ])
+    // row e: the fork for g must NOT reuse col 1 in the same row its merge
+    // arc used it (no V bounce) — it takes a brand-new column instead
+    const rowE = rows[4]!
+    expect(rowE.merges.map(m => m.col)).toEqual([1])
+    expect(rowE.forks.map(f => f.col)).toEqual([2])
+    // row h: the second diamond also joins into the leftmost lane
+    expect(rows[7]!.merges.map(m => m.col)).toEqual([2])
+    // row i: col 1 (freed back at row e) is a normal free column again →
+    // the fork for k recycles it instead of widening the graph
+    expect(rows[8]!.forks.map(f => f.col)).toEqual([1])
+    expect(rows[8]!.lanes.has(1)).toBe(true)
+    expect(rows[9]!.dotCol).toBe(0)
+    expect(rows[10]!.dotCol).toBe(1)
+  })
+
+  it('joins a fork into an existing lane when the parent was already promised', () => {
+    const { rows } = computeGraphRows([
+      commit('a', ['b', 'p']), // p forks to col 1
+      commit('b', ['c']),      // main continues on col 0
+      commit('c', ['d', 'p']), // merge: p's lane (col 1) already exists
+      commit('d', []),         // main reaches a root
+      commit('p', []),         // p is displayed on col 1
+    ])
+    // row c: the second parent p needs no new lane — the fork joins col 1
+    expect(rows[2]!.dotCol).toBe(0)
+    expect(rows[2]!.forks.map(f => f.col)).toEqual([1])
+    // no diamond anywhere here → no merge arcs at all
+    expect(rows.every(r => r.merges.length === 0)).toBe(true)
+    // p is displayed on the lane the forks kept feeding
+    expect(rows[4]!.dotCol).toBe(1)
+    expect(rows[4]!.below.size).toBe(0)
+  })
+
+  it('assigns a stable color per column that cycles through the palette', () => {
+    expect(laneColor(0)).toBe('var(--gg-lane-0)')
+    expect(laneColor(5)).toBe('var(--gg-lane-5)')
+    expect(laneColor(6)).toBe('var(--gg-lane-0)') // wraps
+  })
+})

--- a/tests/git-graph.spec.ts
+++ b/tests/git-graph.spec.ts
@@ -8,7 +8,9 @@
  */
 import { describe, expect, it } from 'vitest'
 import type { GitGraphEntry } from '../src/client/api.ts'
-import { CELL_W, computeGraphRows, laneColor } from '../src/client/git-graph.ts'
+import {
+  CELL_W, colX, computeGraphRows, laneColor, pathForkOut, pathMergeIn, pathV,
+} from '../src/client/git-graph.ts'
 
 /** A minimal graph log entry; hashes double as the full hashes. */
 function commit(hash: string, parents: string[], refs = ''): GitGraphEntry {
@@ -133,5 +135,32 @@ describe('computeGraphRows', () => {
     expect(laneColor(0)).toBe('var(--gg-lane-0)')
     expect(laneColor(5)).toBe('var(--gg-lane-5)')
     expect(laneColor(6)).toBe('var(--gg-lane-0)') // wraps
+  })
+})
+
+describe('path geometry', () => {
+  it('places the dot x at the column center', () => {
+    expect(colX(0)).toBe(CELL_W / 2)
+    expect(colX(2)).toBe(2 * CELL_W + CELL_W / 2)
+  })
+
+  it('spans a vertical line between arbitrary y bounds', () => {
+    expect(pathV(12, 0, 20)).toBe('M 12 0 L 12 20')
+    expect(pathV(12, 20, 56)).toBe('M 12 20 L 12 56')
+  })
+
+  it('ends a merge arc at the dot mid', () => {
+    const d = pathMergeIn(12, 36, 28) // taller row: mid = 28
+    expect(d.endsWith('L 36 28')).toBe(true)
+    expect(d).toContain('M 12 0')
+  })
+
+  it('forks down to the ACTUAL row height (tag chips make rows taller)', () => {
+    // nominal 40px row
+    expect(pathForkOut(12, 36, 20, 40).endsWith('L 36 40')).toBe(true)
+    // a row that grew to 56px (wrapped chips): the fork must reach the bottom
+    expect(pathForkOut(12, 36, 28, 56).endsWith('L 36 56')).toBe(true)
+    // same-column fork: a plain vertical to the row bottom
+    expect(pathForkOut(12, 12, 28, 56)).toBe('M 12 28 L 12 56')
   })
 })

--- a/tests/git.spec.ts
+++ b/tests/git.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parseUnifiedDiff } from '../src/client/DiffView.tsx'
-import { parseLogLines, parsePorcelainZ } from '../src/git.ts'
+import { parseGraphLines, parseLogLines, parsePorcelainZ } from '../src/git.ts'
 
 describe('git parsing', () => {
   it('parses porcelain -z entries including renames', () => {
@@ -109,6 +109,36 @@ describe('git parsing', () => {
       { kind: 'del', text: 'one', oldNum: 1, newNum: null },
       { kind: 'del', text: 'two', oldNum: 2, newNum: null },
       { kind: 'meta', text: ' No newline at end of file', oldNum: null, newNum: null },
+    ])
+  })
+
+  it('parses graph log rows with parent hashes (first-parent first, root = empty)', () => {
+    const full = 'abc1234def5678abc1234def5678abc1234def5678'
+    const parent1 = 'def5678abc1234def5678abc1234def5678abc1234'
+    const parent2 = 'fedcba9876543210fedcba9876543210fedcba98'
+    const rows = parseGraphLines(
+      `${full}\x1f${parent1} ${parent2}\x1fMerge branch\x1fAlice\x1f2024-01-01 10:00:00 +0800\x1fHEAD -> main\n`
+      + `${parent1}\x1f\x1fRoot commit\x1fBob\x1f2024-01-02 10:00:00 +0800\x1f\n`,
+    )
+    expect(rows).toEqual([
+      {
+        hash: full.slice(0, 7),
+        hashFull: full,
+        subject: 'Merge branch',
+        author: 'Alice',
+        date: '2024-01-01 10:00:00 +0800',
+        refs: 'HEAD -> main',
+        parents: [parent1, parent2],
+      },
+      {
+        hash: parent1.slice(0, 7),
+        hashFull: parent1,
+        subject: 'Root commit',
+        author: 'Bob',
+        date: '2024-01-02 10:00:00 +0800',
+        refs: '',
+        parents: [],
+      },
     ])
   })
 


### PR DESCRIPTION
## 背景

Git 面板历史列表原本是纯文本行；工作区已有未提交的 host/API 半成品（graphLog / git.log-graph 路由 / gitLogGraph API），缺客户端 lane 布局与渲染。本 PR 参考 docs/prototypes/gitgraph-lines 原型 demo 移植其 lane/弧线/圆点视觉语言完成。

## 改动

- **src/client/git-graph.ts**（新）：纯布局 computeGraphRows——topo 序提交 → dot lane / 菱形汇入弧 / 分叉弧 / 列回收；路径生成与原型逐行对齐；lane 色 = var(--gg-lane-N)（列号取色循环），默认映射 DSH 语义令牌（皮肤兼容，无硬编码色）
- **src/client/GitGraph.tsx**（新）：每行提交图 SVG 渲染；高度纯 CSS 跟随行高（absolute top/bottom + viewBox y 拉伸 + CSS 圆点），无 JS 测量、无反馈循环，tag chips 换行不留空白
- **src/client/GitView.tsx**：历史改用 api.gitLogGraph（--topo-order 分页），行首渲染 lane 图；点击/右键菜单/分页行为不变
- **host/API 半**（src/git.ts / src/index.ts / src/client/api.ts）：工作区既有 WIP，随本特性一并提交，并补 parseGraphLines 测试
- **测试**：tests/git-graph.spec.ts（直线/分支合并/菱形/章鱼/列回收/既有 lane 复用/列色/路径几何）+ tests/git.spec.ts
- **文档**：docs/plans/2026-08-19-git-graph-lanes-design.md + AGENTS.md §10

## 验证

- pnpm typecheck / pnpm build 通过
- pnpm test 608 通过；27 失败为预存环境问题（node-pty 原生模块 + zh locale，clean 树同样失败）
- 真实 DAG（本仓库 main 40 提交含 merge）布局验证通过

## 基线

已 merge offical/main（含 3 个 docs/plans 新提交）。