### PR TITLE
feat(sidebar): support DSH Desktop advanced mode layout push

### DIFF
--- a/src/client/layout.css
+++ b/src/client/layout.css
@@ -24,6 +24,19 @@
   transition: margin-right var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
 
+/* DSH Desktop advanced mode replaces the upstream AppFrame with its own
+   .dshDesktopFrame grid. Reserve the sidebar width/height on that frame too,
+   so the fixed panels occupy layout space instead of overlaying the
+   conversation / input bar. */
+body[data-dsh-desktop-mode="advanced"] .dshDesktopFrame {
+  box-sizing: border-box;
+  padding-right: var(--dsh-sidebar-width, 0px);
+  padding-bottom: var(--dsh-sidebar-height, 0px);
+  transition:
+    padding-right var(--ds-transition-duration-slow) var(--ds-ease-in-out),
+    padding-bottom var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+}
+
 /* The AppFrame's grid items are sidebarCol, centerCol, detailsCol (children
    1-3 of #root > div[data-slot="root"] > div) — nth-child(2) is the center
    column. A stretched grid item shrinks by its margins, so the conversation


### PR DESCRIPTION
## 适配项目

- 本 PR 提交到：`omdsh-dev/DSH-better-sidebar`（better-sidebar 插件）
- 适配对象：**DSH Desktop**（https://github.com/anywhere-labs/deepseek-harness-desktop ）的高级模式（advanced mode）

## 背景

DSH Desktop 在高级模式（`dsh-desktop.mode: advanced`）下会使用自定义的 `.dshDesktopFrame` 网格布局，而不是标准 Web 的 `#root` AppFrame 三栏布局。

better-sidebar 原来的布局推挤只写了：

```css
#root {
  margin-right: var(--dsh-sidebar-width, 0px);
}
```

所以在 DSH Desktop 高级模式下这个规则不生效，侧边栏会变成 fixed 悬浮层，**遮挡会话框/输入框**，而不是在会话区旁边把空间挤出来。

## 改动

在 `src/client/layout.css` 中增加 DSH Desktop 高级模式适配：

```css
body[data-dsh-desktop-mode="advanced"] .dshDesktopFrame {
  box-sizing: border-box;
  padding-right: var(--dsh-sidebar-width, 0px);
  padding-bottom: var(--dsh-sidebar-height, 0px);
  transition:
    padding-right var(--ds-transition-duration-slow) var(--ds-ease-in-out),
    padding-bottom var(--ds-transition-duration-slow) var(--ds-ease-in-out);
}
```

这样 DSH Desktop 高级模式下，`.dshDesktopFrame` 会从右侧和底部让出空间，侧边栏/底部面板从“遮挡”变为“占位推挤”。

## 验证

- 兼容模式（compatibility）：原本正常，不受影响。
- DSH Desktop 高级模式（advanced）：修复后侧边栏不再遮挡会话区，而是从右侧正常展开。
