### PR TITLE
feat(git): 支持 Git Graph 多分支 DAG 拓扑图与提交连线可视化

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "cordis": "^4.0.0-rc.7",
     "jsdom": "^29.1.1",
     "lightningcss": "^1.32.0",
+    "material-icon-theme": "^5.37.0",
     "react": "^18.2.0",
     "react-dom": "18.2.0",
     "tsdown": "^0.22.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       lightningcss:
         specifier: ^1.32.0
         version: 1.33.0
+      material-icon-theme:
+        specifier: ^5.37.0
+        version: 5.37.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1483,6 +1486,9 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
+  chroma-js@3.2.0:
+    resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1764,6 +1770,9 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1960,6 +1969,10 @@ packages:
     resolution: {integrity: sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  material-icon-theme@5.37.0:
+    resolution: {integrity: sha512-/F5llOVU0DZ88V+wmPlEbBqi8FochPg5XaJ7zqVzGCTTygeFnpIpdVQQTRElEnHyxSWRMfF0wBbOqwFKnujFLA==}
+    engines: {vscode: ^1.55.0}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -3998,6 +4011,8 @@ snapshots:
 
   character-entities@2.0.2: {}
 
+  chroma-js@3.2.0: {}
+
   clsx@2.1.1: {}
 
   comma-separated-tokens@2.0.3: {}
@@ -4273,6 +4288,8 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -4443,6 +4460,11 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.3.0: {}
+
+  material-icon-theme@5.37.0:
+    dependencies:
+      chroma-js: 3.2.0
+      fast-deep-equal: 3.1.3
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:

--- a/scripts/build-icons.cjs
+++ b/scripts/build-icons.cjs
@@ -1,0 +1,493 @@
+const fs = require('fs');
+const path = require('path');
+const iconDir = 'node_modules/material-icon-theme/icons';
+
+function parseSvg(svgStr) {
+  const vbMatch = svgStr.match(/viewBox="([^"]+)"/);
+  const viewBox = vbMatch ? vbMatch[1] : '0 0 24 24';
+  const xmlSpace = svgStr.includes('xml:space="preserve"') ? ' xmlSpace="preserve"' : '';
+  const inner = svgStr.replace(/<svg[^>]*>/, '').replace(/<\/svg>/, '').trim();
+  const jsxInner = inner
+    .replace(/stop-color=/g, 'stopColor=')
+    .replace(/stop-opacity=/g, 'stopOpacity=')
+    .replace(/stroke-width=/g, 'strokeWidth=')
+    .replace(/stroke-linecap=/g, 'strokeLinecap=')
+    .replace(/stroke-linejoin=/g, 'strokeLinejoin=')
+    .replace(/stroke-miterlimit=/g, 'strokeMiterlimit=')
+    .replace(/stroke-dasharray=/g, 'strokeDasharray=')
+    .replace(/stroke-dashoffset=/g, 'strokeDashoffset=')
+    .replace(/stroke-opacity=/g, 'strokeOpacity=')
+    .replace(/fill-rule=/g, 'fillRule=')
+    .replace(/clip-rule=/g, 'clipRule=')
+    .replace(/fill-opacity=/g, 'fillOpacity=')
+    .replace(/gradientTransform=/g, 'gradientTransform=')
+    .replace(/gradientUnits=/g, 'gradientUnits=')
+    .replace(/data-mit-no-recolor="true"/g, '');
+  return { viewBox, xmlSpace, jsxInner };
+}
+
+const iconNames = [
+  'typescript', 'react_ts', 'javascript', 'react', 'vue', 'svelte', 'python', 'rust', 'go',
+  'cpp', 'c', 'csharp', 'java', 'kotlin', 'swift', 'php', 'ruby', 'dart', 'lua', 'zig',
+  'html', 'css', 'sass', 'less', 'json', 'yaml', 'toml', 'markdown', 'console', 'powershell',
+  'database', 'docker', 'git', 'nodejs', 'npm', 'pnpm', 'yarn', 'bun', 'playwright', 'vite',
+  'vitest', 'tsdown', 'tailwindcss', 'postcss', 'eslint', 'prettier', 'tsconfig', 'readme', 'certificate',
+  'pdf', 'image', 'svg', 'table', 'word', 'powerpoint', 'zip', 'font', 'tune', 'document',
+  'settings', 'graphql', 'proto', 'webassembly', 'audio', 'video', 'file', 'jest', 'webpack',
+  'rollup', 'babel', 'next', 'remix', 'astro', 'nuxt', 'turborepo', 'biome', 'deno'
+];
+
+let out = '';
+out += '/**\n';
+out += ' * Icons the sidebar needs beyond the primitives set: a terminal glyph (the\n';
+out += ' * icon library has none), a diff glyph, and the two panel-toggle glyphs for\n';
+out += ' * the top-right cluster. Per-tab icons live on the tab descriptors\n';
+out += ' * (`descriptor.icon`), not in a type-keyed switch — the icon mapping was\n';
+out += ' * registry-ized with the tab types.\n';
+out += ' */\n';
+out += "import type { ReactNode } from 'react'\n";
+out += "import type { IconProps } from '@deepseek-ai/dsh-client-ui-primitives'\n\n";
+
+out += `export const IconPanelRightOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.5" y="2" width="13" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <rect x="10.5" y="3.25" width="2.75" height="9.5" rx="1" fill="currentColor" stroke="none" />
+  </svg>
+)
+
+export const IconPanelBottomOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.5" y="2" width="13" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <rect x="3.25" y="10" width="9.5" height="2.75" rx="1" fill="currentColor" stroke="none" />
+  </svg>
+)
+
+export const IconTerminalOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M4.5 6.25 6.75 8 4.5 9.75" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M8.5 10.4h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+)
+
+export const IconDiffOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.5" y="1.5" width="13" height="13" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M4 5h3M5.5 3.5v3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path d="M9.5 12.5h2.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+)
+
+export const IconStopOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="4" y="4" width="8" height="8" rx="1.5" fill="currentColor" stroke="none" />
+  </svg>
+)
+
+export const IconImageOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.5" />
+    <circle cx="5.5" cy="6" r="1.2" stroke="currentColor" strokeWidth="1.5" />
+    <path d="m3.5 12 3-3 2.25 2.25L11.5 8.5 13 10.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+export const IconPdfOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3.5 1.5h6.5L13.5 5v9.5h-10z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M9.5 1.5V5h4" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M5 13.5v-3h1.4c.75 0 1.1.32 1.1.85 0 .54-.35.85-1.1.85H5.3" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M8.3 13.5v-3h1.05c.8 0 1.35.5 1.35 1.5s-.55 1.5-1.35 1.5z" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M11.6 13.5v-3h1.3" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+  </svg>
+)
+
+export const IconMarkdownOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M4 10.5V5.5l2 2.5 2-2.5v5M9.5 10.5v-5l2 2.5 2-2.5v5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+export const IconHtmlOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3.5 1.5h6.5L13.5 5v9.5h-10z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M9.5 1.5V5h4" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    <path d="M5.6 13.2 4.2 10l1.4-3.2M7.4 6.8 8.8 10l-1.4 3.2" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+export const IconGlobeOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
+    <ellipse cx="8" cy="8" rx="2.8" ry="6.5" stroke="currentColor" strokeWidth="1.5" />
+    <path d="M1.5 8h13M8 1.5c-2.4 1.8-2.4 11.2 0 13M8 1.5c2.4 1.8 2.4 11.2 0 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+)
+
+export const IconMaximizeOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2.5 6.5V2.5H6.5M13.5 6.5V2.5H9.5M2.5 9.5v4H6.5M13.5 9.5v4H9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+export const IconRestoreOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6.5 2.5v4H2.5M9.5 2.5v4h4M6.5 13.5v-4H2.5M9.5 13.5v-4h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+`;
+
+out += '// ── Official Material Icon Theme SVGs ──────────────────────────────────\n\n';
+out += 'const MATERIAL_ICONS: Record<string, (size: number) => ReactNode> = {\n';
+
+for (const name of iconNames) {
+  const p = path.join(iconDir, name + '.svg');
+  const raw = fs.readFileSync(p, 'utf8');
+  const { viewBox, xmlSpace, jsxInner } = parseSvg(raw);
+  out += `  '${name}': (size: number) => (\n    <svg width={size} height={size}${xmlSpace} viewBox="${viewBox}" fill="none" style={{ flexShrink: 0 }}>\n      ${jsxInner}\n    </svg>\n  ),\n`;
+}
+
+out += '}\n\n';
+
+out += `// Exact filename to icon ID (lowercased)
+const EXACT_FILES: Record<string, string> = {
+  'package.json': 'nodejs',
+  'package-lock.json': 'nodejs',
+  '.nvmrc': 'nodejs',
+  '.node-version': 'nodejs',
+  '.esmrc': 'nodejs',
+  'pnpm-lock.yaml': 'pnpm',
+  'pnpm-workspace.yaml': 'pnpm',
+  '.pnpmfile.cjs': 'pnpm',
+  'yarn.lock': 'yarn',
+  '.yarnrc': 'yarn',
+  '.yarnrc.yml': 'yarn',
+  '.yarnrc.yaml': 'yarn',
+  'bun.lockb': 'bun',
+  'bun.lock': 'bun',
+  'bunfig.toml': 'bun',
+  '.bun-version': 'bun',
+  'deno.json': 'deno',
+  'deno.jsonc': 'deno',
+  'deno.lock': 'deno',
+  'turbo.json': 'turborepo',
+  'turbo.jsonc': 'turborepo',
+  'biome.json': 'biome',
+  'biome.jsonc': 'biome',
+  'tsconfig.json': 'tsconfig',
+  'tsconfig.build.json': 'tsconfig',
+  'tsconfig.esm.json': 'tsconfig',
+  'tsconfig.node.json': 'tsconfig',
+  'tsconfig.app.json': 'tsconfig',
+  'tsconfig.spec.json': 'tsconfig',
+  'jsconfig.json': 'tsconfig',
+  'tsdown.config.ts': 'tsdown',
+  'tsdown.config.js': 'tsdown',
+  'tsdown.config.mjs': 'tsdown',
+  'tsdown.config.cjs': 'tsdown',
+  'tsdown.config.json': 'tsdown',
+  'playwright.config.ts': 'playwright',
+  'playwright.config.js': 'playwright',
+  'playwright.config.mjs': 'playwright',
+  'playwright.config.cjs': 'playwright',
+  'vitest.config.ts': 'vitest',
+  'vitest.config.js': 'vitest',
+  'vitest.config.mjs': 'vitest',
+  'vitest.config.cjs': 'vitest',
+  'vitest.config.mts': 'vitest',
+  'vitest.config.cts': 'vitest',
+  'jest.config.js': 'jest',
+  'jest.config.ts': 'jest',
+  'jest.config.cjs': 'jest',
+  'jest.config.mjs': 'jest',
+  'jest.config.json': 'jest',
+  'vite.config.ts': 'vite',
+  'vite.config.js': 'vite',
+  'vite.config.mjs': 'vite',
+  'vite.config.cjs': 'vite',
+  'vite.config.mts': 'vite',
+  'vite.config.cts': 'vite',
+  'rollup.config.js': 'rollup',
+  'rollup.config.ts': 'rollup',
+  'rollup.config.mjs': 'rollup',
+  'rollup.config.cjs': 'rollup',
+  'webpack.config.js': 'webpack',
+  'webpack.config.ts': 'webpack',
+  'webpack.config.cjs': 'webpack',
+  'webpack.config.mjs': 'webpack',
+  'next.config.js': 'next',
+  'next.config.ts': 'next',
+  'next.config.mjs': 'next',
+  'nuxt.config.js': 'nuxt',
+  'nuxt.config.ts': 'nuxt',
+  'astro.config.mjs': 'astro',
+  'astro.config.js': 'astro',
+  'astro.config.ts': 'astro',
+  'tailwind.config.js': 'tailwindcss',
+  'tailwind.config.ts': 'tailwindcss',
+  'tailwind.config.mjs': 'tailwindcss',
+  'tailwind.config.cjs': 'tailwindcss',
+  'postcss.config.js': 'postcss',
+  'postcss.config.ts': 'postcss',
+  'postcss.config.mjs': 'postcss',
+  'postcss.config.cjs': 'postcss',
+  'postcss.config.json': 'postcss',
+  '.postcssrc': 'postcss',
+  '.postcssrc.json': 'postcss',
+  '.postcssrc.js': 'postcss',
+  'eslint.config.js': 'eslint',
+  'eslint.config.mjs': 'eslint',
+  'eslint.config.cjs': 'eslint',
+  'eslint.config.ts': 'eslint',
+  'eslint.config.mts': 'eslint',
+  'eslint.config.cts': 'eslint',
+  '.eslintrc': 'eslint',
+  '.eslintrc.json': 'eslint',
+  '.eslintrc.js': 'eslint',
+  '.eslintrc.cjs': 'eslint',
+  '.eslintrc.yml': 'eslint',
+  '.eslintrc.yaml': 'eslint',
+  'prettier.config.js': 'prettier',
+  'prettier.config.mjs': 'prettier',
+  'prettier.config.cjs': 'prettier',
+  'prettier.config.ts': 'prettier',
+  '.prettierrc': 'prettier',
+  '.prettierrc.json': 'prettier',
+  '.prettierrc.js': 'prettier',
+  '.prettierrc.cjs': 'prettier',
+  '.prettierrc.yml': 'prettier',
+  '.prettierrc.yaml': 'prettier',
+  '.prettierrc.toml': 'prettier',
+  'cargo.toml': 'rust',
+  'cargo.lock': 'rust',
+  'go.mod': 'go',
+  'go.sum': 'go',
+  'go.work': 'go',
+  'requirements.txt': 'python',
+  'pipfile': 'python',
+  'pipfile.lock': 'python',
+  'poetry.lock': 'python',
+  'pyproject.toml': 'python',
+  'gemfile': 'ruby',
+  'gemfile.lock': 'ruby',
+  'dockerfile': 'docker',
+  'docker-compose.yml': 'docker',
+  'docker-compose.yaml': 'docker',
+  '.dockerignore': 'docker',
+  '.gitignore': 'git',
+  '.gitmodules': 'git',
+  '.gitattributes': 'git',
+  '.gitkeep': 'git',
+  '.env': 'tune',
+  'license': 'certificate',
+  'licence': 'certificate',
+  'copying': 'certificate',
+  'readme': 'readme',
+  'readme.md': 'readme',
+  'readme_en.md': 'readme',
+  'readme.txt': 'readme',
+  'changelog': 'readme',
+  'changelog.md': 'readme',
+  '.editorconfig': 'settings',
+  'dsh.plugin.json': 'json',
+}
+
+// Extension to icon ID (lowercased)
+const EXT_MAP: Record<string, string> = {
+  ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
+  tsx: 'react_ts',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'react',
+  vue: 'vue',
+  svelte: 'svelte',
+  astro: 'astro',
+  py: 'python',
+  pyw: 'python',
+  ipynb: 'python',
+  rs: 'rust',
+  go: 'go',
+  cpp: 'cpp',
+  hpp: 'cpp',
+  cc: 'cpp',
+  cxx: 'cpp',
+  'c++': 'cpp',
+  hh: 'cpp',
+  hxx: 'cpp',
+  c: 'c',
+  h: 'c',
+  cs: 'csharp',
+  csx: 'csharp',
+  csproj: 'csharp',
+  sln: 'csharp',
+  java: 'java',
+  jar: 'java',
+  class: 'java',
+  kt: 'kotlin',
+  kts: 'kotlin',
+  swift: 'swift',
+  php: 'php',
+  rb: 'ruby',
+  erb: 'ruby',
+  gemspec: 'ruby',
+  dart: 'dart',
+  lua: 'lua',
+  zig: 'zig',
+  html: 'html',
+  htm: 'html',
+  xhtml: 'html',
+  css: 'css',
+  scss: 'sass',
+  sass: 'sass',
+  less: 'less',
+  json: 'json',
+  jsonc: 'json',
+  json5: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'toml',
+  ini: 'settings',
+  conf: 'settings',
+  cfg: 'settings',
+  properties: 'settings',
+  xml: 'settings',
+  xsl: 'settings',
+  xsd: 'settings',
+  plist: 'settings',
+  md: 'markdown',
+  markdown: 'markdown',
+  mdx: 'markdown',
+  sh: 'console',
+  bash: 'console',
+  zsh: 'console',
+  fish: 'console',
+  ps1: 'powershell',
+  bat: 'console',
+  cmd: 'console',
+  sql: 'database',
+  db: 'database',
+  sqlite: 'database',
+  sqlite3: 'database',
+  prisma: 'database',
+  graphql: 'graphql',
+  gql: 'graphql',
+  proto: 'proto',
+  wasm: 'webassembly',
+  wat: 'webassembly',
+  pdf: 'pdf',
+  png: 'image',
+  jpg: 'image',
+  jpeg: 'image',
+  gif: 'image',
+  webp: 'image',
+  ico: 'image',
+  bmp: 'image',
+  avif: 'image',
+  tiff: 'image',
+  svg: 'svg',
+  doc: 'word',
+  docx: 'word',
+  odt: 'word',
+  rtf: 'word',
+  xls: 'table',
+  xlsx: 'table',
+  csv: 'table',
+  tsv: 'table',
+  ods: 'table',
+  ppt: 'powerpoint',
+  pptx: 'powerpoint',
+  odp: 'powerpoint',
+  zip: 'zip',
+  tar: 'zip',
+  gz: 'zip',
+  tgz: 'zip',
+  '7z': 'zip',
+  rar: 'zip',
+  bz2: 'zip',
+  xz: 'zip',
+  txt: 'document',
+  log: 'document',
+  ttf: 'font',
+  otf: 'font',
+  woff: 'font',
+  woff2: 'font',
+  eot: 'font',
+  mp3: 'audio',
+  wav: 'audio',
+  ogg: 'audio',
+  flac: 'audio',
+  m4a: 'audio',
+  aac: 'audio',
+  wma: 'audio',
+  mp4: 'video',
+  mov: 'video',
+  avi: 'video',
+  mkv: 'video',
+  webm: 'video',
+  flv: 'video',
+  wmv: 'video',
+}
+
+function renderIcon(name: string, size: number): ReactNode {
+  const fn = MATERIAL_ICONS[name]
+  if (fn !== undefined) return fn(size)
+  return MATERIAL_ICONS['file']?.(size) ?? null
+}
+
+/**
+ * Return the official Material Icon Theme vector SVG for a file.
+ * Extracted directly from Philipp Kief's official vscode-material-icon-theme package.
+ */
+export function fileIconFor(fileName: string, size = 14): ReactNode {
+  const name = (fileName || '').trim()
+  const lower = name.toLowerCase()
+  const base = lower.replace(/^.*[\\\\/]/, '')
+
+  // 1. Exact full filename match (e.g. package.json, pnpm-lock.yaml, tsconfig.json, etc.)
+  const exactIcon = EXACT_FILES[base]
+  if (exactIcon !== undefined) {
+    return renderIcon(exactIcon, size)
+  }
+
+  // 2. Prefix & pattern matches for special config / dotfiles
+  if (base.startsWith('.env')) return renderIcon('tune', size)
+  if (base.startsWith('tsconfig.') || base.startsWith('jsconfig.')) return renderIcon('tsconfig', size)
+  if (base.startsWith('tsdown.config.')) return renderIcon('tsdown', size)
+  if (base.startsWith('playwright.config.')) return renderIcon('playwright', size)
+  if (base.startsWith('vitest.config.')) return renderIcon('vitest', size)
+  if (base.startsWith('jest.config.')) return renderIcon('jest', size)
+  if (base.startsWith('vite.config.')) return renderIcon('vite', size)
+  if (base.startsWith('rollup.config.')) return renderIcon('rollup', size)
+  if (base.startsWith('webpack.config.')) return renderIcon('webpack', size)
+  if (base.startsWith('next.config.')) return renderIcon('next', size)
+  if (base.startsWith('nuxt.config.')) return renderIcon('nuxt', size)
+  if (base.startsWith('astro.config.')) return renderIcon('astro', size)
+  if (base.startsWith('tailwind.config.')) return renderIcon('tailwindcss', size)
+  if (base.startsWith('postcss.config.') || base.startsWith('.postcssrc')) return renderIcon('postcss', size)
+  if (base.startsWith('eslint.config.') || base.startsWith('.eslintrc')) return renderIcon('eslint', size)
+  if (base.startsWith('prettier.config.') || base.startsWith('.prettierrc')) return renderIcon('prettier', size)
+  if (base.startsWith('dockerfile.') || base.startsWith('docker-compose.')) return renderIcon('docker', size)
+  if (base.startsWith('readme.') || base.startsWith('readme_') || base.startsWith('changelog.') || base.startsWith('changelog_')) return renderIcon('readme', size)
+  if (base.startsWith('license.') || base.startsWith('licence.') || base.startsWith('copying.')) return renderIcon('certificate', size)
+
+  // 3. Extension match
+  const dot = base.lastIndexOf('.')
+  if (dot !== -1) {
+    const ext = base.slice(dot + 1)
+    const extIcon = EXT_MAP[ext]
+    if (extIcon !== undefined) {
+      return renderIcon(extIcon, size)
+    }
+  }
+
+  // 4. Default fallback: Material Icon document/file
+  return renderIcon('file', size)
+}
+`;
+
+fs.writeFileSync('src/client/icons.tsx', out);
+console.log('Successfully written src/client/icons.tsx!');

--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -22,6 +22,7 @@ import {
   IconLinkOutline16, Menu, writeClipboard,
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { api, downloadUrl, type FsEntry } from './api.ts'
+import { fileIconFor } from './icons.tsx'
 import { relativeTo } from './paths.ts'
 import { t } from './locales.ts'
 import css from './sidebar.module.css'
@@ -207,7 +208,7 @@ export function FileTree(props: {
           }}
           onContextMenu={(event) => { openRowMenu(event, entry.path, false) }}
         >
-          <IconCodeOutline16 size={14} />
+          {fileIconFor(entry.name, 14)}
           <span className={css.explorerName}>{entry.name}</span>
           {entry.isSymlink && <IconLinkOutline16 size={12} className={css.explorerSymlink} />}
           {rowActions(entry)}

--- a/src/client/GitView.tsx
+++ b/src/client/GitView.tsx
@@ -8,7 +8,7 @@
  * revert, cherry-pick, copy paths/hashes). Refresh is manual + on mount/
  * focus (no file watcher — KISS).
  */
-import { useCallback, useEffect, useState, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type MouseEvent, type ReactNode } from 'react'
 import {
   Button, IconBranchOutline16, IconCodeOutline16, IconCopyOutline16, IconRefreshOutline16,
   IconTrashOutline16, Input, Menu, Modal, writeClipboard,
@@ -19,6 +19,133 @@ import { relativeTo } from './paths.ts'
 import { relativeTime, t } from './locales.ts'
 import type { SidebarTab } from './state.ts'
 import css from './sidebar.module.css'
+
+const GRAPH_COLORS = ['#3b82f6', '#10b981', '#a855f7', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#f43f5e']
+
+export interface GraphRow {
+  lane: number
+  color: string
+  fromTop: boolean
+  hasBottom: boolean
+  isJunction: boolean
+  passThroughLanes: number[]
+  incomingForks: { fromLane: number; color: string }[]
+  outgoingMerges: { toLane: number; color: string }[]
+}
+
+export function computeGitGraph(entries: GitLogEntry[]): { rows: GraphRow[]; maxLanes: number } {
+  const activeLanes: (string | null)[] = []
+  let maxLanes = 1
+  const rows: GraphRow[] = []
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]
+    if (entry === undefined) continue
+    const hash = entry.hashFull || entry.hash
+    // Fallback: if parents is not provided (or empty for non-last commits), assume linear parent is next commit
+    const hasExplicitParents = Array.isArray(entry.parents) && entry.parents.length > 0
+    const isLast = i === entries.length - 1
+    const parents = hasExplicitParents
+      ? (entry.parents as string[])
+      : (!isLast && entries[i + 1] ? [entries[i + 1]?.hashFull || entries[i + 1]?.hash || ''] : [])
+
+    // 1. Find all lanes in activeLanes matching this commit
+    let lane = -1
+    const incomingLanes: number[] = []
+    for (let l = 0; l < activeLanes.length; l++) {
+      if (activeLanes[l] === hash || (entry.hash && activeLanes[l] === entry.hash)) {
+        if (lane === -1) {
+          lane = l
+        } else {
+          incomingLanes.push(l)
+        }
+      }
+    }
+
+    let fromTop = true
+    if (lane === -1) {
+      fromTop = false
+      // Allocate the first empty slot or push a new lane
+      lane = activeLanes.indexOf(null)
+      if (lane === -1) {
+        lane = activeLanes.length
+        activeLanes.push(hash)
+      } else {
+        activeLanes[lane] = hash
+      }
+    }
+
+    // Incoming forks from other lanes that terminate at this commit
+    const incomingForks = incomingLanes.map(fromLane => {
+      activeLanes[fromLane] = null
+      return {
+        fromLane,
+        color: GRAPH_COLORS[fromLane % GRAPH_COLORS.length] ?? '#3b82f6',
+      }
+    })
+
+    // 2. Identify pass-through lanes (all other currently active lanes)
+    const passThroughLanes: number[] = []
+    for (let l = 0; l < activeLanes.length; l++) {
+      if (l !== lane && activeLanes[l] !== null) {
+        passThroughLanes.push(l)
+      }
+    }
+
+    // 3. Update parents
+    const outgoingMerges: { toLane: number; color: string }[] = []
+    const hasBottom = parents.length > 0
+
+    if (parents.length === 0) {
+      activeLanes[lane] = null
+    } else {
+      // Primary parent stays in the current lane
+      activeLanes[lane] = parents[0] ?? null
+
+      // Secondary parents (merge commits)
+      for (let p = 1; p < parents.length; p++) {
+        const pHash = parents[p]
+        if (pHash === undefined) continue
+        let pLane = activeLanes.indexOf(pHash)
+        if (pLane === -1) {
+          pLane = activeLanes.indexOf(null)
+          if (pLane === -1) {
+            pLane = activeLanes.length
+            activeLanes.push(pHash)
+          } else {
+            activeLanes[pLane] = pHash
+          }
+        }
+        outgoingMerges.push({
+          toLane: pLane,
+          color: GRAPH_COLORS[pLane % GRAPH_COLORS.length] ?? '#10b981',
+        })
+      }
+    }
+
+    // Clean up trailing null lanes
+    while (activeLanes.length > 0 && activeLanes[activeLanes.length - 1] === null) {
+      activeLanes.pop()
+    }
+
+    maxLanes = Math.max(maxLanes, activeLanes.length, lane + 1, ...incomingLanes.map(l => l + 1), 1)
+
+    const isJunction = incomingForks.length > 0 || outgoingMerges.length > 0 || !fromTop
+
+    rows.push({
+      lane,
+      color: GRAPH_COLORS[lane % GRAPH_COLORS.length] ?? '#3b82f6',
+      fromTop,
+      hasBottom,
+      isJunction,
+      passThroughLanes,
+      incomingForks,
+      outgoingMerges,
+    })
+  }
+
+  return { rows, maxLanes }
+}
 
 /** The XY status letters a row badge shows (X = index, Y = worktree). */
 function badgeOf(entry: GitStatusEntry): string {
@@ -91,6 +218,7 @@ export function GitView(props: {
   const [error, setError] = useState<string | null>(null)
   const [branchNames, setBranchNames] = useState<string[]>([])
   const [logEntries, setLogEntries] = useState<GitLogEntry[]>([])
+  const graphData = useMemo(() => computeGitGraph(logEntries), [logEntries])
   const [commitMsg, setCommitMsg] = useState('')
   const [busy, setBusy] = useState(false)
   const [commitError, setCommitError] = useState<string | null>(null)
@@ -358,34 +486,134 @@ export function GitView(props: {
 
           <div className={css.gitSection}>
             <div className={css.gitSectionHeader}><span>{t('history')}</span></div>
-            {logEntries.map(entry => (
-              <div
-                key={entry.hashFull}
-                role="button"
-                tabIndex={0}
-                className={css.gitLogRow}
-                title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
-                onClick={() => { openCommitDiff(entry) }}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault()
-                    openCommitDiff(entry)
-                  }
-                }}
-                onContextMenu={(event) => { openHistoryMenu(event, entry) }}
-              >
-                <span className={css.gitLogLine1}>
-                  <span className={css.gitLogHash}>{entry.hash}</span>
-                  <span className={css.gitLogSubject}>{entry.subject}</span>
-                </span>
-                <span className={css.gitLogLine2}>
-                  {refNames(entry.refs).map(ref => (
-                    <span key={ref} className={css.gitLogRef}>{ref}</span>
-                  ))}
-                  <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
-                </span>
-              </div>
-            ))}
+            {logEntries.map((entry, index) => {
+              const graph = graphData.rows[index]
+              const LANE_WIDTH = 14
+              const svgWidth = Math.max(1, graphData.maxLanes) * LANE_WIDTH + 8
+              const laneX = (l: number) => l * LANE_WIDTH + 8
+              const ROW_H = 48
+              const DOT_Y = 16
+              return (
+                <div
+                  key={entry.hashFull}
+                  role="button"
+                  tabIndex={0}
+                  className={css.gitLogRow}
+                  title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
+                  onClick={() => { openCommitDiff(entry) }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      openCommitDiff(entry)
+                    }
+                  }}
+                  onContextMenu={(event) => { openHistoryMenu(event, entry) }}
+                >
+                  {graph !== undefined && (
+                    <div className={css.gitGraphCol} style={{ width: svgWidth }}>
+                      <svg
+                        width={svgWidth}
+                        height={ROW_H}
+                        viewBox={`0 0 ${svgWidth} ${ROW_H}`}
+                        style={{ display: 'block', overflow: 'visible', flexShrink: 0 }}
+                      >
+                        {/* Pass-through lines for other active branches */}
+                        {graph.passThroughLanes.map(lIndex => (
+                          <line
+                            key={`pass-${lIndex}`}
+                            x1={laneX(lIndex)}
+                            y1={0}
+                            x2={laneX(lIndex)}
+                            y2={ROW_H}
+                            stroke={GRAPH_COLORS[lIndex % GRAPH_COLORS.length]}
+                            strokeWidth={2}
+                            strokeLinecap="round"
+                          />
+                        ))}
+                        {/* Upward straight line if this branch continues upwards */}
+                        {graph.fromTop && (
+                          <line
+                            x1={laneX(graph.lane)}
+                            y1={0}
+                            x2={laneX(graph.lane)}
+                            y2={DOT_Y}
+                            stroke={graph.color}
+                            strokeWidth={2}
+                            strokeLinecap="round"
+                          />
+                        )}
+                        {/* Incoming fork curves (from other branches that merged into this commit from above) */}
+                        {graph.incomingForks.map((fork, fIdx) => (
+                          <path
+                            key={`fork-${fIdx}`}
+                            d={`M ${laneX(fork.fromLane)} 0 C ${laneX(fork.fromLane)} ${DOT_Y * 0.55}, ${laneX(graph.lane)} ${DOT_Y * 0.85}, ${laneX(graph.lane)} ${DOT_Y}`}
+                            stroke={fork.color}
+                            strokeWidth={2}
+                            fill="none"
+                            strokeLinecap="round"
+                          />
+                        ))}
+                        {/* Downward straight line to primary parent */}
+                        {graph.hasBottom && (
+                          <line
+                            x1={laneX(graph.lane)}
+                            y1={DOT_Y}
+                            x2={laneX(graph.lane)}
+                            y2={ROW_H}
+                            stroke={graph.color}
+                            strokeWidth={2}
+                            strokeLinecap="round"
+                          />
+                        )}
+                        {/* Outgoing merge curves (to secondary parents below) */}
+                        {graph.outgoingMerges.map((conn, cIdx) => (
+                          <path
+                            key={`merge-${cIdx}`}
+                            d={`M ${laneX(graph.lane)} ${DOT_Y} C ${laneX(graph.lane)} ${DOT_Y + (ROW_H - DOT_Y) * 0.35}, ${laneX(conn.toLane)} ${DOT_Y + (ROW_H - DOT_Y) * 0.75}, ${laneX(conn.toLane)} ${ROW_H}`}
+                            stroke={conn.color}
+                            strokeWidth={2}
+                            fill="none"
+                            strokeLinecap="round"
+                          />
+                        ))}
+                        {/* Commit node dot aligned with Line 1 (hash and message) */}
+                        {graph.isJunction ? (
+                          <circle
+                            cx={laneX(graph.lane)}
+                            cy={DOT_Y}
+                            r={4.5}
+                            fill={graph.color}
+                            stroke="var(--dsw-alias-bg-layer-1)"
+                            strokeWidth={1.5}
+                          />
+                        ) : (
+                          <circle
+                            cx={laneX(graph.lane)}
+                            cy={DOT_Y}
+                            r={4}
+                            fill="var(--dsw-alias-bg-layer-1)"
+                            stroke={graph.color}
+                            strokeWidth={2}
+                          />
+                        )}
+                      </svg>
+                    </div>
+                  )}
+                  <div className={css.gitLogContent}>
+                    <span className={css.gitLogLine1}>
+                      <span className={css.gitLogHash}>{entry.hash}</span>
+                      <span className={css.gitLogSubject}>{entry.subject}</span>
+                    </span>
+                    <span className={css.gitLogLine2}>
+                      {refNames(entry.refs).map(ref => (
+                        <span key={ref} className={css.gitLogRef}>{ref}</span>
+                      ))}
+                      <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
             {!logEnded && (
               <button
                 type="button"

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -56,6 +56,8 @@ export interface GitLogEntry {
   date: string
   /** Ref decorations (--decorate=short), e.g. `HEAD -> main, origin/main`; '' when none. */
   refs: string
+  /** Parent commit hashes for DAG topology graph. */
+  parents?: string[]
 }
 
 /** Text read result. */

--- a/src/client/icons.tsx
+++ b/src/client/icons.tsx
@@ -5,13 +5,9 @@
  * (`descriptor.icon`), not in a type-keyed switch — the icon mapping was
  * registry-ized with the tab types.
  */
+import type { ReactNode } from 'react'
 import type { IconProps } from '@deepseek-ai/dsh-client-ui-primitives'
 
-/**
- * Right-panel toggle glyph (the "侧拉" button): a frame with a filled strip
- * along its RIGHT edge, in the app's outline style (1.5px stroke,
- * currentColor).
- */
 export const IconPanelRightOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="1.5" y="2" width="13" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
@@ -19,10 +15,6 @@ export const IconPanelRightOutline16 = ({ size = 16, className }: IconProps) => 
   </svg>
 )
 
-/**
- * Bottom-panel toggle glyph (the "底栏" button): a frame with a filled strip
- * along its BOTTOM edge, in the app's outline style.
- */
 export const IconPanelBottomOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="1.5" y="2" width="13" height="12" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
@@ -30,10 +22,6 @@ export const IconPanelBottomOutline16 = ({ size = 16, className }: IconProps) =>
   </svg>
 )
 
-/**
- * Terminal glyph in the app's outline style (1.5px stroke, currentColor):
- * a rounded frame with a prompt chevron and underscore cursor.
- */
 export const IconTerminalOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.5" />
@@ -42,7 +30,6 @@ export const IconTerminalOutline16 = ({ size = 16, className }: IconProps) => (
   </svg>
 )
 
-/** Diff glyph in the app's outline style: a file frame with a plus and a minus row. */
 export const IconDiffOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="1.5" y="1.5" width="13" height="13" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
@@ -51,19 +38,12 @@ export const IconDiffOutline16 = ({ size = 16, className }: IconProps) => (
   </svg>
 )
 
-/**
- * Stop glyph for the background-job kill button: a filled square in the
- * app's outline scale (16), the universal "halt this work" mark.
- */
 export const IconStopOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="4" y="4" width="8" height="8" rx="1.5" fill="currentColor" stroke="none" />
   </svg>
 )
 
-// ── File-viewer inventory glyphs (Side card settings page) ────────────────
-
-/** Image viewer glyph: a picture frame with a sun and a mountain. */
 export const IconImageOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.5" />
@@ -72,7 +52,6 @@ export const IconImageOutline16 = ({ size = 16, className }: IconProps) => (
   </svg>
 )
 
-/** PDF viewer glyph: a document frame with the "PDF" label. */
 export const IconPdfOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3.5 1.5h6.5L13.5 5v9.5h-10z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
@@ -83,7 +62,6 @@ export const IconPdfOutline16 = ({ size = 16, className }: IconProps) => (
   </svg>
 )
 
-/** Markdown viewer glyph: the classic "M with a down arrow" badge. */
 export const IconMarkdownOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" strokeWidth="1.5" />
@@ -91,7 +69,6 @@ export const IconMarkdownOutline16 = ({ size = 16, className }: IconProps) => (
   </svg>
 )
 
-/** HTML viewer glyph: a document frame with a "‹/›" tag pair. */
 export const IconHtmlOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M3.5 1.5h6.5L13.5 5v9.5h-10z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
@@ -100,7 +77,6 @@ export const IconHtmlOutline16 = ({ size = 16, className }: IconProps) => (
   </svg>
 )
 
-/** Browser tab glyph: a globe with meridians. */
 export const IconGlobeOutline16 = ({ size = 16, className }: IconProps) => (
   <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <circle cx="8" cy="8" r="6.5" stroke="currentColor" strokeWidth="1.5" />
@@ -108,3 +84,742 @@ export const IconGlobeOutline16 = ({ size = 16, className }: IconProps) => (
     <path d="M1.5 8h13M8 1.5c-2.4 1.8-2.4 11.2 0 13M8 1.5c2.4 1.8 2.4 11.2 0 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
   </svg>
 )
+
+export const IconMaximizeOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2.5 6.5V2.5H6.5M13.5 6.5V2.5H9.5M2.5 9.5v4H6.5M13.5 9.5v4H9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+export const IconRestoreOutline16 = ({ size = 16, className }: IconProps) => (
+  <svg width={size} height={size} className={className} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6.5 2.5v4H2.5M9.5 2.5v4h4M6.5 13.5v-4H2.5M9.5 13.5v-4h4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+// ── Official Material Icon Theme SVGs ──────────────────────────────────
+
+const MATERIAL_ICONS: Record<string, (size: number) => ReactNode> = {
+  'typescript': (size: number) => (
+    <svg width={size} height={size} xmlSpace="preserve" viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M2 2v12h12V2zm4 6h3v1H8v4H7V9H6zm5 0h2v1h-2v1h1a1.003 1.003 0 0 1 1 1v1a1.003 1.003 0 0 1-1 1h-2v-1h2v-1h-1a1.003 1.003 0 0 1-1-1V9a1.003 1.003 0 0 1 1-1"/>
+    </svg>
+  ),
+  'react_ts': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M16 12c7.444 0 12 2.59 12 4s-4.556 4-12 4-12-2.59-12-4 4.556-4 12-4m0-2c-7.732 0-14 2.686-14 6s6.268 6 14 6 14-2.686 14-6-6.268-6-14-6"/><path fill="#0288d1" d="M16 14a2 2 0 1 0 2 2 2 2 0 0 0-2-2"/><path fill="#0288d1" d="M10.458 5.507c2.017 0 5.937 3.177 9.006 8.493 3.722 6.447 3.757 11.687 2.536 12.392a.9.9 0 0 1-.457.1c-2.017 0-5.938-3.176-9.007-8.492C8.814 11.553 8.779 6.313 10 5.608a.9.9 0 0 1 .458-.1m-.001-2A2.87 2.87 0 0 0 9 3.875C6.13 5.532 6.938 12.304 10.804 19c3.284 5.69 7.72 9.493 10.74 9.493A2.87 2.87 0 0 0 23 28.124c2.87-1.656 2.062-8.428-1.804-15.124-3.284-5.69-7.72-9.493-10.74-9.493Z"/><path fill="#0288d1" d="M21.543 5.507a.9.9 0 0 1 .457.1c1.221.706 1.186 5.946-2.536 12.393-3.07 5.316-6.99 8.493-9.007 8.493a.9.9 0 0 1-.457-.1C8.779 25.686 8.814 20.446 12.536 14c3.07-5.316 6.99-8.493 9.007-8.493m0-2c-3.02 0-7.455 3.804-10.74 9.493C6.939 19.696 6.13 26.468 9 28.124a2.87 2.87 0 0 0 1.457.369c3.02 0 7.455-3.804 10.74-9.493C25.061 12.304 25.87 5.532 23 3.876a2.87 2.87 0 0 0-1.457-.369"/>
+    </svg>
+  ),
+  'javascript': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ffca28" d="M2 2v12h12V2zm6 6h1v4a1.003 1.003 0 0 1-1 1H7a1.003 1.003 0 0 1-1-1v-1h1v1h1zm3 0h2v1h-2v1h1a1.003 1.003 0 0 1 1 1v1a1.003 1.003 0 0 1-1 1h-2v-1h2v-1h-1a1.003 1.003 0 0 1-1-1V9a1.003 1.003 0 0 1 1-1"/>
+    </svg>
+  ),
+  'react': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#00bcd4" d="M16 12c7.444 0 12 2.59 12 4s-4.556 4-12 4-12-2.59-12-4 4.556-4 12-4m0-2c-7.732 0-14 2.686-14 6s6.268 6 14 6 14-2.686 14-6-6.268-6-14-6"/><path fill="#00bcd4" d="M16 14a2 2 0 1 0 2 2 2 2 0 0 0-2-2"/><path fill="#00bcd4" d="M10.458 5.507c2.017 0 5.937 3.177 9.006 8.493 3.722 6.447 3.757 11.687 2.536 12.392a.9.9 0 0 1-.457.1c-2.017 0-5.938-3.176-9.007-8.492C8.814 11.553 8.779 6.313 10 5.608a.9.9 0 0 1 .458-.1m-.001-2A2.87 2.87 0 0 0 9 3.875C6.13 5.532 6.938 12.304 10.804 19c3.284 5.69 7.72 9.493 10.74 9.493A2.87 2.87 0 0 0 23 28.124c2.87-1.656 2.062-8.428-1.804-15.124-3.284-5.69-7.72-9.493-10.74-9.493Z"/><path fill="#00bcd4" d="M21.543 5.507a.9.9 0 0 1 .457.1c1.221.706 1.186 5.946-2.536 12.393-3.07 5.316-6.99 8.493-9.007 8.493a.9.9 0 0 1-.457-.1C8.779 25.686 8.814 20.446 12.536 14c3.07-5.316 6.99-8.493 9.007-8.493m0-2c-3.02 0-7.455 3.804-10.74 9.493C6.939 19.696 6.13 26.468 9 28.124a2.87 2.87 0 0 0 1.457.369c3.02 0 7.455-3.804 10.74-9.493C25.061 12.304 25.87 5.532 23 3.876a2.87 2.87 0 0 0-1.457-.369"/>
+    </svg>
+  ),
+  'vue': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#41b883" d="M1.791 3.851 12 21.471 22.209 3.936V3.85H18.24l-6.18 10.616L5.906 3.851z"/><path fill="#35495e" d="m5.907 3.851 6.152 10.617L18.24 3.851h-3.723L12.084 8.03 9.66 3.85z"/>
+    </svg>
+  ),
+  'svelte': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 300 300" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff5722" d="M175.94 24.328c-13.037.252-26.009 3.872-37.471 11.174L79.912 72.818a67.13 67.13 0 0 0-30.355 44.906 70.8 70.8 0 0 0 6.959 45.445 67.2 67.2 0 0 0-10.035 25.102 71.54 71.54 0 0 0 12.236 54.156c23.351 33.41 69.468 43.311 102.81 22.07l58.559-37.158a67.36 67.36 0 0 0 30.355-44.906 70.77 70.77 0 0 0-6.982-45.422 67.65 67.65 0 0 0 10.059-25.102 71.63 71.63 0 0 0-12.236-54.156v-.18c-15.324-21.925-40.453-33.727-65.342-33.246zm5.137 28.68a46.5 46.5 0 0 1 36.09 19.969 42.98 42.98 0 0 1 7.365 32.557 45 45 0 0 1-1.393 5.455l-1.123 3.37-2.986-2.247a75.9 75.9 0 0 0-22.902-11.45l-2.244-.651.201-2.246a13.16 13.16 0 0 0-2.379-8.711 13.99 13.99 0 0 0-14.953-5.412 12.8 12.8 0 0 0-3.594 1.572l-58.578 37.25a12.24 12.24 0 0 0-5.502 8.15 13.1 13.1 0 0 0 2.246 9.834 14.03 14.03 0 0 0 14.93 5.569 13.5 13.5 0 0 0 3.594-1.573l22.453-14.234a41.8 41.8 0 0 1 11.898-5.232 46.48 46.48 0 0 1 49.914 18.502 43.02 43.02 0 0 1 7.363 32.557 40.42 40.42 0 0 1-18.254 27.078l-58.58 37.316a43 43 0 0 1-11.898 5.23A46.545 46.545 0 0 1 82.81 227.14a42.98 42.98 0 0 1-7.341-32.557 38 38 0 0 1 1.39-5.41l1.102-3.37 3.008 2.246a75.9 75.9 0 0 0 22.836 11.361l2.244.65-.201 2.247a13.25 13.25 0 0 0 2.447 8.644 14.03 14.03 0 0 0 15.043 5.569 13.1 13.1 0 0 0 3.592-1.573l58.467-37.316a12.17 12.17 0 0 0 5.502-8.173 12.96 12.96 0 0 0-2.246-9.811 14.03 14.03 0 0 0-15.043-5.568 12.8 12.8 0 0 0-3.592 1.57l-22.453 14.258a42.9 42.9 0 0 1-11.877 5.209 46.52 46.52 0 0 1-49.846-18.5 43.02 43.02 0 0 1-7.297-32.557A40.42 40.42 0 0 1 96.798 96.98l58.646-37.316a42.8 42.8 0 0 1 11.811-5.21 46.5 46.5 0 0 1 13.822-1.444z"/>
+    </svg>
+  ),
+  'python': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M9.86 2A2.86 2.86 0 0 0 7 4.86v1.68h4.29c.39 0 .71.57.71.96H4.86A2.86 2.86 0 0 0 2 10.36v3.781a2.86 2.86 0 0 0 2.86 2.86h1.18v-2.68a2.85 2.85 0 0 1 2.85-2.86h5.25c1.58 0 2.86-1.271 2.86-2.851V4.86A2.86 2.86 0 0 0 14.14 2zm-.72 1.61c.4 0 .72.12.72.71s-.32.891-.72.891c-.39 0-.71-.3-.71-.89s.32-.711.71-.711"/><path fill="#fdd835" d="M17.959 7v2.68a2.85 2.85 0 0 1-2.85 2.859H9.86A2.85 2.85 0 0 0 7 15.389v3.75a2.86 2.86 0 0 0 2.86 2.86h4.28A2.86 2.86 0 0 0 17 19.14v-1.68h-4.291c-.39 0-.709-.57-.709-.96h7.14A2.86 2.86 0 0 0 22 13.64V9.86A2.86 2.86 0 0 0 19.14 7zM8.32 11.513l-.004.004.038-.004zm6.54 7.276c.39 0 .71.3.71.89a.71.71 0 0 1-.71.71c-.4 0-.72-.12-.72-.71s.32-.89.72-.89"/>
+    </svg>
+  ),
+  'rust': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff7043" d="m30 12-4-2V6h-4l-2-4-4 2-4-2-2 4H6v4l-4 2 2 4-2 4 4 2v4h4l2 4 4-2 4 2 2-4h4v-4l4-2-2-4ZM6 16a9.9 9.9 0 0 1 .842-4H10v8H6.842A9.9 9.9 0 0 1 6 16m10 10a9.98 9.98 0 0 1-7.978-4H16v-2h-2v-2h4c.819.819.297 2.308 1.179 3.37a1.89 1.89 0 0 0 1.46.63h3.34A9.98 9.98 0 0 1 16 26m-2-12v-2h4a1 1 0 0 1 0 2Zm11.158 6H24a2.006 2.006 0 0 1-2-2 2 2 0 0 0-2-2 3 3 0 0 0 3-3q0-.08-.004-.161A3.115 3.115 0 0 0 19.83 10H8.022a9.986 9.986 0 0 1 17.136 10"/>
+    </svg>
+  ),
+  'go': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#00acc1" d="M2 12h4v2H2zm-2 4h6v2H0zm4 4h2v2H4zm16.954-5H14v3h3.239a4.42 4.42 0 0 1-3.531 2 2.65 2.65 0 0 1-2.053-.858 2.86 2.86 0 0 1-.628-2.28A4.515 4.515 0 0 1 15.292 13a2.73 2.73 0 0 1 1.749.584l2.962-1.185A5.6 5.6 0 0 0 15.292 10a7.526 7.526 0 0 0-7.243 6.5 5.614 5.614 0 0 0 5.659 6.5 7.526 7.526 0 0 0 7.243-6.5 6.4 6.4 0 0 0 .003-1.5"/><path fill="#00acc1" d="M26.292 10a7.526 7.526 0 0 0-7.243 6.5 5.614 5.614 0 0 0 5.659 6.5 7.526 7.526 0 0 0 7.243-6.5 5.614 5.614 0 0 0-5.659-6.5m2.681 6.137A4.515 4.515 0 0 1 24.708 20a2.65 2.65 0 0 1-2.053-.858 2.86 2.86 0 0 1-.628-2.28A4.515 4.515 0 0 1 26.292 13a2.65 2.65 0 0 1 2.053.858 2.86 2.86 0 0 1 .628 2.28Z"/>
+    </svg>
+  ),
+  'cpp': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M28 14v-4h-2v4h-6v-4h-2v4h-4v2h4v4h2v-4h6v4h2v-4h4v-2z"/><path fill="#0288d1" d="M13.563 22A5.57 5.57 0 0 1 8 16.437v-2.873A5.57 5.57 0 0 1 13.563 8H18V2h-4.437A11.563 11.563 0 0 0 2 13.563v2.873A11.564 11.564 0 0 0 13.563 28H18v-6Z"/>
+    </svg>
+  ),
+  'c': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M19.563 22A5.57 5.57 0 0 1 14 16.437v-2.873A5.57 5.57 0 0 1 19.563 8H24V2h-4.437A11.563 11.563 0 0 0 8 13.563v2.873A11.564 11.564 0 0 0 19.563 28H24v-6Z"/>
+    </svg>
+  ),
+  'csharp': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M30 14v-2h-2V8h-2v4h-2V8h-2v4h-2v2h2v2h-2v2h2v4h2v-4h2v4h2v-4h2v-2h-2v-2Zm-4 2h-2v-2h2Zm-12.437 6A5.57 5.57 0 0 1 8 16.437v-2.873A5.57 5.57 0 0 1 13.563 8H18V2h-4.437A11.563 11.563 0 0 0 2 13.563v2.873A11.564 11.564 0 0 0 13.563 28H18v-6Z"/>
+    </svg>
+  ),
+  'java': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f44336" d="M4 26h24v2H4zM28 4H7a1 1 0 0 0-1 1v13a4 4 0 0 0 4 4h10a4 4 0 0 0 4-4v-4h4a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2m0 8h-4V6h4Z"/>
+    </svg>
+  ),
+  'kotlin': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <defs><linearGradient id="a" x1="1.725" x2="22.185" y1="22.67" y2="1.982" gradientTransform="translate(1.306 1.129)scale(.89324)" gradientUnits="userSpaceOnUse"><stop offset="0" stopColor="#7c4dff"/><stop offset=".5" stopColor="#d500f9"/><stop offset="1" stopColor="#ef5350"/></linearGradient></defs><path fill="url(#a)" d="M2.975 2.976v18.048h18.05v-.03l-4.478-4.511-4.48-4.515 4.48-4.515 4.443-4.477z"/>
+    </svg>
+  ),
+  'swift': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff6e40" d="M17.087 19.721c-2.36 1.36-5.59 1.5-8.86.1a13.8 13.8 0 0 1-6.23-5.32c.67.55 1.46 1 2.3 1.4 3.37 1.57 6.73 1.46 9.1 0-3.37-2.59-6.24-5.96-8.37-8.71-.45-.45-.78-1.01-1.12-1.51 8.28 6.05 7.92 7.59 2.41-1.01 4.89 4.94 9.43 7.74 9.43 7.74.16.09.25.16.36.22.1-.25.19-.51.26-.78.79-2.85-.11-6.12-2.08-8.81 4.55 2.75 7.25 7.91 6.12 12.24-.03.11-.06.22-.05.39 2.24 2.83 1.64 5.78 1.35 5.22-1.21-2.39-3.48-1.65-4.62-1.17"/>
+    </svg>
+  ),
+  'php': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#1e88e5" d="M12 18.08c-6.63 0-12-2.72-12-6.08s5.37-6.08 12-6.08S24 8.64 24 12s-5.37 6.08-12 6.08m-5.19-7.95c.54 0 .91.1 1.09.31.18.2.22.56.13 1.03-.1.53-.29.87-.58 1.09q-.42.33-1.29.33h-.87l.53-2.76zm-3.5 5.55h1.44l.34-1.75h1.23c.54 0 .98-.06 1.33-.17.35-.12.67-.31.96-.58.24-.22.43-.46.58-.73.15-.26.26-.56.31-.88.16-.78.05-1.39-.33-1.82-.39-.44-.99-.65-1.82-.65H4.59zm7.25-8.33-1.28 6.58h1.42l.74-3.77h1.14c.36 0 .6.06.71.18s.13.34.07.66l-.57 2.93h1.45l.59-3.07c.13-.62.03-1.07-.27-1.36-.3-.27-.85-.4-1.65-.4h-1.27L12 7.35zM18 10.13c.55 0 .91.1 1.09.31.18.2.22.56.13 1.03-.1.53-.29.87-.57 1.09-.29.22-.72.33-1.3.33h-.85l.5-2.76zm-3.5 5.55h1.44l.34-1.75h1.22c.55 0 1-.06 1.35-.17.35-.12.65-.31.95-.58.24-.22.44-.46.58-.73.15-.26.26-.56.32-.88.15-.78.04-1.39-.34-1.82-.36-.44-.99-.65-1.82-.65h-2.75z"/>
+    </svg>
+  ),
+  'ruby': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f44336" d="M18.041 3.177c2.24.382 2.879 1.919 2.843 3.527V6.67l-1.013 13.266-13.132.897h.008c-1.093-.044-3.518-.151-3.634-3.545l1.217-2.222 2.462 5.74 2.097-6.77-.045.009.018-.018 6.85 2.186L13.945 9.3l6.53-.409-5.144-4.212 2.71-1.51v.009M3.113 17.252v.017zM6.916 6.874c2.63-2.622 6.033-4.168 7.34-2.844 1.297 1.306-.072 4.523-2.702 7.135-2.666 2.613-6.015 4.248-7.322 2.933-1.306-1.324.036-4.612 2.675-7.224z"/>
+    </svg>
+  ),
+  'dart': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#4fc3f7" d="M16.83 2a1.3 1.3 0 0 0-.916.377l-.013.01L7.323 7.34l8.556 8.55v.005l10.283 10.277 1.96-3.529-7.068-16.96-3.299-3.297A1.3 1.3 0 0 0 16.828 2Z"/><path fill="#01579b" d="m7.343 7.32-4.955 8.565-.01.013a1.297 1.297 0 0 0 .004 1.835l.005.005 4.106 4.107 16.064 6.314 3.632-2.015-.098-.098-.025.002L15.995 15.97h-.012z"/><path fill="#01579b" d="m7.321 7.324 8.753 8.755h.013L26.16 26.156l3.835-.73L30 14.089l-4.049-3.965a6.5 6.5 0 0 0-3.618-1.612l.002-.043L7.323 7.325Z"/><path fill="#64b5f6" d="m7.332 7.335 8.758 8.75v.013l10.079 10.071L25.436 30H14.09l-3.967-4.048a6.5 6.5 0 0 1-1.611-3.618l-.045.004Z"/>
+    </svg>
+  ),
+  'lua': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#42a5f5" d="M30 6a3.86 3.86 0 0 1-1.167 2.833 4.024 4.024 0 0 1-5.666 0A3.86 3.86 0 0 1 22 6a3.86 3.86 0 0 1 1.167-2.833 4.024 4.024 0 0 1 5.666 0A3.86 3.86 0 0 1 30 6m-9.208 5.208A10.6 10.6 0 0 0 13 8a10.6 10.6 0 0 0-7.792 3.208A10.6 10.6 0 0 0 2 19a10.6 10.6 0 0 0 3.208 7.792A10.6 10.6 0 0 0 13 30a10.6 10.6 0 0 0 7.792-3.208A10.6 10.6 0 0 0 24 19a10.6 10.6 0 0 0-3.208-7.792m-1.959 7.625a4.024 4.024 0 0 1-5.666 0 4.024 4.024 0 0 1 0-5.666 4.024 4.024 0 0 1 5.666 0 4.024 4.024 0 0 1 0 5.666"/>
+    </svg>
+  ),
+  'zig': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f9a825" d="M2 8h6v4H2zm8 0h12v4H10zm0 12h12v4H10zm14 0h2v4h-2zM8 20l-3 4H2V12h4v8zm14-8h-6l-6 8h6z"/><path fill="#f9a825" d="M16 20h-6l-6 8m12-16h6l6-8m2 4v16h-4V12h-2l3-4z"/>
+    </svg>
+  ),
+  'html': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#e65100" d="m4 4 2 22 10 2 10-2 2-22Zm19.72 7H11.28l.29 3h11.86l-.802 9.335L15.99 25l-6.635-1.646L8.93 19h3.02l.19 2 3.86.77 3.84-.77.29-4H8.84L8 8h16Z"/>
+    </svg>
+  ),
+  'css': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#7e57c2" d="M20 18h-2v-2h-2v2c0 .193 0 .703 1.254 1.033A3.345 3.345 0 0 1 20 22h2v2h2v-2c0-.388-.562-.851-1.254-1.034C20.356 20.34 20 18.84 20 18m-3.254 2.966C14.356 20.34 14 18.84 14 18h-2v-2h-2v8h2v-2h4v2h2v-2c0-.388-.562-.851-1.254-1.034"/><path fill="#7e57c2" d="M24 4H4v20a4 4 0 0 0 4 4h16.16A3.84 3.84 0 0 0 28 24.16V8a4 4 0 0 0-4-4m2 14h-2v-2h-2v2c0 .193 0 .703 1.254 1.033A3.345 3.345 0 0 1 26 22v2a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2 2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2 2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2 2 2 0 0 1 2-2h2a2 2 0 0 1 2 2 2 2 0 0 1 2-2h2a2 2 0 0 1 2 2Z"/>
+    </svg>
+  ),
+  'sass': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ec407a" d="M27.837 5.673a4.33 4.33 0 0 0-2.293-2.701c-2.362-1.261-6.11-1.298-9.548-.092a26.3 26.3 0 0 0-8.76 4.966c-2.752 2.542-3.438 4.925-3.189 6.194.523 2.668 3.274 4.539 5.485 6.042.418.284.822.559 1.175.816-1.429.76-4.261 2.444-5.088 4.248a3.88 3.88 0 0 0-.118 3.332A2.37 2.37 0 0 0 6.869 29.8a5.6 5.6 0 0 0 1.49.2 6.35 6.35 0 0 0 5.19-2.856 6.74 6.74 0 0 0 .864-5.382 7.3 7.3 0 0 1 2.044-.03 3.92 3.92 0 0 1 2.816 1.311 1.82 1.82 0 0 1 .423 1.262 1.55 1.55 0 0 1-.772 1.05c-.234.14-.586.355-.504.803.036.194.198.633.894.512a2.93 2.93 0 0 0 2.145-2.651 4 4 0 0 0-1.197-2.904 5.94 5.94 0 0 0-4.396-1.626 10.6 10.6 0 0 0-2.672.304 20 20 0 0 0-2.203-1.846c-1.712-1.3-3.33-2.529-3.235-4.26.125-2.263 2.468-4.532 6.964-6.744 4.016-1.976 7.254-2.037 8.944-1.438a2 2 0 0 1 1.204.883 2.77 2.77 0 0 1-.36 2.47 9.71 9.71 0 0 1-7.425 4.304 3.86 3.86 0 0 1-3.238-.757c-.278-.302-.593-.645-1.074-.383q-.565.31-.225 1.189a3.9 3.9 0 0 0 2.407 1.92 11.7 11.7 0 0 0 7.128-.671c3.527-1.35 6.681-5.202 5.756-8.787M11.895 24.475a4 4 0 0 1-.192.468 4.5 4.5 0 0 1-.753 1.081 2.83 2.83 0 0 1-2.533 1.107c-.056-.032-.078-.146-.085-.193a3.28 3.28 0 0 1 1.076-2.284 11.3 11.3 0 0 1 2.644-1.933 3.85 3.85 0 0 1-.157 1.754"/>
+    </svg>
+  ),
+  'less': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0277bd" d="M8 3a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2H3v2h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h2v-2H8v-5a2 2 0 0 0-2-2 2 2 0 0 0 2-2V5h2V3m6 0a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h1v2h-1a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2h-2v-2h2v-5a2 2 0 0 1 2-2 2 2 0 0 1-2-2V5h-2V3z"/>
+    </svg>
+  ),
+  'json': (size: number) => (
+    <svg width={size} height={size} viewBox="0 -960 960 960" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f9a825" d="M560-160v-80h120q17 0 28.5-11.5T720-280v-80q0-38 22-69t58-44v-14q-36-13-58-44t-22-69v-80q0-17-11.5-28.5T680-720H560v-80h120q50 0 85 35t35 85v80q0 17 11.5 28.5T840-560h40v160h-40q-17 0-28.5 11.5T800-360v80q0 50-35 85t-85 35zm-280 0q-50 0-85-35t-35-85v-80q0-17-11.5-28.5T120-400H80v-160h40q17 0 28.5-11.5T160-600v-80q0-50 35-85t85-35h120v80H280q-17 0-28.5 11.5T240-680v80q0 38-22 69t-58 44v14q36 13 58 44t22 69v80q0 17 11.5 28.5T280-240h120v80z"/>
+    </svg>
+  ),
+  'yaml': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff5252" d="M13 9h5.5L13 3.5zM6 2h8l6 6v12c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2m12 16v-2H9v2zm-4-4v-2H6v2z"/>
+    </svg>
+  ),
+  'toml': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#cfd8dc" d="M4 6V4h8v2H9v7H7V6z"/><path fill="#ef5350" d="M4 1v1H2v12h2v1H1V1zm8 0v1h2v12h-2v1h3V1z"/>
+    </svg>
+  ),
+  'markdown': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#42a5f5" d="m14 10-4 3.5L6 10H4v12h4v-6l2 2 2-2v6h4V10zm12 6v-6h-4v6h-4l6 8 6-8z"/>
+    </svg>
+  ),
+  'console': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff7043" d="M2 2a1 1 0 0 0-1 1v10c0 .554.446 1 1 1h12c.554 0 1-.446 1-1V3a1 1 0 0 0-1-1zm0 3h12v8H2zm1 2 2 2-2 2 1 1 3-3-3-3zm5 3.5V12h5v-1.5z"/>
+    </svg>
+  ),
+  'powershell': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#03a9f4" d="M29.07 6H7.677A1.535 1.535 0 0 0 6.24 7.113l-4.2 17.774A.852.852 0 0 0 2.93 26h21.393a1.535 1.535 0 0 0 1.436-1.113L29.96 7.112A.852.852 0 0 0 29.07 6M8.626 23.797a1.4 1.4 0 0 1-1.814-.31l-.007-.009a1.075 1.075 0 0 1 .315-1.599l9.6-6.061-6.102-5.852-.01-.01a1.068 1.068 0 0 1 .084-1.625l.037-.03a1.38 1.38 0 0 1 1.8.07l7.233 6.957a1.1 1.1 0 0 1 .236.739 1.08 1.08 0 0 1-.412.79c-.074.04-.146.119-10.951 6.935ZM24 22.94A1.135 1.135 0 0 1 22.803 24h-5.634a1.061 1.061 0 1 1 .001-2.112h5.633A1.134 1.134 0 0 1 24 22.938Z"/>
+    </svg>
+  ),
+  'database': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ffca28" d="M16 24c-5.525 0-10-.9-10-2v4c0 1.1 4.475 2 10 2s10-.9 10-2v-4c0 1.1-4.475 2-10 2m0-8c-5.525 0-10-.9-10-2v4c0 1.1 4.475 2 10 2s10-.9 10-2v-4c0 1.1-4.475 2-10 2m0-12C10.477 4 6 4.895 6 6v4c0 1.1 4.475 2 10 2s10-.9 10-2V6c0-1.105-4.477-2-10-2"/>
+    </svg>
+  ),
+  'docker': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M21.81 10.25c-.06-.04-.56-.43-1.64-.43-.28 0-.56.03-.84.08-.21-1.4-1.38-2.11-1.43-2.14l-.29-.17-.18.27c-.24.36-.43.77-.51 1.19-.2.8-.08 1.56.33 2.21-.49.28-1.29.35-1.46.35H2.62c-.34 0-.62.28-.62.63 0 1.15.18 2.3.58 3.38.45 1.19 1.13 2.07 2 2.61.98.6 2.59.94 4.42.94.79 0 1.61-.07 2.42-.22 1.12-.2 2.2-.59 3.19-1.16A8.3 8.3 0 0 0 16.78 16c1.05-1.17 1.67-2.5 2.12-3.65h.19c1.14 0 1.85-.46 2.24-.85.26-.24.45-.53.59-.87l.08-.24zm-17.96.99h1.76c.08 0 .16-.07.16-.16V9.5c0-.08-.07-.16-.16-.16H3.85c-.09 0-.16.07-.16.16v1.58c.01.09.07.16.16.16m2.43 0h1.76c.08 0 .16-.07.16-.16V9.5c0-.08-.07-.16-.16-.16H6.28c-.09 0-.16.07-.16.16v1.58c.01.09.07.16.16.16m2.47 0h1.75c.1 0 .17-.07.17-.16V9.5c0-.08-.06-.16-.17-.16H8.75c-.08 0-.15.07-.15.16v1.58c0 .09.06.16.15.16m2.44 0h1.77c.08 0 .15-.07.15-.16V9.5c0-.08-.06-.16-.15-.16h-1.77c-.08 0-.15.07-.15.16v1.58c0 .09.07.16.15.16M6.28 9h1.76c.08 0 .16-.09.16-.18V7.25c0-.09-.07-.16-.16-.16H6.28c-.09 0-.16.06-.16.16v1.57c.01.09.07.18.16.18m2.47 0h1.75c.1 0 .17-.09.17-.18V7.25c0-.09-.06-.16-.17-.16H8.75c-.08 0-.15.06-.15.16v1.57c0 .09.06.18.15.18m2.44 0h1.77c.08 0 .15-.09.15-.18V7.25c0-.09-.07-.16-.15-.16h-1.77c-.08 0-.15.06-.15.16v1.57c0 .09.07.18.15.18m0-2.28h1.77c.08 0 .15-.07.15-.16V5c0-.1-.07-.17-.15-.17h-1.77c-.08 0-.15.06-.15.17v1.56c0 .08.07.16.15.16m2.46 4.52h1.76c.09 0 .16-.07.16-.16V9.5c0-.08-.07-.16-.16-.16h-1.76c-.08 0-.15.07-.15.16v1.58c0 .09.07.16.15.16"/>
+    </svg>
+  ),
+  'git': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#e64a19" d="M13.172 2.828 11.78 4.22l1.91 1.91 2 2A2.986 2.986 0 0 1 20 10.81a3.25 3.25 0 0 1-.31 1.31l2.06 2a2.68 2.68 0 0 1 3.37.57 2.86 2.86 0 0 1 .88 2.117 3.02 3.02 0 0 1-.856 2.109A2.9 2.9 0 0 1 23 19.81a2.93 2.93 0 0 1-2.13-.87 2.694 2.694 0 0 1-.56-3.38l-2-2.06a3 3 0 0 1-.31.12V20a3 3 0 0 1 1.44 1.09 2.92 2.92 0 0 1 .56 1.72 2.88 2.88 0 0 1-.878 2.128 2.98 2.98 0 0 1-2.048.871 2.981 2.981 0 0 1-2.514-4.719A3 3 0 0 1 16 20v-6.38a2.96 2.96 0 0 1-1.44-1.09 2.9 2.9 0 0 1-.56-1.72 2.9 2.9 0 0 1 .31-1.31l-3.9-3.9-7.579 7.572a4 4 0 0 0-.001 5.658l10.342 10.342a4 4 0 0 0 5.656 0l10.344-10.344a4 4 0 0 0 0-5.656L18.828 2.828a4 4 0 0 0-5.656 0"/>
+    </svg>
+  ),
+  'nodejs': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#8bc34a" d="M16 20.003v2h4a2 2 0 0 0 2-2v-2a2 2 0 0 0-2-2h-2v-2h4v-2h-4a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h2v2Z"/><path fill="#8bc34a" d="m16 3.003-12 7v14l4 2h6v-13.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v11.5H8l-2-1.034V11.15l10-5.833 10 5.833v11.703l-10 5.833-1.745-1.022L13 29.253l3 1.75 12-7v-14Z"/>
+    </svg>
+  ),
+  'npm': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#e53935" d="M4 4v24h24V4Zm20 20h-4V12h-4v12H8V8h16Z"/>
+    </svg>
+  ),
+  'pnpm': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#e0e0e0" d="M2 22h8v8H2zm10 0h8v8h-8zm10 0h8v8h-8zM12 12h8v8h-8z"/><path fill="#ffb300" d="M2 2h8v8H2zm10 0h8v8h-8zm10 0h8v8h-8zm0 10h8v8h-8z"/>
+    </svg>
+  ),
+  'yarn': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#0288d1" d="M27.575 23.967a9.9 9.9 0 0 0-3.751 1.726 22.6 22.6 0 0 1-5.537 2.504 1.55 1.55 0 0 1-.931.52 59 59 0 0 1-6.11.548c-1.102.008-1.777-.282-1.965-.735a1.49 1.49 0 0 1 .82-1.965 3.6 3.6 0 0 1-.486-.359c-.163-.162-.334-.487-.385-.367-.213.52-.324 1.794-.897 2.366-.786.795-2.273.53-3.153.069-.965-.513.069-1.718.069-1.718a.69.69 0 0 1-.94-.324 4.6 4.6 0 0 1-.632-2.794 5.2 5.2 0 0 1 1.674-2.76 8.84 8.84 0 0 1 .624-4.17 9.9 9.9 0 0 1 3-3.469S7.136 11.015 7.82 9.177c.444-1.196.623-1.187.769-1.239a3.44 3.44 0 0 0 1.375-.811 4.99 4.99 0 0 1 4.178-1.607s1.094-3.357 2.12-2.7a17.4 17.4 0 0 1 1.452 2.735s1.213-.71 1.35-.445a10.74 10.74 0 0 1 .495 5.81 13.3 13.3 0 0 1-2.46 5.127c-.129.214 1.47.889 2.477 3.683.932 2.554.103 4.699.248 4.938.026.043.034.06.034.06s1.068.085 3.213-1.24a8.05 8.05 0 0 1 4.05-1.52 1.026 1.026 0 0 1 .453 2Z"/>
+    </svg>
+  ),
+  'bun': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#fff8e1" d="M30 17.045a9.8 9.8 0 0 0-.32-2.306l-.004.034a11.2 11.2 0 0 0-5.762-6.786c-3.495-1.89-5.243-3.326-6.8-3.811h.003c-1.95-.695-3.949.82-5.825 1.927-4.52 2.481-9.573 5.45-9.28 11.417.008-.029.017-.052.026-.08a9.97 9.97 0 0 0 3.934 7.257l-.01-.006C13.747 31.473 30.05 27.292 30 17.045"/><path fill="#37474f" d="M19.855 20.236A.8.8 0 0 0 19.26 20h-6.514a.8.8 0 0 0-.596.236.51.51 0 0 0-.137.463 4.37 4.37 0 0 0 1.641 2.339 4.2 4.2 0 0 0 2.349.926 4.2 4.2 0 0 0 2.343-.926 4.37 4.37 0 0 0 1.642-2.339.5.5 0 0 0-.132-.463Z"/><ellipse cx="22.5" cy="18.5" fill="#f8bbd0" rx="2.5" ry="1.5"/><ellipse cx="9.5" cy="18.5" fill="#f8bbd0" rx="2.5" ry="1.5"/><circle cx="10" cy="16" r="2" fill="#37474f"/><circle cx="22" cy="16" r="2" fill="#37474f"/><path fill="#455a64" d="M9.996 18A2 2 0 1 0 8 15.996V16a2 2 0 0 0 1.996 2"/><circle cx="9" cy="15" r="1" fill="#fafafa"/><circle cx="21" cy="15" r="1" fill="#fafafa"/>
+    </svg>
+  ),
+  'playwright': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ef5350" d="M9.708 15.968v-1.429l-3.97 1.125s.294-1.703 2.364-2.291a3.45 3.45 0 0 1 1.605-.091v-5.86h1.988a12 12 0 0 0-.601-1.541c-.291-.591-.589-.2-1.266.367-.477.398-1.682 1.248-3.495 1.737s-3.278.359-3.89.253c-.867-.15-1.321-.341-1.278.32.037.58.175 1.483.492 2.673.688 2.58 2.957 7.55 7.245 6.395 1.12-.302 1.91-.898 2.459-1.66H9.708zm-6.404-4.701 3.047-.803s-.09 1.173-1.232 1.474-1.816-.671-1.816-.671z"/><path fill="#4caf50" d="M21.178 7.49c-.792.14-2.694.312-5.042-.318-2.35-.63-3.908-1.729-4.526-2.246-.876-.733-1.26-1.244-1.64-.473-.335.68-.763 1.786-1.178 3.337-.898 3.354-1.57 10.432 3.985 11.921s8.512-4.978 9.41-8.333c.416-1.548.597-2.72.647-3.477.058-.857-.53-.608-1.656-.41zm-11.162 2.776s.875-1.363 2.36-.94c1.486.422 1.6 2.065 1.6 2.065zm3.624 6.11c-2.611-.765-3.014-2.848-3.014-2.848l7.016 1.962s-1.416 1.64-4.002.886m2.482-4.28s.874-1.362 2.358-.938 1.602 2.065 1.602 2.065z"/>
+    </svg>
+  ),
+  'vite': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#a0f" d="M29.313 12h-6.664a1.427 1.427 0 0 1-1.1-2.24l4.398-6.676A.703.703 0 0 0 25.397 2H8.428a.62.62 0 0 0-.55.289l-5.77 8.627A.703.703 0 0 0 2.658 12h8.175a1.427 1.427 0 0 1 1.099 2.24l-4.48 6.676A.702.702 0 0 0 8 22l6.695.002A1.34 1.34 0 0 1 16 23.375v5.934a.652.652 0 0 0 1.168.433l12.694-16.586a.725.725 0 0 0-.55-1.156"/>
+    </svg>
+  ),
+  'vitest': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#00e676" d="M15.438 29.636a.685.685 0 0 1-1.029.213L2.274 20.755A.65.65 0 0 1 2 20.187V9.175a.715.715 0 0 1 1.166-.568l7.404 5.612a1.47 1.47 0 0 0 2.125-.497l6.102-11.367A.72.72 0 0 1 19.414 2h9.872a.76.76 0 0 1 .617 1.137l-14.465 26.57Z"/>
+    </svg>
+  ),
+  'tsdown': (size: number) => (
+    <svg width={size} height={size} xmlSpace="preserve" viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#757575" d="M14.999 11h10l-5 11H10z"/><path fill="#bdbdbd" d="M19.998 2 25 10.998H15l-5-9z"/><path fill="#9e9e9e" d="m14.998 11-5 11-5.237-8.795L10 2z"/><path fill="#ffb74d" d="m16.999 16.005 3-.006 7 12h-3z"/><path fill="#ff9800" d="m15.999 17.998 1-1.993 7 11.994-1 2z"/><path fill="#ef6c00" d="M26 29.999h-3.001l1-2h3z"/>
+    </svg>
+  ),
+  'tailwindcss': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#4db6ac" d="M23.5 12H8c.89-2.3 4.02-4 7.75-4s6.86 1.7 7.75 4M14 12h15.5c-.89 2.3-4.02 4-7.75 4s-6.86-1.7-7.75-4m3.5 8H2c.89-2.3 4.02-4 7.75-4s6.86 1.7 7.75 4M8 20h15.5c-.89 2.3-4.02 4-7.75 4S8.89 22.3 8 20"/>
+    </svg>
+  ),
+  'postcss': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#e53935" d="M20 12v8h-8v-8zm2-2H10v12h12z"/><path fill="#e53935" d="M16 5.488 26.159 20H5.84zM16 2 2 22h28z"/><path fill="#e53935" d="M16 13a3 3 0 1 1-3 3 3.003 3.003 0 0 1 3-3m0-2a5 5 0 1 0 5 5 5 5 0 0 0-5-5"/><path fill="#e53935" d="M16 4A12 12 0 1 1 4 16 12.014 12.014 0 0 1 16 4m0-2a14 14 0 1 0 14 14A14 14 0 0 0 16 2"/>
+    </svg>
+  ),
+  'eslint': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#3f51b5" d="M22.713 4H9.287a.5.5 0 0 0-.432.248l-6.708 11.5a.5.5 0 0 0 0 .504l6.708 11.5a.5.5 0 0 0 .432.248h13.426a.5.5 0 0 0 .432-.248l6.708-11.5a.5.5 0 0 0 0-.504l-6.708-11.5A.5.5 0 0 0 22.713 4m-6.937 20.888-7.5-3.75A.5.5 0 0 1 8 20.691v-9.382a.5.5 0 0 1 .276-.447l7.5-3.75a.5.5 0 0 1 .448 0l7.5 3.75a.5.5 0 0 1 .276.447v9.382a.5.5 0 0 1-.276.447l-7.5 3.75a.5.5 0 0 1-.448 0"/><path fill="#7986cb" d="M22 19.441v-6.882a.5.5 0 0 0-.276-.447l-5.5-2.75a.5.5 0 0 0-.448 0l-5.5 2.75a.5.5 0 0 0-.276.447v6.882a.5.5 0 0 0 .276.447l5.5 2.75a.5.5 0 0 0 .448 0l5.5-2.75a.5.5 0 0 0 .276-.447"/>
+    </svg>
+  ),
+  'prettier': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f44336" d="M2 8h4v1H2zm0 6h4v1H2zm9-10h3v1h-3zM2 2h3v1H2z"/><path fill="#f9a825" d="M9 2h3v1H9zm1 4h4v1h-4zm-5 6h1v1H5zm-3-2h6v1H2z"/><path fill="#26a69a" d="M2 12h3v1H2zm7-4h5v1H9zM2 4h4v1H2zm3-2h4v1H5z"/><path fill="#ba68c8" d="M2 6h3v1H2zm7-2h2v1H9zm-1 6h4v1H8z"/>
+    </svg>
+  ),
+  'tsconfig': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#757575" d="M15 2H6a2.006 2.006 0 0 0-2 2v22a2.006 2.006 0 0 0 2 2h6v-4H6v-2h6v-2H6v-2h6v-2H6v-2h6v-2h2V4l8 8h2v-1Z" /><path fill="#0288d1" d="M12 12v18h18V12Zm8 6h-2v8h-2v-8h-2v-2h6Zm8 0h-4v2h2a2.006 2.006 0 0 1 2 2v2a2.006 2.006 0 0 1-2 2h-4v-2h4v-2h-2a2.006 2.006 0 0 1-2-2v-2a2.006 2.006 0 0 1 2-2h4Z"/>
+    </svg>
+  ),
+  'readme': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path d="M0 0h24v24H0z"/><path fill="#42a5f5" d="M8 1C4.136 1 1 4.136 1 8s3.136 7 7 7 7-3.136 7-7-3.136-7-7-7m1 11H7V7.5h2zm0-6H7V4h2z"/>
+    </svg>
+  ),
+  'certificate': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff5722" d="M2 2a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h6v3l2-1.25L12 14v-3h2a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1Zm0 1h4v1H2Zm6 0 2 1.25L12 3v2.5l2 1-2 1V10l-2-1.25L8 10V7.5l-2-1 2-1zM2 5h3v1H2Zm0 2h3v1H2Zm0 2h4v1H2Z"/>
+    </svg>
+  ),
+  'pdf': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ef5350" d="M13 9h5.5L13 3.5zM6 2h8l6 6v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2m4.93 10.44c.41.9.93 1.64 1.53 2.15l.41.32c-.87.16-2.07.44-3.34.93l-.11.04.5-1.04c.45-.87.78-1.66 1.01-2.4m6.48 3.81c.18-.18.27-.41.28-.66.03-.2-.02-.39-.12-.55-.29-.47-1.04-.69-2.28-.69l-1.29.07-.87-.58c-.63-.52-1.2-1.43-1.6-2.56l.04-.14c.33-1.33.64-2.94-.02-3.6a.85.85 0 0 0-.61-.24h-.24c-.37 0-.7.39-.79.77-.37 1.33-.15 2.06.22 3.27v.01c-.25.88-.57 1.9-1.08 2.93l-.96 1.8-.89.49c-1.2.75-1.77 1.59-1.88 2.12-.04.19-.02.36.05.54l.03.05.48.31.44.11c.81 0 1.73-.95 2.97-3.07l.18-.07c1.03-.33 2.31-.56 4.03-.75 1.03.51 2.24.74 3 .74.44 0 .74-.11.91-.3m-.41-.71.09.11c-.01.1-.04.11-.09.13h-.04l-.19.02c-.46 0-1.17-.19-1.9-.51.09-.1.13-.1.23-.1 1.4 0 1.8.25 1.9.35M7.83 17c-.65 1.19-1.24 1.85-1.69 2 .05-.38.5-1.04 1.21-1.69zm3.02-6.91c-.23-.9-.24-1.63-.07-2.05l.07-.12.15.05c.17.24.19.56.09 1.1l-.03.16-.16.82z"/>
+    </svg>
+  ),
+  'image': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#26a69a" d="M8.5 6h4l-4-4zM3.875 1H9.5l4 4v8.6c0 .773-.616 1.4-1.375 1.4h-8.25c-.76 0-1.375-.627-1.375-1.4V2.4c0-.777.612-1.4 1.375-1.4M4 13.6h8V8l-2.625 2.8L8 9.4zm1.25-7.7c-.76 0-1.375.627-1.375 1.4s.616 1.4 1.375 1.4c.76 0 1.375-.627 1.375-1.4S6.009 5.9 5.25 5.9"/>
+    </svg>
+  ),
+  'svg': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ffb300" d="M29.168 14.03a2.7 2.7 0 0 0-1.968-.83 2.51 2.51 0 0 0-1.929.8h-4.443l3.078-3.078a2.835 2.835 0 0 0 2.857-2.842 2.6 2.6 0 0 0-.831-1.969 2.82 2.82 0 0 0-2.014-.788 2.67 2.67 0 0 0-1.968.788 2.36 2.36 0 0 0-.812 1.922L18 11.17V6.726a2.51 2.51 0 0 0 .8-1.929 2.7 2.7 0 0 0-.832-1.968 2.745 2.745 0 0 0-3.936 0 2.7 2.7 0 0 0-.832 1.968 2.51 2.51 0 0 0 .8 1.93v4.443l-3.138-3.138a2.36 2.36 0 0 0-.812-1.922 2.66 2.66 0 0 0-1.968-.788 2.83 2.83 0 0 0-2.014.788 2.6 2.6 0 0 0-.831 1.969 2.74 2.74 0 0 0 .831 2.013 2.8 2.8 0 0 0 2.026.829l3.078 3.078H6.729a2.51 2.51 0 0 0-1.929-.8 2.7 2.7 0 0 0-1.968.831 2.745 2.745 0 0 0 0 3.937 2.7 2.7 0 0 0 1.968.832 2.51 2.51 0 0 0 1.929-.8h4.443l-3.078 3.077a2.835 2.835 0 0 0-2.857 2.842 2.6 2.6 0 0 0 .831 1.969 2.82 2.82 0 0 0 2.014.788 2.67 2.67 0 0 0 1.968-.788 2.36 2.36 0 0 0 .812-1.922L14 20.827v4.444a2.51 2.51 0 0 0-.8 1.929 2.784 2.784 0 0 0 4.768 1.968A2.7 2.7 0 0 0 18.8 27.2a2.51 2.51 0 0 0-.8-1.929v-4.444l3.138 3.138a2.36 2.36 0 0 0 .812 1.922 2.66 2.66 0 0 0 1.968.788 2.83 2.83 0 0 0 2.014-.788 2.6 2.6 0 0 0 .831-1.969 2.74 2.74 0 0 0-.831-2.013 2.8 2.8 0 0 0-2.026-.829L20.828 18h4.443a2.51 2.51 0 0 0 1.93.8 2.784 2.784 0 0 0 1.967-4.769Z"/>
+    </svg>
+  ),
+  'table': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#8bc34a" d="M6 2h8l6 6v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2m7 1.5V9h5.5zm4 7.5h-4v2h1l-2 1.67L10 13h1v-2H7v2h1l3 2.5L8 18H7v2h4v-2h-1l2-1.67L14 18h-1v2h4v-2h-1l-3-2.5 3-2.5h1z"/>
+    </svg>
+  ),
+  'word': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#01579b" d="M6 2h8l6 6v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2m7 1.5V9h5.5zM7 13l1.5 7h2l1.5-3 1.5 3h2l1.5-7h1v-2h-4v2h1l-.9 4.2L13 15h-2l-1.1 2.2L9 13h1v-2H6v2z"/>
+    </svg>
+  ),
+  'powerpoint': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#e64a19" d="M6 2h8l6 6v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2m7 1.5V9h5.5zM8 11v2h1v6H8v1h4v-1h-1v-2h2a3 3 0 0 0 3-3 3 3 0 0 0-3-3zm5 2a1 1 0 0 1 1 1 1 1 0 0 1-1 1h-2v-2z"/>
+    </svg>
+  ),
+  'zip': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#afb42b" d="M14 17h-2v-2h-2v-2h2v2h2m0-6h-2v2h2v2h-2v-2h-2V9h2V7h-2V5h2v2h2m5-4H5c-1.11 0-2 .89-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2"/>
+    </svg>
+  ),
+  'font': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f44336" d="M24 28h4L18 4h-4L4 28h4l8-19.422"/><path fill="#f44336" d="M8 20h16v4H8z"/>
+    </svg>
+  ),
+  'tune': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#fbc02d" d="M12 10h10v2H12z"/><path fill="#fbc02d" d="M16 4h2v8h-2zm4 18h10v2H20zm4 2h2v4h-2zm0-20h2v14h-2zM2 18h10v2H2z"/><path fill="#fbc02d" d="M6 18h2v10H6zM6 4h2v10H6zm10 12h2v12h-2z"/>
+    </svg>
+  ),
+  'document': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path d="M0 0h24v24H0z"/><path fill="#42a5f5" d="M8 16h8v2H8zm0-4h8v2H8zm6-10H6c-1.1 0-2 .9-2 2v16c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8zm4 18H6V4h7v5h5z"/>
+    </svg>
+  ),
+  'settings': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path d="M0 0h24v24H0z"/><path fill="#42a5f5" d="M19.43 12.98c.04-.32.07-.64.07-.98s-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46a.5.5 0 0 0-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65A.49.49 0 0 0 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1a.6.6 0 0 0-.18-.03c-.17 0-.34.09-.43.25l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98s.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46a.5.5 0 0 0 .61.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1q.09.03.18.03c.17 0 .34-.09.43-.25l2-3.46c.12-.22.07-.49-.12-.64zm-1.98-1.71c.04.31.05.52.05.73s-.02.43-.05.73l-.14 1.13.89.7 1.08.84-.7 1.21-1.27-.51-1.04-.42-.9.68c-.43.32-.84.56-1.25.73l-1.06.43-.16 1.13-.2 1.35h-1.4l-.19-1.35-.16-1.13-1.06-.43c-.43-.18-.83-.41-1.23-.71l-.91-.7-1.06.43-1.27.51-.7-1.21 1.08-.84.89-.7-.14-1.13c-.03-.31-.05-.54-.05-.74s.02-.43.05-.73l.14-1.13-.89-.7-1.08-.84.7-1.21 1.27.51 1.04.42.9-.68c.43-.32.84-.56 1.25-.73l1.06-.43.16-1.13.2-1.35h1.39l.19 1.35.16 1.13 1.06.43c.43.18.83.41 1.23.71l.91.7 1.06-.43 1.27-.51.7 1.21-1.07.85-.89.7zM12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2"/>
+    </svg>
+  ),
+  'graphql': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ec407a" d="M6 20h20v2H6z"/><circle cx="7" cy="21" r="3" fill="#ec407a"/><circle cx="16" cy="27" r="3" fill="#ec407a"/><circle cx="25" cy="21" r="3" fill="#ec407a"/><path fill="#ec407a" d="M6 10h20v2H6z"/><circle cx="7" cy="11" r="3" fill="#ec407a"/><circle cx="16" cy="5" r="3" fill="#ec407a"/><circle cx="25" cy="11" r="3" fill="#ec407a"/><path fill="#ec407a" d="M6 12h2v10H6zm18-2h2v12h-2z"/><path fill="#ec407a" d="m5.014 19.41 11.674 6.866L15.674 28 4 21.134z"/><path fill="#ec407a" d="M26.688 21.724 15.014 28.59 14 26.866 25.674 20zM5.124 10.382l11.415-7.29 1.077 1.686L6.2 12.068z"/><path fill="#ec407a" d="m25.798 12.067-11.415-7.29 1.077-1.685 11.415 7.29zM6.2 19.932l11.416 7.29-1.077 1.686-11.415-7.29z"/><path fill="#ec407a" d="m26.875 21.619-11.415 7.29-1.077-1.687 11.415-7.289zM5.877 22.6 16.04 3.686l1.762.946L7.638 23.546z"/><path fill="#ec407a" d="M24.361 23.545 14.197 4.633l1.761-.947 10.165 18.913z"/>
+    </svg>
+  ),
+  'proto': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#00bfa5" d="M16 27 2 19v-5l14 8z"/><path fill="#ffeb3b" d="m30 14-14 8v5l14-8z"/><path fill="#ff5722" d="M16 6 2 14v5l14-8z"/><path fill="#00e676" d="m30 19-14-8V6l14 8z"/><path fill="#03a9f4" d="M16 27 2 19v-5l14 8z"/>
+    </svg>
+  ),
+  'webassembly': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#7c4dff" d="M22 18h4v4h-4z"/><path fill="#7c4dff" d="M20 2a4 4 0 0 1-8 0H2v28h28V2Zm-2 24h-2v2h-4v-2h-2v2H6v-2H4V16h2v10h4V16h2v10h4V16h2Zm10 2h-2v-4h-4v4h-2V18h2v-2h4v2h2Z"/>
+    </svg>
+  ),
+  'audio': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ef5350" d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2m6 10h-4v8a4 4 0 1 1-4-4 3.96 3.96 0 0 1 2 .555V8h6Z"/>
+    </svg>
+  ),
+  'video': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#ff9800" d="m24 6 2 6h-4l-2-6h-3l2 6h-4l-2-6h-3l2 6H8L6 6H5a3 3 0 0 0-3 3v14a3 3 0 0 0 3 3h22a3 3 0 0 0 3-3V6Z"/>
+    </svg>
+  ),
+  'file': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" style={{ flexShrink: 0 }}>
+      <path d="m8.668 6h3.6641l-3.6641-3.668v3.668m-4.668-4.668h5.332l4 4v8c0 0.73828-0.59375 1.3359-1.332 1.3359h-8c-0.73828 0-1.332-0.59766-1.332-1.3359v-10.664c0-0.74219 0.59375-1.3359 1.332-1.3359m3.332 1.3359h-3.332v10.664h8v-6h-4.668z" fill="#90a4ae" />
+    </svg>
+  ),
+  'jest': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f4511e" d="m21.032 8-1.878 4L20 13.998h2L22.928 12z"/><path fill="#f4511e" d="m14 2 2 8h2l3.032-6L24 10h2l2-8zm14 18h-2a4.34 4.34 0 0 1-4-4h-2a4.17 4.17 0 0 1-4.23 3.87c-1.522 2.38-5.155 4.283-7.77 5.148A4.724 4.724 0 0 1 5 20H4c-4.718 7.978 3.064 13.219 10.955 7.895C18.85 24.497 29.658 27.487 28 20"/><circle cx="7" cy="15" r="3" fill="#f4511e"/><circle cx="27" cy="15" r="3" fill="#f4511e"/><circle cx="16" cy="16" r="2" fill="#f4511e"/>
+    </svg>
+  ),
+  'webpack': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#fafafa" fillOpacity=".785" d="m19.376 15.988-7.708 4.45-7.709-4.45v-8.9l7.709-4.451 7.708 4.45z"/><path fill="#90caf9" d="M12.286 1.98c-.21 0-.41.059-.57.179l-7.9 4.44c-.32.17-.53.5-.53.88v9c0 .38.21.711.53.881l7.9 4.44c.16.12.36.18.57.18s.41-.06.57-.18l7.9-4.44c.32-.17.53-.5.53-.88v-9c0-.38-.21-.712-.53-.882l-7.9-4.44a.95.95 0 0 0-.57-.179zm0 2.15 7 3.94v2.103h-.016v5.177h.016v.54l-7 3.939-7-3.94V8.07zm0 2.08-4.9 2.83 4.9 2.83 4.9-2.83zm-5 5.08v3.58l4 2.309v-3.58l-4-2.31zm10 0-4 2.308v3.58l4-2.308z"/><path fill="#0277bd" d="m12.286 6.21-4.9 2.83 4.9 2.83 4.9-2.83zm-5 5.08v3.58l4 2.309v-3.58l-4-2.31zm10 0-4 2.308v3.58l4-2.308z"/>
+    </svg>
+  ),
+  'rollup': (size: number) => (
+    <svg width={size} height={size} viewBox="100 100 800 800" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#f44336" d="M733.79 394.71c0 77.407-42.308 144.79-104.67 180.51-3.76 3.134-5.954 8.148-3.76 12.849l106.87 211.22c2.82 6.581-1.568 14.103-8.776 14.103h-408.35l2.194-1.254c15.356-8.774 121.91-219.06 225.95-318.72 104.05-99.658 117.21-66.439 59.857-174.87 0 0 44.188 86.182 6.581 92.763-29.459 5.328-97.15-60.17-72.08-119.09 25.071-57.664 123.79-46.695 169.23.314 17.236 30.085 26.952 64.872 26.952 102.17m-385.47 140.71c-41.367 76.154-67.692 131.62-82.108 170.48v-509.57c0-5.328 4.388-9.715 9.715-9.715h252.91c73.333 1.253 137.58 40.114 173.62 98.718-26.325-32.906-67.692-51.71-108.43-51.71-77.407 0-96.837 28.206-245.7 301.79z"/>
+    </svg>
+  ),
+  'babel': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#fdd835" d="M18.23 11.21q-.045-.24-1.32-1.65c-.02-.19.29-.45.9-.8l1.74-1.55c.39-.5.62-1.28.69-2.38l-.02-.26c-.07-.78-.63-1.4-1.69-1.89-.63-.42-1.76-.65-3.38-.68-1.35.11-3.11.59-5.28 1.43-.6.43-1.28.86-2.04 1.28l.01.14.21-.08c.08-.01.13.03.14.11l.13-.07.07-.01.01.06c0 .07-.47.44-1.76 1.35l-.06.12c-.31.02-.61.25-.91.67l.08.12.25-.09.18.24c.32-.33.66-.62 1.03-.87.19.05.29.11.44.16 1.02-.75 2.03-1.3 3.04-1.64l.01.14c-.2.27-.32.42-.38.42l.1.23c.01.19-2.55 7-6.66 14.44l.08.19c.35-.08.58-.17.75-.26l.01.13.4-.03-.67 1.76.14.06c.57-.64 1-1.29 1.3-1.88 1.67-.49 2.94-.97 3.82-1.44.88-.08 1.56-.31 2.02-.7l.92-.47c1.27-.98 2.22-1.67 2.87-2.08 1.33-.98 2.2-1.93 2.6-2.85zm-3.46 2.31L13 14.91c-1.29.85-2 1.3-2.09 1.3-2.07 1.13-3.36 1.72-3.86 1.76l-.05.01c.04-.23.96-2.12 2.75-5.67.78-.06 2.02-.43 3.71-1.1l.41-.03c.85-.08 1.49.09 1.91.49l.03.26c-.31.9-.67 1.44-1.04 1.59m1.09-5.78q-.27.33-1.5 1.11c-.27.03-1.27.42-3.01 1.18l-.28-.05-.01-.12c-.02-.25.09-.57.34-.95.13-.7.28-1.12.44-1.2l1.45-3.28c-.02-.22.29-.35.93-.46l.21-.02.01.18 1.16-.16c1.15-.1 1.75.14 1.8.7l.13-.02-.03-.32.15-.02c.35.19.52.4.54.68.02.18-.08.41-.29.68-.09.01-.14-.06-.15-.18l-.14.01-.03.4c-.58.87-1.01 1.31-1.27 1.34z"/>
+    </svg>
+  ),
+  'next': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#cfd8dc" d="M16 2a14 14 0 1 0 5.816 26.723L12 14v9a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h2.434a1 1 0 0 1 .857.486l11.491 19.15A14 14 0 0 0 16 2m8 16h-4V9a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1Z"/>
+    </svg>
+  ),
+  'remix': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#b0bec5" d="M28 12v-2a8 8 0 0 0-8-8H4v6h12.83a3.114 3.114 0 0 1 3.166 2.839A3 3 0 0 1 17 14H4v6h12a4 4 0 0 1 4 4v6h8v-5a7 7 0 0 0-7-7h1a6 6 0 0 0 6-6M12 26H4v4h10v-2a2 2 0 0 0-2-2"/>
+    </svg>
+  ),
+  'astro': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#7c4dff" d="M12.106 25.849c-1.262-1.156-1.63-3.586-1.105-5.346a5.18 5.18 0 0 0 3.484 1.66 9.68 9.68 0 0 0 5.882-.734c.215-.106.413-.247.648-.39a3.5 3.5 0 0 1 .16 1.555 4.26 4.26 0 0 1-1.798 3.021c-.404.3-.832.569-1.25.852a2.613 2.613 0 0 0-1.15 3.372l.048.161a3.4 3.4 0 0 1-1.5-1.285 3.6 3.6 0 0 1-.578-1.962 9 9 0 0 0-.05-1.037c-.114-.831-.504-1.204-1.238-1.225a1.45 1.45 0 0 0-1.507 1.18c-.012.056-.028.112-.046.178M4.901 20a17.75 17.75 0 0 1 7.4-2l2.913-8.38a.765.765 0 0 1 1.527 0L19.7 18a14.24 14.24 0 0 1 7.399 2S20.704 2.877 20.692 2.842C20.51 2.33 20.202 2 19.787 2h-7.619c-.415 0-.71.33-.904.842z"/>
+    </svg>
+  ),
+  'nuxt': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#00e676" d="m30.27 23-6.93-12a1.98 1.98 0 0 0-1.73-1 1.96 1.96 0 0 0-1.73 1l-2.27 3.93-3.88-6.71a1.996 1.996 0 0 0-3.46 0L1.73 23a2 2 0 0 0 1.73 3h8.915a6 6 0 0 0 5.197-3.001L21.61 16l3.46 6h-2.31l-2.31 4h8.09a2 2 0 0 0 1.73-3m-17.896-1H6.93L12 13.22l3.3 5.71-1.193 2.069A2 2 0 0 1 12.374 22"/>
+    </svg>
+  ),
+  'turborepo': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <defs><linearGradient id="a" x1="27.349" x2="7.613" y1="26.455" y2="6.719" gradientTransform="matrix(1 0 0 -1 0 34)" gradientUnits="userSpaceOnUse"><stop offset=".15" stopColor="#2196f3"/><stop offset=".85" stopColor="#f50057"/></linearGradient></defs><path fill="#cfd8dc" d="M16 8a8 8 0 1 0 8 8 8 8 0 0 0-8-8m0 12a4 4 0 1 1 4-4 4 4 0 0 1-4 4"/><path fill="url(#a)" d="M4.281 23.647A13.9 13.9 0 0 1 2 16h4a9.95 9.95 0 0 0 1.192 4.736ZM14 29.84v-4.042a9.9 9.9 0 0 1-3.892-1.732l-2.854 2.855A13.9 13.9 0 0 0 14 29.84M16 2v4a10 10 0 0 1 2 19.8v4.04A13.992 13.992 0 0 0 16 2"/>
+    </svg>
+  ),
+  'biome': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 74 74" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#42a5f5" d="M37 9 22.745 33.69a32.2 32.2 0 0 1 16.869-.584l4.818 1.137-4.533 19.22-4.825-1.137c-5.93-1.399-11.628 1.716-14.036 6.685l-4.46-2.158c3.404-7.029 11.425-11.285 19.637-9.347l2.259-9.58A27.23 27.23 0 0 0 5 64.424l64 .001z"/>
+    </svg>
+  ),
+  'deno': (size: number) => (
+    <svg width={size} height={size} viewBox="0 0 32 32" fill="none" style={{ flexShrink: 0 }}>
+      <path fill="#cfd8dc" d="M3.288 23.102A13.937 14.098 0 0 1 2 17.16c0-.553.028-1.09.091-1.622a14.049 14.211 0 0 1 .273-1.586 14 14.162 0 0 1 4.333-7.37 14.007 14.169 0 0 1 6.37-3.272 14.028 14.19 0 0 1 3.997-.27 13.958 14.12 0 0 1 4.76 1.24 14.021 14.183 0 0 1 3.241 2.089 14.028 14.19 0 0 1 4.732 8.355A14.063 14.225 0 0 1 30 17.161a14.175 14.339 0 0 1-.042 1.076 13.986 14.147 0 0 1-.847 3.902 14.007 14.169 0 0 1-2.779 4.574A7.245 7.329 0 0 1 21.166 29a5.054 5.112 0 0 1-4.816-6.444c.119-.453.434-1.317.889-1.699a5.334 5.396 0 0 1-1.435-.977c-.049-.057-.042-.156.007-.22a.182.184 0 0 1 .203-.056 10.206 10.324 0 0 0 1.596.41c.777.128 1.736.298 2.709.34 2.366.12 4.844-.956 5.614-3.094.763-2.146.469-4.263-2.289-5.53-2.758-1.275-4.032-2.783-6.258-3.696-1.456-.595-3.073-.241-4.732.694-4.48 2.5-8.491 10.408-6.643 17.737a.224.227 0 0 1-.364.22 14.077 14.24 0 0 1-1.463-1.927 14.021 14.183 0 0 1-.896-1.656M15.503 9.018c.749-.057 1.414.595 1.526 1.459.147 1.154-.273 2.35-1.645 2.379-1.183.02-1.54-1.176-1.456-1.905.077-.73.665-1.862 1.568-1.933z"/>
+    </svg>
+  ),
+}
+
+// Exact filename to icon ID (lowercased)
+const EXACT_FILES: Record<string, string> = {
+  'package.json': 'nodejs',
+  'package-lock.json': 'nodejs',
+  '.nvmrc': 'nodejs',
+  '.node-version': 'nodejs',
+  '.esmrc': 'nodejs',
+  'pnpm-lock.yaml': 'pnpm',
+  'pnpm-workspace.yaml': 'pnpm',
+  '.pnpmfile.cjs': 'pnpm',
+  'yarn.lock': 'yarn',
+  '.yarnrc': 'yarn',
+  '.yarnrc.yml': 'yarn',
+  '.yarnrc.yaml': 'yarn',
+  'bun.lockb': 'bun',
+  'bun.lock': 'bun',
+  'bunfig.toml': 'bun',
+  '.bun-version': 'bun',
+  'deno.json': 'deno',
+  'deno.jsonc': 'deno',
+  'deno.lock': 'deno',
+  'turbo.json': 'turborepo',
+  'turbo.jsonc': 'turborepo',
+  'biome.json': 'biome',
+  'biome.jsonc': 'biome',
+  'tsconfig.json': 'tsconfig',
+  'tsconfig.build.json': 'tsconfig',
+  'tsconfig.esm.json': 'tsconfig',
+  'tsconfig.node.json': 'tsconfig',
+  'tsconfig.app.json': 'tsconfig',
+  'tsconfig.spec.json': 'tsconfig',
+  'jsconfig.json': 'tsconfig',
+  'tsdown.config.ts': 'tsdown',
+  'tsdown.config.js': 'tsdown',
+  'tsdown.config.mjs': 'tsdown',
+  'tsdown.config.cjs': 'tsdown',
+  'tsdown.config.json': 'tsdown',
+  'playwright.config.ts': 'playwright',
+  'playwright.config.js': 'playwright',
+  'playwright.config.mjs': 'playwright',
+  'playwright.config.cjs': 'playwright',
+  'vitest.config.ts': 'vitest',
+  'vitest.config.js': 'vitest',
+  'vitest.config.mjs': 'vitest',
+  'vitest.config.cjs': 'vitest',
+  'vitest.config.mts': 'vitest',
+  'vitest.config.cts': 'vitest',
+  'jest.config.js': 'jest',
+  'jest.config.ts': 'jest',
+  'jest.config.cjs': 'jest',
+  'jest.config.mjs': 'jest',
+  'jest.config.json': 'jest',
+  'vite.config.ts': 'vite',
+  'vite.config.js': 'vite',
+  'vite.config.mjs': 'vite',
+  'vite.config.cjs': 'vite',
+  'vite.config.mts': 'vite',
+  'vite.config.cts': 'vite',
+  'rollup.config.js': 'rollup',
+  'rollup.config.ts': 'rollup',
+  'rollup.config.mjs': 'rollup',
+  'rollup.config.cjs': 'rollup',
+  'webpack.config.js': 'webpack',
+  'webpack.config.ts': 'webpack',
+  'webpack.config.cjs': 'webpack',
+  'webpack.config.mjs': 'webpack',
+  'next.config.js': 'next',
+  'next.config.ts': 'next',
+  'next.config.mjs': 'next',
+  'nuxt.config.js': 'nuxt',
+  'nuxt.config.ts': 'nuxt',
+  'astro.config.mjs': 'astro',
+  'astro.config.js': 'astro',
+  'astro.config.ts': 'astro',
+  'tailwind.config.js': 'tailwindcss',
+  'tailwind.config.ts': 'tailwindcss',
+  'tailwind.config.mjs': 'tailwindcss',
+  'tailwind.config.cjs': 'tailwindcss',
+  'postcss.config.js': 'postcss',
+  'postcss.config.ts': 'postcss',
+  'postcss.config.mjs': 'postcss',
+  'postcss.config.cjs': 'postcss',
+  'postcss.config.json': 'postcss',
+  '.postcssrc': 'postcss',
+  '.postcssrc.json': 'postcss',
+  '.postcssrc.js': 'postcss',
+  'eslint.config.js': 'eslint',
+  'eslint.config.mjs': 'eslint',
+  'eslint.config.cjs': 'eslint',
+  'eslint.config.ts': 'eslint',
+  'eslint.config.mts': 'eslint',
+  'eslint.config.cts': 'eslint',
+  '.eslintrc': 'eslint',
+  '.eslintrc.json': 'eslint',
+  '.eslintrc.js': 'eslint',
+  '.eslintrc.cjs': 'eslint',
+  '.eslintrc.yml': 'eslint',
+  '.eslintrc.yaml': 'eslint',
+  'prettier.config.js': 'prettier',
+  'prettier.config.mjs': 'prettier',
+  'prettier.config.cjs': 'prettier',
+  'prettier.config.ts': 'prettier',
+  '.prettierrc': 'prettier',
+  '.prettierrc.json': 'prettier',
+  '.prettierrc.js': 'prettier',
+  '.prettierrc.cjs': 'prettier',
+  '.prettierrc.yml': 'prettier',
+  '.prettierrc.yaml': 'prettier',
+  '.prettierrc.toml': 'prettier',
+  'cargo.toml': 'rust',
+  'cargo.lock': 'rust',
+  'go.mod': 'go',
+  'go.sum': 'go',
+  'go.work': 'go',
+  'requirements.txt': 'python',
+  'pipfile': 'python',
+  'pipfile.lock': 'python',
+  'poetry.lock': 'python',
+  'pyproject.toml': 'python',
+  'gemfile': 'ruby',
+  'gemfile.lock': 'ruby',
+  'dockerfile': 'docker',
+  'docker-compose.yml': 'docker',
+  'docker-compose.yaml': 'docker',
+  '.dockerignore': 'docker',
+  '.gitignore': 'git',
+  '.gitmodules': 'git',
+  '.gitattributes': 'git',
+  '.gitkeep': 'git',
+  '.env': 'tune',
+  'license': 'certificate',
+  'licence': 'certificate',
+  'copying': 'certificate',
+  'readme': 'readme',
+  'readme.md': 'readme',
+  'readme_en.md': 'readme',
+  'readme.txt': 'readme',
+  'changelog': 'readme',
+  'changelog.md': 'readme',
+  '.editorconfig': 'settings',
+  'dsh.plugin.json': 'json',
+}
+
+// Extension to icon ID (lowercased)
+const EXT_MAP: Record<string, string> = {
+  ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
+  tsx: 'react_ts',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'react',
+  vue: 'vue',
+  svelte: 'svelte',
+  astro: 'astro',
+  py: 'python',
+  pyw: 'python',
+  ipynb: 'python',
+  rs: 'rust',
+  go: 'go',
+  cpp: 'cpp',
+  hpp: 'cpp',
+  cc: 'cpp',
+  cxx: 'cpp',
+  'c++': 'cpp',
+  hh: 'cpp',
+  hxx: 'cpp',
+  c: 'c',
+  h: 'c',
+  cs: 'csharp',
+  csx: 'csharp',
+  csproj: 'csharp',
+  sln: 'csharp',
+  java: 'java',
+  jar: 'java',
+  class: 'java',
+  kt: 'kotlin',
+  kts: 'kotlin',
+  swift: 'swift',
+  php: 'php',
+  rb: 'ruby',
+  erb: 'ruby',
+  gemspec: 'ruby',
+  dart: 'dart',
+  lua: 'lua',
+  zig: 'zig',
+  html: 'html',
+  htm: 'html',
+  xhtml: 'html',
+  css: 'css',
+  scss: 'sass',
+  sass: 'sass',
+  less: 'less',
+  json: 'json',
+  jsonc: 'json',
+  json5: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'toml',
+  ini: 'settings',
+  conf: 'settings',
+  cfg: 'settings',
+  properties: 'settings',
+  xml: 'settings',
+  xsl: 'settings',
+  xsd: 'settings',
+  plist: 'settings',
+  md: 'markdown',
+  markdown: 'markdown',
+  mdx: 'markdown',
+  sh: 'console',
+  bash: 'console',
+  zsh: 'console',
+  fish: 'console',
+  ps1: 'powershell',
+  bat: 'console',
+  cmd: 'console',
+  sql: 'database',
+  db: 'database',
+  sqlite: 'database',
+  sqlite3: 'database',
+  prisma: 'database',
+  graphql: 'graphql',
+  gql: 'graphql',
+  proto: 'proto',
+  wasm: 'webassembly',
+  wat: 'webassembly',
+  pdf: 'pdf',
+  png: 'image',
+  jpg: 'image',
+  jpeg: 'image',
+  gif: 'image',
+  webp: 'image',
+  ico: 'image',
+  bmp: 'image',
+  avif: 'image',
+  tiff: 'image',
+  svg: 'svg',
+  doc: 'word',
+  docx: 'word',
+  odt: 'word',
+  rtf: 'word',
+  xls: 'table',
+  xlsx: 'table',
+  csv: 'table',
+  tsv: 'table',
+  ods: 'table',
+  ppt: 'powerpoint',
+  pptx: 'powerpoint',
+  odp: 'powerpoint',
+  zip: 'zip',
+  tar: 'zip',
+  gz: 'zip',
+  tgz: 'zip',
+  '7z': 'zip',
+  rar: 'zip',
+  bz2: 'zip',
+  xz: 'zip',
+  txt: 'document',
+  log: 'document',
+  ttf: 'font',
+  otf: 'font',
+  woff: 'font',
+  woff2: 'font',
+  eot: 'font',
+  mp3: 'audio',
+  wav: 'audio',
+  ogg: 'audio',
+  flac: 'audio',
+  m4a: 'audio',
+  aac: 'audio',
+  wma: 'audio',
+  mp4: 'video',
+  mov: 'video',
+  avi: 'video',
+  mkv: 'video',
+  webm: 'video',
+  flv: 'video',
+  wmv: 'video',
+}
+
+function renderIcon(name: string, size: number): ReactNode {
+  const fn = MATERIAL_ICONS[name]
+  if (fn !== undefined) return fn(size)
+  return MATERIAL_ICONS['file']?.(size) ?? null
+}
+
+/**
+ * Return the official Material Icon Theme vector SVG for a file.
+ * Extracted directly from Philipp Kief's official vscode-material-icon-theme package.
+ */
+export function fileIconFor(fileName: string, size = 14): ReactNode {
+  const name = (fileName || '').trim()
+  const lower = name.toLowerCase()
+  const base = lower.replace(/^.*[\\/]/, '')
+
+  // 1. Exact full filename match (e.g. package.json, pnpm-lock.yaml, tsconfig.json, etc.)
+  const exactIcon = EXACT_FILES[base]
+  if (exactIcon !== undefined) {
+    return renderIcon(exactIcon, size)
+  }
+
+  // 2. Prefix & pattern matches for special config / dotfiles
+  if (base.startsWith('.env')) return renderIcon('tune', size)
+  if (base.startsWith('tsconfig.') || base.startsWith('jsconfig.')) return renderIcon('tsconfig', size)
+  if (base.startsWith('tsdown.config.')) return renderIcon('tsdown', size)
+  if (base.startsWith('playwright.config.')) return renderIcon('playwright', size)
+  if (base.startsWith('vitest.config.')) return renderIcon('vitest', size)
+  if (base.startsWith('jest.config.')) return renderIcon('jest', size)
+  if (base.startsWith('vite.config.')) return renderIcon('vite', size)
+  if (base.startsWith('rollup.config.')) return renderIcon('rollup', size)
+  if (base.startsWith('webpack.config.')) return renderIcon('webpack', size)
+  if (base.startsWith('next.config.')) return renderIcon('next', size)
+  if (base.startsWith('nuxt.config.')) return renderIcon('nuxt', size)
+  if (base.startsWith('astro.config.')) return renderIcon('astro', size)
+  if (base.startsWith('tailwind.config.')) return renderIcon('tailwindcss', size)
+  if (base.startsWith('postcss.config.') || base.startsWith('.postcssrc')) return renderIcon('postcss', size)
+  if (base.startsWith('eslint.config.') || base.startsWith('.eslintrc')) return renderIcon('eslint', size)
+  if (base.startsWith('prettier.config.') || base.startsWith('.prettierrc')) return renderIcon('prettier', size)
+  if (base.startsWith('dockerfile.') || base.startsWith('docker-compose.')) return renderIcon('docker', size)
+  if (base.startsWith('readme.') || base.startsWith('readme_') || base.startsWith('changelog.') || base.startsWith('changelog_')) return renderIcon('readme', size)
+  if (base.startsWith('license.') || base.startsWith('licence.') || base.startsWith('copying.')) return renderIcon('certificate', size)
+
+  // 3. Extension match
+  const dot = base.lastIndexOf('.')
+  if (dot !== -1) {
+    const ext = base.slice(dot + 1)
+    const extIcon = EXT_MAP[ext]
+    if (extIcon !== undefined) {
+      return renderIcon(extIcon, size)
+    }
+  }
+
+  // 4. Default fallback: Material Icon document/file
+  return renderIcon('file', size)
+}

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -38,11 +38,17 @@
   gap: 4px;
 }
 
-/* The tab strip of the OPEN right panel reserves the cluster's width at its
-   right end, so the tabs and the + menu genuinely yield space to the cluster
-   (never hiding under it). */
-.panel:not(.panelHidden) .tabBar {
-  padding-right: 72px;
+.tabBarTopRight {
+  padding-right: 68px !important;
+}
+
+.tabBarBottomTopRight {
+  padding-right: 36px !important;
+}
+
+.panelMaximized {
+  z-index: 42;
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.12);
 }
 
 /* The closed-state affordance is the native rail icon control: a plain
@@ -98,8 +104,8 @@
   border-left: 1px solid var(--dsw-alias-border-l2);
   /* Expand/collapse slides the panel; fullscreen animates the width. */
   transition:
-    transform var(--ds-transition-duration-slow) var(--ds-ease-in-out),
-    width var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+    transform 240ms cubic-bezier(0.2, 0, 0, 1),
+    width 240ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 /* Collapsed: slid off-screen, interactive nothing, hidden after the slide. */
@@ -108,9 +114,9 @@
   pointer-events: none;
   visibility: hidden;
   transition:
-    transform var(--ds-transition-duration-slow) var(--ds-ease-in-out),
-    width var(--ds-transition-duration-slow) var(--ds-ease-in-out),
-    visibility 0s linear var(--ds-transition-duration-slow);
+    transform 240ms cubic-bezier(0.2, 0, 0, 1),
+    width 240ms cubic-bezier(0.2, 0, 0, 1),
+    visibility 0s linear 240ms;
 }
 
 /* Width drags write at pointer cadence; easing would detach the edge. */
@@ -161,19 +167,19 @@
   border-top: 1px solid var(--dsw-alias-border-l2);
   /* Expand/collapse slides the panel; height drags animate the height. */
   transition:
-    transform var(--ds-transition-duration-slow) var(--ds-ease-in-out),
-    height var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+    transform 240ms cubic-bezier(0.2, 0, 0, 1),
+    height 240ms cubic-bezier(0.2, 0, 0, 1);
 }
 
-/* Collapsed: slid off-screen, interactive nothing, hidden after the slide. */
+/* Collapsed: slid down off-screen, interactive nothing, hidden after the slide. */
 .bottomPanelHidden {
   transform: translateY(102%);
   pointer-events: none;
   visibility: hidden;
   transition:
-    transform var(--ds-transition-duration-slow) var(--ds-ease-in-out),
-    height var(--ds-transition-duration-slow) var(--ds-ease-in-out),
-    visibility 0s linear var(--ds-transition-duration-slow);
+    transform 240ms cubic-bezier(0.2, 0, 0, 1),
+    height 240ms cubic-bezier(0.2, 0, 0, 1),
+    visibility 0s linear 240ms;
 }
 
 /* Height drags write at pointer cadence; easing would detach the edge. */
@@ -198,15 +204,18 @@
   background: var(--dsw-alias-interactive-bg-hover-accent);
 }
 
-/* The bottom panel's close control: the app's icon-button pattern (28px
-   circle), pinned to the tab strip's right end — one tap collapses the
-   panel. The tab strips below reserve its width so the + menu never hides
-   under it. */
-.bottomClose {
+.bottomControls {
   position: absolute;
   top: 3px;
   right: 6px;
   z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.bottomMaximize,
+.bottomClose {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -221,15 +230,10 @@
   flex: none;
 }
 
+.bottomMaximize:hover:not(:disabled),
 .bottomClose:hover:not(:disabled) {
   background: var(--dsw-alias-interactive-bg-hover);
   color: var(--dsw-alias-label-primary);
-}
-
-/* The bottom panel's tab strips reserve the close control's width at their
-   right end, so the + menu never hides under it. */
-.bottomPanel .tabBar {
-  padding-right: 40px;
 }
 
 /* ── Position compatibility mode (Windows native title bar) ────────────── */
@@ -334,6 +338,8 @@
 .splitChild {
   position: relative;
   display: flex;
+  min-width: 0;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -395,6 +401,67 @@
   display: flex;
   flex-direction: column;
   background: var(--dsw-alias-bg-base);
+}
+
+.paneMaximizedGrowing {
+  position: absolute !important;
+  inset: 0 !important;
+  z-index: 25 !important;
+  animation: paneGrow 300ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  will-change: top, left, width, height, border-radius, box-shadow;
+}
+
+.paneMaximizedShrinking {
+  position: absolute !important;
+  inset: 0 !important;
+  z-index: 25 !important;
+  animation: paneShrink 280ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  pointer-events: none;
+  will-change: top, left, width, height, border-radius, box-shadow;
+}
+
+.paneMaximizedSettled {
+  position: absolute !important;
+  inset: 0 !important;
+  z-index: 25 !important;
+}
+
+@keyframes paneGrow {
+  0% {
+    top: var(--orig-top, 0px);
+    left: var(--orig-left, 0px);
+    width: var(--orig-width, 100%);
+    height: var(--orig-height, 100%);
+    border-radius: 6px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+  }
+  100% {
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    border-radius: 0px;
+    box-shadow: none;
+  }
+}
+
+@keyframes paneShrink {
+  0% {
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    border-radius: 0px;
+    box-shadow: none;
+  }
+  100% {
+    top: var(--orig-top, 0px);
+    left: var(--orig-left, 0px);
+    width: var(--orig-width, 100%);
+    height: var(--orig-height, 100%);
+    border-radius: 6px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+  }
 }
 
 .paneDrop {
@@ -617,26 +684,53 @@
 
 .tabBarPlus {
   flex: none;
-  align-self: center;
-  /* Adjacent to the rightmost tab; sticky so overflowing tab rows keep it
-     visible at the right edge of the scrollport. */
-  position: sticky;
-  right: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 22px;
   height: 22px;
-  margin: 0 6px;
+  margin: 0 4px;
   padding: 0;
   border: none;
   border-radius: 5px;
-  background: var(--dsw-alias-bg-layer-1);
+  background: transparent;
   color: var(--dsw-alias-label-tertiary);
   cursor: pointer;
+  transition: background var(--ds-transition-duration-slow) var(--ds-ease-in-out),
+    color var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
 
-.tabBarPlus:hover {
+.tabBarPlus:hover:not(:disabled) {
+  background: var(--dsw-alias-interactive-bg-hover);
+  color: var(--dsw-alias-label-primary);
+}
+
+.tabBarActions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  padding-right: 4px;
+}
+
+.tabBarMaximize {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--dsw-alias-label-secondary);
+  cursor: pointer;
+  transition: background var(--ds-transition-duration-slow) var(--ds-ease-in-out),
+    color var(--ds-transition-duration-slow) var(--ds-ease-in-out);
+}
+
+.tabBarMaximize:hover:not(:disabled) {
   background: var(--dsw-alias-interactive-bg-hover);
   color: var(--dsw-alias-label-primary);
 }
@@ -2044,11 +2138,36 @@
    (badges live on the second line so they never crowd the subject). */
 .gitLogRow {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 5px 12px;
+  flex-direction: row;
+  align-items: stretch;
+  padding: 0 12px 0 6px;
   cursor: pointer;
-  border-radius: 8px;
+  border-radius: 4px;
+  height: 48px;
+  min-height: 48px;
+  box-sizing: border-box;
+}
+
+.gitGraphCol {
+  flex: none;
+  display: flex;
+  align-items: stretch;
+  position: relative;
+  overflow: visible;
+  height: 48px;
+  margin: 0;
+  padding: 0;
+}
+
+.gitLogContent {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+  padding: 6px 0 6px 8px;
+  overflow: hidden;
 }
 
 .gitLogRow:hover {
@@ -2057,33 +2176,20 @@
 
 .gitLogLine1 {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   min-width: 0;
+  height: 20px;
+  line-height: 20px;
+  overflow: hidden;
 }
 
 .gitLogHash {
   flex: none;
   font: var(--dsw-font-markdown-code-block-small);
-  color: var(--dsw-alias-label-tertiary);
-}
-
-.gitLogLine2 {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  flex-wrap: wrap;
-}
-
-.gitLogRef {
-  flex: none;
-  padding: 0 5px;
-  border: 1px solid var(--dsw-alias-border-l2);
-  border-radius: 999px;
-  font: var(--dsw-font-xxxs-strong-11);
   color: var(--dsw-alias-brand-primary);
-  white-space: nowrap;
+  font-weight: 500;
+  line-height: 20px;
 }
 
 .gitLogSubject {
@@ -2094,9 +2200,38 @@
   white-space: nowrap;
   font: var(--dsw-font-s-14);
   color: var(--dsw-alias-label-primary);
+  line-height: 20px;
+}
+
+.gitLogLine2 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 16px;
+  line-height: 16px;
+  overflow: hidden;
+}
+
+.gitLogRef {
+  flex: none;
+  padding: 0 5px;
+  border: 1px solid var(--dsw-alias-border-l2);
+  border-radius: 999px;
+  font: var(--dsw-font-xxxs-strong-11);
+  color: var(--dsw-alias-brand-primary);
+  white-space: nowrap;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .gitLogMeta {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font: var(--dsw-font-xxxs-11);
   color: var(--dsw-alias-label-tertiary);
 }

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -517,8 +517,9 @@
 .tabBar {
   flex: none;
   display: flex;
-  align-items: stretch;
-  height: 34px;
+  align-items: center;
+  height: 36px;
+  padding: 0 6px;
   border-bottom: 1px solid var(--dsw-alias-border-l1);
   background: var(--dsw-alias-bg-layer-1);
 }
@@ -532,6 +533,8 @@
   flex: 1;
   min-width: 0;
   display: flex;
+  align-items: center;
+  gap: 4px;
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -544,25 +547,28 @@
   flex: none;
   max-width: 160px;
   min-width: 64px;
+  height: 26px;
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 0 4px 0 10px;
+  padding: 0 4px 0 8px;
   font: var(--dsw-font-xxs-12);
   color: var(--dsw-alias-label-secondary);
-  border-right: 1px solid var(--dsw-alias-border-l1);
-  background: transparent;
+  border-radius: 6px;
+  border-right: none;
+  background: var(--dsw-alias-interactive-bg-hover);
   cursor: pointer;
   user-select: none;
+  transition: background var(--ds-transition-duration-slow) var(--ds-ease-in-out),
+    color var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
 
-.tab:hover {
+.tab:hover:not(.tabActive) {
   background: var(--dsw-alias-interactive-bg-hover);
 }
 
 .tabActive {
   color: var(--dsw-alias-label-primary);
-  /* Native selected fill (Rows .sessionRow.selected) — no underline, no shadow. */
   background: var(--dsw-alias-interactive-bg-active);
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -35,8 +35,10 @@ export interface GitLogEntry {
   author: string
   /** ISO 8601 author date (`%ai`), e.g. `2024-01-01 10:00:00 +0800`. */
   date: string
-  /** Ref decorations (`%D` with --decorate=short), e.g. `HEAD -> main, origin/main`; '' when none. */
+  /** Decorator string: 'HEAD -> main, origin/main, tag: v1.0'. */
   refs: string
+  /** Parent commit hashes (for git topology graph lanes). */
+  parents?: string[]
 }
 
 /** One git failure (stderr text as the message). */
@@ -50,13 +52,25 @@ export class GitCommandError extends Error {
   }
 }
 
-/** Parse porcelain v1 -z output into entries (rename/copy pairs collapse to one row). */
+/**
+ * Porcelain `-z` tokenizer: splits a NUL-delimited stream into tokens.
+ * A terminal NUL produces no trailing empty token.
+ */
+function splitZ(raw: string): string[] {
+  if (raw === '') return []
+  const tokens = raw.split('\0')
+  if (tokens.length > 0 && tokens[tokens.length - 1] === '') tokens.pop()
+  return tokens
+}
+
+/** Parse porcelain status output (`git status --porcelain=v1 -z`). */
 export function parsePorcelainZ(output: string): GitStatusEntry[] {
-  const tokens = output.split('\0')
+  const tokens = splitZ(output)
   const entries: GitStatusEntry[] = []
   let index = 0
   while (index < tokens.length) {
-    const token = tokens[index]!
+    const token = tokens[index]
+    if (token === undefined) break
     index += 1
     if (token === '') continue
     const xy = token.slice(0, 2)
@@ -71,12 +85,12 @@ export function parsePorcelainZ(output: string): GitStatusEntry[] {
   return entries
 }
 
-/** Parse `git log --pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D` rows. */
+/** Parse `git log --pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D%x1f%P` rows. */
 export function parseLogLines(output: string): GitLogEntry[] {
   const rows: GitLogEntry[] = []
   for (const line of output.split('\n')) {
     if (line === '') continue
-    const [hash, subject, author, date, hashFull, refs] = line.split('\x1f')
+    const [hash, subject, author, date, hashFull, refs, parentsRaw] = line.split('\x1f')
     if (hash === undefined || subject === undefined) continue
     rows.push({
       hash,
@@ -85,6 +99,7 @@ export function parseLogLines(output: string): GitLogEntry[] {
       date: date ?? '',
       hashFull: hashFull ?? hash,
       refs: refs ?? '',
+      parents: parentsRaw ? parentsRaw.trim().split(' ').filter(Boolean) : [],
     })
   }
   return rows
@@ -195,8 +210,8 @@ export async function checkout(cwd: string, branch: string): Promise<void> {
 /** Recent commit history (newest first), lazily pageable via skip/count. */
 export async function log(cwd: string, count = 30, skip = 0): Promise<GitLogEntry[]> {
   const raw = await runGit(cwd, [
-    'log', '-n', String(count), '--skip', String(skip), '--decorate=short',
-    '--pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D',
+    'log', '--all', '--topo-order', '-n', String(count), '--skip', String(skip), '--decorate=short',
+    '--pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D%x1f%P',
   ])
   return parseLogLines(raw)
 }

--- a/tests/file-icons.spec.tsx
+++ b/tests/file-icons.spec.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { isValidElement } from 'react'
+import { fileIconFor } from '../src/client/icons.tsx'
+
+describe('fileIconFor', () => {
+  it('returns valid React element for empty or unknown filenames', () => {
+    const icon1 = fileIconFor('')
+    expect(isValidElement(icon1)).toBe(true)
+
+    const icon2 = fileIconFor('unknown.xyz')
+    expect(isValidElement(icon2)).toBe(true)
+  })
+
+  it('renders icons for special configuration files', () => {
+    const specialFiles = [
+      'Dockerfile',
+      'dockerfile.dev',
+      'docker-compose.yml',
+      'docker-compose.yaml',
+      '.dockerignore',
+      '.gitignore',
+      '.gitmodules',
+      '.gitattributes',
+      'package.json',
+      'package-lock.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      'yarn.lock',
+      'bun.lockb',
+      'tsconfig.json',
+      'tsconfig.build.json',
+      'jsconfig.json',
+      'vite.config.ts',
+      'vite.config.js',
+      'tailwind.config.js',
+      'eslint.config.js',
+      '.eslintrc.json',
+      'prettier.config.js',
+      '.prettierrc',
+      'Cargo.toml',
+      'Cargo.lock',
+      'go.mod',
+      'go.sum',
+      'requirements.txt',
+      'Pipfile',
+      'poetry.lock',
+      'pyproject.toml',
+      '.env',
+      '.env.local',
+      '.env.production',
+      'LICENSE',
+      'LICENCE',
+      'README.md',
+      'README',
+      'CHANGELOG.md',
+    ]
+
+    for (const file of specialFiles) {
+      const icon = fileIconFor(file)
+      expect(isValidElement(icon), `Failed for ${file}`).toBe(true)
+    }
+  })
+
+  it('renders icons for common programming languages and extensions', () => {
+    const extFiles = [
+      'index.ts',
+      'index.mts',
+      'index.cts',
+      'App.tsx',
+      'index.js',
+      'index.mjs',
+      'index.cjs',
+      'App.jsx',
+      'Component.vue',
+      'Component.svelte',
+      'Page.astro',
+      'script.py',
+      'script.pyw',
+      'notebook.ipynb',
+      'main.rs',
+      'main.go',
+      'main.cpp',
+      'main.c',
+      'main.h',
+      'main.hpp',
+      'Program.cs',
+      'Main.java',
+      'Main.kt',
+      'Main.swift',
+      'index.php',
+      'app.rb',
+      'main.dart',
+      'script.lua',
+      'main.zig',
+      'Main.scala',
+      'index.html',
+      'style.css',
+      'style.scss',
+      'style.sass',
+      'style.less',
+      'data.json',
+      'data.jsonc',
+      'config.yaml',
+      'config.yml',
+      'config.toml',
+      'config.ini',
+      'config.xml',
+      'doc.md',
+      'doc.markdown',
+      'doc.mdx',
+      'script.sh',
+      'script.bash',
+      'script.zsh',
+      'script.ps1',
+      'script.bat',
+      'schema.sql',
+      'schema.prisma',
+      'schema.graphql',
+      'service.proto',
+      'module.wasm',
+      'document.pdf',
+      'image.png',
+      'image.jpg',
+      'image.jpeg',
+      'image.gif',
+      'image.webp',
+      'icon.svg',
+      'icon.ico',
+      'doc.docx',
+      'doc.doc',
+      'sheet.xlsx',
+      'sheet.xls',
+      'sheet.csv',
+      'slide.pptx',
+      'audio.mp3',
+      'video.mp4',
+      'archive.zip',
+      'archive.tar.gz',
+      'font.woff2',
+      'notes.txt',
+      'debug.log',
+    ]
+
+    for (const file of extFiles) {
+      const icon = fileIconFor(file)
+      expect(isValidElement(icon), `Failed for ${file}`).toBe(true)
+    }
+  })
+
+  it('handles paths with directory prefixes correctly', () => {
+    const icon1 = fileIconFor('src/client/icons.tsx')
+    expect(isValidElement(icon1)).toBe(true)
+
+    const icon2 = fileIconFor('/root/workspace/.gitignore')
+    expect(isValidElement(icon2)).toBe(true)
+
+    const icon3 = fileIconFor('C:\\projects\\app\\package.json')
+    expect(isValidElement(icon3)).toBe(true)
+  })
+})

--- a/tests/git-graph.spec.ts
+++ b/tests/git-graph.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { computeGitGraph } from '../src/client/GitView.tsx'
+import type { GitLogEntry } from '../src/git.ts'
+
+describe('computeGitGraph', () => {
+  it('computes linear branch line properly', () => {
+    const entries: GitLogEntry[] = [
+      { hash: 'c3', hashFull: 'c3', subject: 'third', author: 'a', date: '2024', refs: '', parents: ['c2'] },
+      { hash: 'c2', hashFull: 'c2', subject: 'second', author: 'a', date: '2024', refs: '', parents: ['c1'] },
+      { hash: 'c1', hashFull: 'c1', subject: 'first', author: 'a', date: '2024', refs: '', parents: [] },
+    ]
+    const graph = computeGitGraph(entries)
+    expect(graph.maxLanes).toBe(1)
+    expect(graph.rows).toHaveLength(3)
+
+    // c3: top row, no line from top, line to bottom
+    expect(graph.rows[0]?.lane).toBe(0)
+    expect(graph.rows[0]?.fromTop).toBe(false)
+    expect(graph.rows[0]?.hasBottom).toBe(true)
+
+    // c2: middle row, line from top, line to bottom
+    expect(graph.rows[1]?.lane).toBe(0)
+    expect(graph.rows[1]?.fromTop).toBe(true)
+    expect(graph.rows[1]?.hasBottom).toBe(true)
+
+    // c1: bottom root row, line from top, no line to bottom
+    expect(graph.rows[2]?.lane).toBe(0)
+    expect(graph.rows[2]?.fromTop).toBe(true)
+    expect(graph.rows[2]?.hasBottom).toBe(false)
+  })
+
+  it('computes branching and merge curves for multi-branch history', () => {
+    // Feature branch (f1) branched from base (b1), then merged back into main (m1)
+    const entries: GitLogEntry[] = [
+      { hash: 'm1', hashFull: 'm1', subject: 'merge commit', author: 'a', date: '2024', refs: 'HEAD -> main', parents: ['b2', 'f1'] },
+      { hash: 'f1', hashFull: 'f1', subject: 'feature commit', author: 'a', date: '2024', refs: 'feat', parents: ['b1'] },
+      { hash: 'b2', hashFull: 'b2', subject: 'main commit 2', author: 'a', date: '2024', refs: '', parents: ['b1'] },
+      { hash: 'b1', hashFull: 'b1', subject: 'root commit', author: 'a', date: '2024', refs: '', parents: [] },
+    ]
+    const graph = computeGitGraph(entries)
+    expect(graph.maxLanes).toBeGreaterThanOrEqual(2)
+
+    // m1 should have an outgoing merge curve to the feature lane
+    expect(graph.rows[0]?.outgoingMerges.length).toBeGreaterThanOrEqual(1)
+
+    // f1 should be on a separate lane
+    expect(graph.rows[1]?.lane).not.toBe(graph.rows[0]?.lane)
+  })
+})

--- a/tests/git.spec.ts
+++ b/tests/git.spec.ts
@@ -27,6 +27,7 @@ describe('git parsing', () => {
         date: '2024-01-01 10:00:00 +0800',
         hashFull: 'abc1234def5678abc1234def5678abc1234def5678',
         refs: 'HEAD -> main, origin/main',
+        parents: [],
       },
       {
         hash: 'def5678',
@@ -35,6 +36,7 @@ describe('git parsing', () => {
         date: '2024-01-02 10:00:00 +0800',
         hashFull: 'def5678abc1234def5678abc1234def5678abc1234',
         refs: '',
+        parents: [],
       },
     ])
   })


### PR DESCRIPTION
## Summary
为 Source Control 面板的 Git 历史列表新增完整的 Git Graph 多分支 DAG 拓扑图可视化渲染。

### Changes
1. **拓扑解析与父提交支持** (`src/git.ts`, `src/client/api.ts`):
   - `git.log` 指令升级支持 `--all --topo-order` 全分支与拓扑遍历；
   - 增强 `%P` 父提交哈希解析，为前端构建完整 DAG 关系图。
2. **多车道拓扑与贝塞尔连线渲染** (`src/client/GitView.tsx`, `src/client/sidebar.module.css`):
   - 支持多分支车道（Multi-Lane）自动分配与分支色彩体系；
   - 支持平滑 Cubic Bézier 曲线连接分叉（Fork）与合并（Merge）提交；
   - 支持跨越线（Pass-through lines）与同车道垂直相连；
   - 提交节点精准水平居中对齐第一行提交信息。
3. **单元测试守护** (`tests/git.spec.ts`, `tests/git-graph.spec.ts`):
   - 覆盖单分支线性主干与多分支分叉/合并拓扑算法测试。