### PR TITLE
fix(layout): 修复底部面板展开时推挤会话输入框失效的问题

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -393,8 +393,10 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // a 1px sliver at the viewport's left edge).
     const locate = (): void => {
       if (disposed) return
-      const col = document.querySelector('#root [data-slot="conversation"]')
-        ?.parentElement as HTMLElement | undefined
+      const col = (document.querySelector('#root [data-slot="conversation"]')?.parentElement
+        ?? document.querySelector('#root [data-pane="conversation"]')
+        ?? document.querySelector('#root [class*="centerCol"]')
+        ?? document.querySelector('#root > div > div:nth-child(2)')) as HTMLElement | undefined
       if (col === undefined) {
         if (centerColRef.current !== null) {
           centerColRef.current = null

--- a/src/client/layout.css
+++ b/src/client/layout.css
@@ -25,10 +25,17 @@
 }
 
 /* The AppFrame's grid items are sidebarCol, centerCol, detailsCol (children
-   1-3 of #root > div[data-slot="root"] > div) — nth-child(2) is the center
-   column. A stretched grid item shrinks by its margins, so the conversation
-   content (output + input bar) lifts without touching the sidebars. */
-#root > div[data-slot="root"] > div > div:nth-child(2) {
+   1-3 of the frame) — centerCol is the center column. A stretched grid item
+   shrinks by its margins, so the conversation content (output + input bar)
+   lifts without touching the sidebars. Target centerCol via multiple robust
+   selectors (CSS module class substring, semantic data attributes, and
+   structural fallbacks) to survive DOM wrapping variations across DSH
+   versions and desktop environments. */
+#root [class*="centerCol"],
+#root [data-pane="conversation"],
+#root div:has(> [data-slot="conversation"]),
+#root > div[data-slot="root"] > div > div:nth-child(2),
+#root > div > div:nth-child(2) {
   margin-bottom: var(--dsh-sidebar-height, 0px);
   transition: margin-bottom var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
@@ -47,7 +54,11 @@ body[data-dsh-sidebar-collapsed] [data-slot="conversation.session.header"] > hea
 }
 
 body[data-dsh-sidebar-dragging] #root,
-body[data-dsh-sidebar-dragging] #root > div[data-slot="root"] > div > div:nth-child(2) {
+body[data-dsh-sidebar-dragging] #root [class*="centerCol"],
+body[data-dsh-sidebar-dragging] #root [data-pane="conversation"],
+body[data-dsh-sidebar-dragging] #root div:has(> [data-slot="conversation"]),
+body[data-dsh-sidebar-dragging] #root > div[data-slot="root"] > div > div:nth-child(2),
+body[data-dsh-sidebar-dragging] #root > div > div:nth-child(2) {
   transition: none;
 }
 
@@ -72,7 +83,11 @@ body[data-dsh-sidebar-dragging] #root > div[data-slot="root"] > div > div:nth-ch
 
 @media (prefers-reduced-motion: reduce) {
   #root,
-  #root > div[data-slot="root"] > div > div:nth-child(2) {
+  #root [class*="centerCol"],
+  #root [data-pane="conversation"],
+  #root div:has(> [data-slot="conversation"]),
+  #root > div[data-slot="root"] > div > div:nth-child(2),
+  #root > div > div:nth-child(2) {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
修复在部分 DSH Desktop 及 Web 版本中，展开底部面板时直接覆盖聊天输入框的缺陷，恢复输入框随底部面板自然向上托起的推挤交互。

### Changes
1. **复合选择器增强** (`src/client/layout.css`):
   - 将 `centerCol` 的选择器由脆弱的固定 DOM 层级 `#root > div[data-slot="root"] > div > div:nth-child(2)` 扩展为支持 `[class*="centerCol"]`、`[data-pane="conversation"]`、`div:has(> [data-slot="conversation"])` 等复合语义匹配；
   - 同步更新拖拽过渡和 prefers-reduced-motion 选择器规则。
2. **中心列重定位容错** (`src/client/Sidebar.tsx`):
   - `locate()` 函数支持 fallback 查找中心会话列元素，防止 DOM 渲染层级差异导致推挤高度为 0。