### PR TITLE
feat: collapse diff files by default

### DIFF
--- a/src/client/DiffView.tsx
+++ b/src/client/DiffView.tsx
@@ -171,6 +171,25 @@ function fileTag(file: DiffFile): string | null {
 /** Cap the flattened rows like DiffBlock: head + tail, expand button between. */
 const MAX_DIFF_ROWS = 500
 
+const TEST_PATH = /(^|\/)(?:__tests__|tests?|specs?|fixtures?|mocks?|snapshots?)(?:\/|$)|\.(?:test|spec)\.[^/]+$/i
+const DOC_PATH = /(^|\/)(?:docs?|documentation)(?:\/|$)|(^|\/)(?:readme|changelog|contributing|license|authors|notice)(?:\.[^/]*)?$/i
+const GENERATED_PATH = /(^|\/)(?:dist|build|coverage|generated|vendor|node_modules)(?:\/|$)|(^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb?|composer\.lock|cargo\.lock|poetry\.lock)$/i
+const SOURCE_PATH = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts|py|pyw|rb|php|java|kt|kts|scala|go|rs|swift|c|h|cc|cpp|cxx|hpp|hh|hxx|cs|fs|fsx|vb|dart|lua|r|ex|exs|erl|hrl|clj|cljs|cljc|groovy|sh|bash|zsh|fish|ps1|sql|vue|svelte|astro|html|htm|css|scss|sass|less)$/i
+
+/** Source files open by default; tests, docs, generated files and unknown types stay folded. */
+function defaultExpandedFiles(files: DiffFile[]): Set<number> {
+  const expanded = new Set<number>()
+  files.forEach((file, index) => {
+    const path = displayPath(file.newPath === '/dev/null' ? file.oldPath : file.newPath)
+    if (!file.binary && file.hunks.length > 0
+      && !TEST_PATH.test(path) && !DOC_PATH.test(path) && !GENERATED_PATH.test(path)
+      && SOURCE_PATH.test(path)) {
+      expanded.add(index)
+    }
+  })
+  return expanded
+}
+
 export interface DiffViewProps {
   /** Unified diff text (`git.diff` or `git.commit-diff` payloads). */
   diff: string
@@ -187,9 +206,9 @@ export function DiffView({ diff, untrackedPath, untrackedContent }: DiffViewProp
     return parseUnifiedDiff(diff)
   }, [diff, untrackedPath, untrackedContent])
   const [expanded, setExpanded] = useState(false)
-  const [expandedFiles, setExpandedFiles] = useState<Set<number>>(() => new Set())
+  const [expandedFiles, setExpandedFiles] = useState<Set<number>>(() => defaultExpandedFiles(parsed.files))
 
-  useEffect(() => { setExpandedFiles(new Set()) }, [parsed])
+  useEffect(() => { setExpandedFiles(defaultExpandedFiles(parsed.files)) }, [parsed])
 
   // Flatten into display rows so the cap can slice a single list.
   const rows = useMemo(() => {

--- a/src/client/DiffView.tsx
+++ b/src/client/DiffView.tsx
@@ -9,7 +9,7 @@
  * The parser is a pure function (`parseUnifiedDiff`) so the interesting
  * cases are unit-tested without a DOM.
  */
-import { useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import clsx from 'clsx'
 import { t } from './locales.ts'
 import css from './sidebar.module.css'
@@ -187,22 +187,25 @@ export function DiffView({ diff, untrackedPath, untrackedContent }: DiffViewProp
     return parseUnifiedDiff(diff)
   }, [diff, untrackedPath, untrackedContent])
   const [expanded, setExpanded] = useState(false)
+  const [expandedFiles, setExpandedFiles] = useState<Set<number>>(() => new Set())
+
+  useEffect(() => { setExpandedFiles(new Set()) }, [parsed])
 
   // Flatten into display rows so the cap can slice a single list.
   const rows = useMemo(() => {
-    const out: Array<{ key: string; file: DiffFile; type: 'path' | 'hunk' | 'line'; hunk?: DiffHunk; line?: DiffLine }> = []
+    const out: Array<{ key: string; file: DiffFile; fileIndex: number; type: 'path' | 'hunk' | 'line'; hunk?: DiffHunk; line?: DiffLine }> = []
     parsed.files.forEach((file, fileIndex) => {
-      out.push({ key: `f${fileIndex}`, file, type: 'path' })
-      if (file.binary) return
+      out.push({ key: `f${fileIndex}`, file, fileIndex, type: 'path' })
+      if (file.binary || !expandedFiles.has(fileIndex)) return
       file.hunks.forEach((hunk, hunkIndex) => {
-        out.push({ key: `f${fileIndex}h${hunkIndex}`, file, type: 'hunk', hunk })
+        out.push({ key: `f${fileIndex}h${hunkIndex}`, file, fileIndex, type: 'hunk', hunk })
         hunk.lines.forEach((line, lineIndex) => {
-          out.push({ key: `f${fileIndex}h${hunkIndex}l${lineIndex}`, file, type: 'line', hunk, line })
+          out.push({ key: `f${fileIndex}h${hunkIndex}l${lineIndex}`, file, fileIndex, type: 'line', hunk, line })
         })
       })
     })
     return out
-  }, [parsed])
+  }, [parsed, expandedFiles])
 
   const hidden = rows.length - MAX_DIFF_ROWS
   const capped = hidden > 0 && !expanded
@@ -218,12 +221,29 @@ export function DiffView({ diff, untrackedPath, untrackedContent }: DiffViewProp
       const tag = fileTag(row.file)
       const from = displayPath(row.file.oldPath)
       const to = displayPath(row.file.newPath)
+      const expandable = !row.file.binary && row.file.hunks.length > 0
+      const fileExpanded = expandedFiles.has(row.fileIndex)
       return (
-        <div key={row.key} className={css.gitDiffFile}>
+        <button
+          key={row.key}
+          type="button"
+          className={css.gitDiffFile}
+          disabled={!expandable}
+          aria-expanded={expandable ? fileExpanded : undefined}
+          onClick={() => {
+            setExpandedFiles(current => {
+              const next = new Set(current)
+              if (next.has(row.fileIndex)) next.delete(row.fileIndex)
+              else next.add(row.fileIndex)
+              return next
+            })
+          }}
+        >
+          {expandable && <span aria-hidden="true" className={clsx(css.gitDiffFileChevron, fileExpanded && css.gitDiffFileChevronExpanded)}>›</span>}
           <span className={css.gitDiffFilePath}>{to}</span>
           {from !== to && <span className={css.gitDiffFileOld}>← {from}</span>}
           {tag !== null && <span className={css.gitDiffFileTag}>{tag}</span>}
-        </div>
+        </button>
       )
     }
     if (row.type === 'hunk') {

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -1923,10 +1923,34 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 
 /* One changed file's section: path header, hunk headers, aligned lines. */
 .gitDiffFile {
+  width: 100%;
   display: flex;
   align-items: baseline;
   gap: 6px;
   padding: 8px 2px 2px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.gitDiffFile:disabled {
+  cursor: default;
+}
+
+.gitDiffFile:hover:not(:disabled) {
+  background: var(--dsw-alias-interactive-bg-hover);
+}
+
+.gitDiffFileChevron {
+  flex: none;
+  color: var(--dsw-alias-label-tertiary);
+  transform: rotate(0deg);
+}
+
+.gitDiffFileChevronExpanded {
+  transform: rotate(90deg);
 }
 
 .gitDiffFilePath {
@@ -2232,6 +2256,7 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 .gitCommitButton:focus-visible,
 .gitLogRow:focus-visible,
 .gitLogMore:focus-visible,
+.gitDiffFile:focus-visible,
 .gitDiffExpand:focus-visible,
 .terminalRetry:focus-visible,
 .editorModeButton:focus-visible,

--- a/tests/diff-view-collapse.spec.tsx
+++ b/tests/diff-view-collapse.spec.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { DiffView } from '../src/client/DiffView.tsx'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+const diff = [
+  'diff --git a/src/a.ts b/src/a.ts',
+  '--- a/src/a.ts',
+  '+++ b/src/a.ts',
+  '@@ -1 +1 @@',
+  '-old-a',
+  '+new-a',
+  'diff --git a/src/b.ts b/src/b.ts',
+  '--- a/src/b.ts',
+  '+++ b/src/b.ts',
+  '@@ -1 +1 @@',
+  '-old-b',
+  '+new-b',
+].join('\n')
+
+afterEach(() => { document.body.innerHTML = '' })
+
+describe('DiffView file folding', () => {
+  it('starts collapsed and expands only the selected file', () => {
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root: Root = createRoot(container)
+    try {
+      act(() => { root.render(createElement(DiffView, { diff })) })
+      const headers = [...container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]')]
+      expect(headers).toHaveLength(2)
+      expect(headers.map(header => header.getAttribute('aria-expanded'))).toEqual(['false', 'false'])
+      expect(container.textContent).not.toContain('new-a')
+      expect(container.textContent).not.toContain('new-b')
+
+      act(() => { headers[0]!.click() })
+      expect(headers[0]!.getAttribute('aria-expanded')).toBe('true')
+      expect(container.textContent).toContain('new-a')
+      expect(container.textContent).not.toContain('new-b')
+
+      act(() => { headers[0]!.click() })
+      expect(headers[0]!.getAttribute('aria-expanded')).toBe('false')
+      expect(container.textContent).not.toContain('new-a')
+    } finally {
+      act(() => { root.unmount() })
+      container.remove()
+    }
+  })
+})

--- a/tests/diff-view-collapse.spec.tsx
+++ b/tests/diff-view-collapse.spec.tsx
@@ -14,33 +14,39 @@ const diff = [
   '@@ -1 +1 @@',
   '-old-a',
   '+new-a',
-  'diff --git a/src/b.ts b/src/b.ts',
-  '--- a/src/b.ts',
-  '+++ b/src/b.ts',
+  'diff --git a/tests/b.spec.ts b/tests/b.spec.ts',
+  '--- a/tests/b.spec.ts',
+  '+++ b/tests/b.spec.ts',
   '@@ -1 +1 @@',
   '-old-b',
   '+new-b',
+  'diff --git a/README.md b/README.md',
+  '--- a/README.md',
+  '+++ b/README.md',
+  '@@ -1 +1 @@',
+  '-old-doc',
+  '+new-doc',
 ].join('\n')
 
 afterEach(() => { document.body.innerHTML = '' })
 
 describe('DiffView file folding', () => {
-  it('starts collapsed and expands only the selected file', () => {
+  it('expands source by default while tests and docs stay collapsed', () => {
     const container = document.createElement('div')
     document.body.append(container)
     const root: Root = createRoot(container)
     try {
       act(() => { root.render(createElement(DiffView, { diff })) })
       const headers = [...container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]')]
-      expect(headers).toHaveLength(2)
-      expect(headers.map(header => header.getAttribute('aria-expanded'))).toEqual(['false', 'false'])
-      expect(container.textContent).not.toContain('new-a')
-      expect(container.textContent).not.toContain('new-b')
-
-      act(() => { headers[0]!.click() })
-      expect(headers[0]!.getAttribute('aria-expanded')).toBe('true')
+      expect(headers).toHaveLength(3)
+      expect(headers.map(header => header.getAttribute('aria-expanded'))).toEqual(['true', 'false', 'false'])
       expect(container.textContent).toContain('new-a')
       expect(container.textContent).not.toContain('new-b')
+      expect(container.textContent).not.toContain('new-doc')
+
+      act(() => { headers[1]!.click() })
+      expect(headers[1]!.getAttribute('aria-expanded')).toBe('true')
+      expect(container.textContent).toContain('new-b')
 
       act(() => { headers[0]!.click() })
       expect(headers[0]!.getAttribute('aria-expanded')).toBe('false')


### PR DESCRIPTION
## Summary
- render each changed-file header as an accessible expand/collapse control
- expand recognized source files by default
- keep tests, docs, generated files, lockfiles, and unknown types collapsed by default
- preserve the existing 500-row cap for expanded content

## Verification
- `pnpm exec vitest run tests/diff-view-collapse.spec.tsx tests/git.spec.ts`
- `pnpm typecheck`
- `pnpm test` (63 test files passed)
- `pnpm build`