### PR TITLE
fix(layout): 面板宿主裁剪视口边缘，收起的面板不再撑出文档双向滚动

### DIFF
--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -34,6 +34,15 @@
   inset: 0;
   z-index: 40;
   pointer-events: none;
+  /* Clip at the viewport edge: collapsed panels slide off-screen with
+     `transform: translate(102%)`, and a transformed element still
+     contributes to its ancestors' scrollable overflow — without this the
+     hidden panels extended the document's scrollable area, making the whole
+     page draggable left-right and up-down while any panel was collapsed.
+     The host is exactly viewport-sized (inset: 0), so the clip is invisible
+     until a panel slides in from the edge; internal scroll containers and
+     the app's fixed overlay stack are unaffected. */
+  overflow: hidden;
 }
 
 :global([data-dsh-panel-host][data-dsh-panel-host-degraded]) {

--- a/tests/e2e/mount.e2e.ts
+++ b/tests/e2e/mount.e2e.ts
@@ -175,6 +175,26 @@ test('plugin mounts into the DSH shell and survives a built-in tab sweep', async
   const tabBar = sidebar.locator('[title]')
   await expect(tabBar.first()).toBeAttached({ timeout: 90_000 })
 
+  // Regression: with the panels still COLLAPSED, the document must not grow
+  // beyond the viewport. Collapsed panels are slid off-screen with
+  // `transform: translate(102%)`, and a transformed element still
+  // contributes to its ancestors' scrollable overflow — unclipped, the
+  // hidden panels extended the document's scroll area and the whole page
+  // became draggable left-right and up-down. The panel host clips at the
+  // viewport edge (overflow: hidden), so scrollWidth/scrollHeight must stay
+  // within the viewport here. (Assert <= not == : a classic scrollbar
+  // narrows clientWidth, so scrollWidth may sit slightly under innerWidth.)
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => ({
+          overflowX: document.documentElement.scrollWidth <= window.innerWidth,
+          overflowY: document.documentElement.scrollHeight <= window.innerHeight,
+        })),
+      { timeout: 30_000 },
+    )
+    .toEqual({ overflowX: true, overflowY: true })
+
   // openByDefault defaults OFF: a fresh session's panel starts collapsed.
   // Expand it through the toggle cluster before the layout push can apply.
   const expandButton = sidebar.getByRole('button', { name: 'Expand sidebar' })


### PR DESCRIPTION
Fixes #277

## 问题

右侧/底部面板**收起**时，整个页面（文档级）可被左右、上下拖拽滚动。实测（视口 1672×1032）：

| 指标 | 修复前 | 修复后 |
|---|---|---|
| `scrollWidth` | 2289 | 1672 |
| `scrollHeight` | 1280 | 1032 |

任意皮肤下均复现。

## 根因

收起的面板靠 `transform: translate(102%)` / `translateY(102%)` 滑出屏幕隐藏（`.panelHidden` / `.bottomPanelHidden`），但 **transform 后的元素仍计入祖先的滚动溢出区**（CSS Overflow 规范：可滚动溢出区包含后代的变换后边界盒）。面板宿主 `[data-dsh-panel-host]` 是 `position: fixed; inset: 0` 的视口级容器、`pointer-events: none`，自身不裁剪——于是滑出屏幕的面板把文档滚动区撑大，页面在无任何内部滚动容器参与的情况下整体可拖。

## 修复

`src/client/sidebar.module.css`：给 `[data-dsh-panel-host]` 补 `overflow: hidden`。

- 宿主精确等于视口尺寸（`inset: 0`），裁剪点恰在视口边缘：面板开合滑入动画、内部滚动容器、fixed 弹层栈（z-index 100+，位于宿主之外）均不受影响；
- 收起的面板本就 `visibility: hidden`，屏幕外裁剪无任何视觉差异。

## 验证

- 本地真实挂载实测：修复后 `scrollWidth/Height` 精确等于视口尺寸（1672×1032），双向无法再拖；
- `tests/e2e/mount.e2e.ts` 新增回归断言：面板收起状态下文档 `scrollWidth <= innerWidth` 且 `scrollHeight <= innerHeight`（用 `<=` 兼容经典滚动条使 clientWidth 收窄的环境）；
- `pnpm typecheck` 通过；`prepare` 构建（含 CSS modules 编译）通过。

## 备选方案（未采用）

- `.panelHidden { display: none }`：会破坏收起/展开的滑入动画（设计上保持挂载以支持动画，见 `Sidebar.tsx` 注释）；
- `contain: paint` 于宿主：语义更严格但支持面更窄，`overflow: hidden` 已完全解决问题且零副作用。