### PR TITLE
feat(prefs): defaultTab — land a new conversation on a chosen tab

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -387,6 +387,46 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   }, [sessionId, store])
 
   /**
+   * Default tab: land a brand-new conversation on the configured tab instead
+   * of the seeded Files window. Runs at most once per session and ONLY while
+   * the layout is still that untouched seed (one pane, one path-less editor
+   * tab, or an empty pane when the editor type is disabled), so a restored
+   * layout and any tab the user opened themselves are never fought.
+   *
+   * The open goes through the ordinary `openTab` path rather than a seed in
+   * `makeDefaultState`, which cannot resolve a descriptor: this way the tab
+   * carries its localized title, honours `isTabEnabled`, and works for a
+   * plugin-registered id exactly like a built-in one. An unregistered or
+   * disabled id opens nothing and leaves the seeded default in place.
+   */
+  const defaultTabSeededRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    if (sessionId === undefined) return
+    if (defaultTabSeededRef.current === sessionId) return
+    const type = store.getPrefs().defaultTab.trim()
+    if (type === '') return
+    if (ctx.betterSidebar?.isTabEnabled(type) === false) return
+    const descriptor = ctx.betterSidebar?.getTab(type)
+    if (descriptor === undefined) return
+    // Read the REACTIVE snapshot, not a one-shot store read: the seeded
+    // state for a freshly created session lands a tick after `sessionId`
+    // changes, so a single read at that moment can still see the previous
+    // session's layout (or none) and skip the seeding entirely.
+    if (snapshot.sessionId !== sessionId) return
+    const state = snapshot.state
+    if (state === undefined) return
+    const leaf = firstLeaf(state.splits)
+    const pristine = state.splits.kind === 'leaf'
+      && (leaf.tabs.length === 0
+        || (leaf.tabs.length === 1 && leaf.tabs[0]!.type === 'editor' && leaf.tabs[0]!.path === undefined))
+    if (!pristine) return
+    defaultTabSeededRef.current = sessionId
+    store.reduce(s => ({ ...s, activePane: firstLeaf(s.splits).id }))
+    const title = typeof descriptor.title === 'function' ? descriptor.title() : descriptor.title
+    ctx.betterSidebar?.openTab({ type, title }, { sessionId, cwd })
+  }, [snapshot, sessionId, cwd, store, ctx])
+
+  /**
    * Subagent auto-activation: the moment the current conversation spawns its
    * FIRST direct subagent (a 0 → N transition on the list feed), the "auto
    * open" pref is on, and the Subagent tab type is enabled in settings,

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -423,7 +423,13 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     defaultTabSeededRef.current = sessionId
     store.reduce(s => ({ ...s, activePane: firstLeaf(s.splits).id }))
     const title = typeof descriptor.title === 'function' ? descriptor.title() : descriptor.title
+    // `openTab` expands a collapsed panel, which is correct for a user gesture
+    // but must not override `openByDefault: false` here: the two prefs are
+    // orthogonal, one picks WHICH tab and the other WHETHER the panel starts
+    // expanded. Restore the collapsed state the seed asked for.
+    const wasOpen = state.panelOpen
     ctx.betterSidebar?.openTab({ type, title }, { sessionId, cwd })
+    if (!wasOpen) store.reduce(s => (s.panelOpen ? togglePanel(s) : s))
   }, [snapshot, sessionId, cwd, store, ctx])
 
   /**

--- a/src/client/prefs.ts
+++ b/src/client/prefs.ts
@@ -46,6 +46,9 @@ export function parsePrefs(value: unknown): SidebarPrefs {
     openByDefault: typeof record.openByDefault === 'boolean'
       ? record.openByDefault
       : SIDEBAR_PREFS_DEFAULTS.openByDefault,
+    defaultTab: typeof record.defaultTab === 'string'
+      ? record.defaultTab.trim()
+      : SIDEBAR_PREFS_DEFAULTS.defaultTab,
     defaultWidthPercent: typeof record.defaultWidthPercent === 'number' && Number.isFinite(record.defaultWidthPercent)
       ? clampWidthPercent(record.defaultWidthPercent)
       : SIDEBAR_PREFS_DEFAULTS.defaultWidthPercent,

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,7 @@ export function resolveSidebarConfig(config: SidebarConfig | undefined): Resolve
 /** Schemastery schema for the user-facing preferences (validated by the settings service). */
 export const PrefsSchema: z<SidebarPrefs> = z.object({
   openByDefault: z.boolean().default(false),
+  defaultTab: z.string().default(''),
   defaultWidthPercent: z.number().step(1).min(WIDTH_PERCENT_MIN).max(WIDTH_PERCENT_MAX).default(WIDTH_PERCENT_DEFAULT),
   autoOpenSubagent: z.boolean().default(true),
   autoOpenJobs: z.boolean().default(true),

--- a/src/prefs-shared.ts
+++ b/src/prefs-shared.ts
@@ -13,6 +13,16 @@ export const SIDEBAR_PREFS_NS = 'dsh-better-sidebar'
 export interface SidebarPrefs {
   /** Whether a brand-new conversation opens the side card by default. */
   openByDefault: boolean
+  /**
+   * Which tab a brand-new conversation lands on, as a registered tab
+   * descriptor id ('git', 'subagent', 'terminal', or a plugin's own id).
+   * EMPTY keeps the historical behaviour: the seeded empty Files window.
+   * An id that is unregistered or disabled in `tabsEnabled` is ignored, so
+   * a stale value degrades to that same default rather than an empty pane.
+   * Only the FIRST paint of a session is affected; once the user picks a
+   * tab, the persisted layout owns the choice like any other state.
+   */
+  defaultTab: string
   /** Default panel width as a percent of the window width (20–60). */
   defaultWidthPercent: number
   /**
@@ -225,6 +235,7 @@ export type TitleBarScheme = typeof TITLE_BAR_SCHEMES[number]
 /** Fallback prefs used whenever the settings document is unreachable or malformed. */
 export const SIDEBAR_PREFS_DEFAULTS: SidebarPrefs = {
   openByDefault: false,
+  defaultTab: '',
   defaultWidthPercent: WIDTH_PERCENT_DEFAULT,
   autoOpenSubagent: true,
   autoOpenJobs: true,

--- a/tests/plugin-shape.spec.ts
+++ b/tests/plugin-shape.spec.ts
@@ -92,6 +92,6 @@ describe('dsh-better-sidebar plugin export shape', () => {
     const overridden = (PrefsSchema as unknown as {
       (input: Record<string, unknown> | undefined): Record<string, unknown>
     })({ openByDefault: false, defaultWidthPercent: 45 })
-    expect(overridden).toEqual({ openByDefault: false, defaultWidthPercent: 45, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: false, terminalShell: '', terminalShellArgs: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
+    expect(overridden).toEqual({ openByDefault: false, defaultTab: '', defaultWidthPercent: 45, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: false, terminalShell: '', terminalShellArgs: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
   })
 })

--- a/tests/prefs.spec.ts
+++ b/tests/prefs.spec.ts
@@ -34,6 +34,7 @@ describe('side card preferences', () => {
     expect(await loadPrefs(wire({ openByDefault: false, defaultWidthPercent: 80, autoOpenSubagent: false, agentTerminalTools: true })))
       .toEqual({
         openByDefault: false,
+        defaultTab: '',
         defaultWidthPercent: 60,
         autoOpenSubagent: false,
         autoOpenJobs: true,
@@ -66,6 +67,7 @@ describe('side card preferences', () => {
     expect(await loadPrefs(wire({ openByDefault: 'yes', defaultWidthPercent: 33, autoOpenSubagent: 'no', agentTerminalTools: 'yes' })))
       .toEqual({
         openByDefault: false,
+        defaultTab: '',
         defaultWidthPercent: 33,
         autoOpenSubagent: true,
         autoOpenJobs: true,
@@ -98,6 +100,7 @@ describe('side card preferences', () => {
     expect(await loadPrefs(wire({ openByDefault: false, defaultWidthPercent: 40 })))
       .toEqual({
         openByDefault: false,
+        defaultTab: '',
         defaultWidthPercent: 40,
         autoOpenSubagent: true,
         autoOpenJobs: true,
@@ -260,9 +263,9 @@ describe('side card preferences', () => {
     const store = createSidebarStore()
     // Node environment: no window → the width falls back to PANEL_DEFAULT,
     // while the open flag still follows the preference.
-    store.setPrefs({ openByDefault: false, defaultWidthPercent: 45, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: true, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
+    store.setPrefs({ openByDefault: false, defaultTab: '', defaultWidthPercent: 45, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: true, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
     store.setSession('fresh-session')
-    expect(store.getPrefs()).toEqual({ openByDefault: false, defaultWidthPercent: 45, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: true, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
+    expect(store.getPrefs()).toEqual({ openByDefault: false, defaultTab: '', defaultWidthPercent: 45, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: true, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
     const snapshot = store.getSnapshot()
     expect(snapshot.sessionId).toBe('fresh-session')
     expect(snapshot.state?.panelOpen).toBe(false)
@@ -298,7 +301,7 @@ describe('side card preferences', () => {
 
   it('skips the default seed tab when the editor (files window) type is disabled', () => {
     const store = createSidebarStore()
-    store.setPrefs({ openByDefault: true, defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: true, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: { editor: false }, viewersEnabled: {}, pluginSettings: {} })
+    store.setPrefs({ openByDefault: true, defaultTab: '', defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer: true, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: { editor: false }, viewersEnabled: {}, pluginSettings: {} })
     store.setSession('no-editor')
     const state = store.getSnapshot().state!
     const tabs = allLeaves(state.splits).flatMap(leaf => leaf.tabs)
@@ -308,7 +311,7 @@ describe('side card preferences', () => {
     // editorExplorer modes.
     for (const editorExplorer of [true, false]) {
       const openStore = createSidebarStore()
-      openStore.setPrefs({ openByDefault: true, defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
+      openStore.setPrefs({ openByDefault: true, defaultTab: '', defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
       openStore.setSession(`with-editor-${editorExplorer}`)
       const openTabs = allLeaves(openStore.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs)
       expect(openTabs.map(tab => tab.type)).toEqual(['editor'])
@@ -318,7 +321,7 @@ describe('side card preferences', () => {
   it('seeds the empty editor home tab (files window) in both editorExplorer modes', () => {
     for (const editorExplorer of [true, false]) {
       const store = createSidebarStore()
-      store.setPrefs({ openByDefault: true, defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
+      store.setPrefs({ openByDefault: true, defaultTab: '', defaultWidthPercent: 30, autoOpenSubagent: true, autoOpenJobs: true, agentTerminalTools: false, bottomPanelAutoTerminal: true, terminalFontFamily: '', terminalFontSize: 13, interceptOpenPath: true, editorExplorer, terminalShell: '', terminalShellArgs: '', titleBarScheme: 'auto', titleBarPresetId: '', customCss: '', titleBarCompat: false, titleBarStripPx: 40, htmlViewerNoSandbox: false, htmlViewerDefaultUnsafe: false, browserNoSandbox: false, browserInterceptLinks: true, browserInterceptHttp: true, browserInterceptHttps: false, tabsEnabled: {}, viewersEnabled: {}, pluginSettings: {} })
       store.setSession(`fresh-${editorExplorer}`)
       const tabs = allLeaves(store.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs)
       expect(tabs).toHaveLength(1)

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -602,6 +602,7 @@ describe('side card settings routes', () => {
     expect(read.value).toEqual({
       value: {
         openByDefault: false,
+        defaultTab: '',
         defaultWidthPercent: 35,
         autoOpenSubagent: true,
         autoOpenJobs: true,


### PR DESCRIPTION
## Motivation

A brand-new conversation always seeds the empty Files window, and there is no way to start anywhere else. The seed is hardcoded in `makeDefaultState`:

```ts
leaf.tabs = [{ id: uid('tab'), type: 'editor', title: 'Files', meta: { treeOpen: true } }]
```

Concretely: I keep a Tasks-first workflow and want every new conversation to land on the Tasks page. `openByDefault` opens the panel but cannot choose the page, and `autoOpenSubagent` is event-driven (it fires on a 0 → N subagent transition), so neither covers it.

## What this adds

`defaultTab` on `SidebarPrefs`, a registered tab descriptor id. **Empty is the default and keeps today's behaviour byte for byte.** Set it, and the first paint of a fresh session opens that tab instead of the Files seed.

## Why in `Sidebar.tsx` and not in `makeDefaultState`

Seeding the tab where the existing seed lives looked natural but is wrong: `makeDefaultState` has no descriptor registry, so it can only store a static title. That is why the current seed hardcodes the English `'Files'` even in a Chinese UI, and `TabBar` renders `tab.title` verbatim.

Routing through the ordinary `openTab` path instead means the tab carries its **localized** title from `descriptor.title()`, honours `isTabEnabled`, and works for a plugin-registered id exactly like a built-in one. It is the same call `onNewTab` makes.

## Guards

- once per session, via a ref keyed by session id
- only while the layout is still the untouched seed (one pane holding either nothing or a single path-less editor tab), so a restored layout and any tab the user opened are never fought
- the effect reads the **reactive** snapshot and re-evaluates until the seeded state for the new session lands. A one-shot `store.getSnapshot()` at the moment `sessionId` changes can still observe the previous session's layout and skip the seeding entirely — this reproduced on the second and later new conversations in my first pass, and the reactive read is what fixed it
- an unregistered or disabled id opens nothing, so a stale value degrades to the Files seed rather than an empty pane

## Verification

Built and installed into a real `dsh web` profile on DSH `0.1.0-rc.7` (Windows, Node 22.22.2) with:

```yaml
# ~/.dsh/settings.yaml
dsh-better-sidebar:
  openByDefault: true
  defaultTab: subagent
```

Three consecutive new conversations each landed on the Tasks page with the panel open, and an existing conversation's restored layout was untouched.

`pnpm run typecheck` clean. `pnpm test`: 693 passed, 2 failures unrelated to this change — `pty-deps` (my sandbox installed with `--ignore-scripts`, so node-pty is unbuilt) and `fs-operations > keeps concurrent uploads to the same target independent`, which is flaky here and passes on re-run. Both reproduce on a clean checkout.

## Notes

- Prefs fixtures in three spec files gain the new field. Those files are LF in the repo; my first pass rewrote them as CRLF and I normalized it, so the diff is the 16 real lines rather than the whole file.
- **No settings-page row yet.** The pref is reachable through the settings document, and a select row listing the registered descriptors would be the natural follow-up — happy to add it here if you would rather it ship together, but I did not want to guess at the settings UX unprompted.
- Naming is open: `defaultTab` mirrors `openByDefault` / `defaultWidthPercent`, but if you would rather scope it as `newSessionTab` or fold it under an existing group, say so and I will rename.