### PR TITLE
fix: 将差异设置合并到源代码管理

### DIFF
--- a/src/client/SideCardSection.tsx
+++ b/src/client/SideCardSection.tsx
@@ -8,8 +8,8 @@
  *    default panel width as a percent of the window (number input row), and
  *    the open-path interception toggle — the DSH settings-row recipe
  *    (title/desc left + control right, hairline separators).
- *  - 侧边栏内容: one SMALL CARD per REGISTERED tab type (built-ins and
- *    external plugins alike), laid out in a responsive grid that wraps
+ *  - 侧边栏内容: one SMALL CARD per configurable tab type (the internal diff
+ *    view follows git), laid out in a responsive grid that wraps
  *    several cards per row — icon chip + title + type id, clicked to toggle
  *    the switch persisted in `prefs.tabsEnabled[id]`.
  *  - 文件预览: one SMALL CARD per REGISTERED file viewer — icon chip + title
@@ -103,7 +103,7 @@ function iconOf(icon: ReactNode | ((size: number) => ReactNode) | undefined, siz
   return typeof icon === 'function' ? icon(size) : icon
 }
 
-/** Tab inventory order: hidden types (editor/diff) last, then + menu order. */
+/** Tab inventory order: hidden types last, then + menu order. */
 function tabOrder(a: TabDescriptor, b: TabDescriptor): number {
   if (a.hidden !== b.hidden) return a.hidden === true ? 1 : -1
   return (a.order ?? 100) - (b.order ?? 100)
@@ -511,13 +511,13 @@ export function SideCardSection({ store, service }: SideCardSectionProps) {
   const optimisticRef = useRef(prefs)
   useEffect(() => { optimisticRef.current = prefs }, [prefs])
 
-  // The declarative inventory: the registered tab types and file viewers.
+  // The declarative inventory: configurable tab types and registered viewers.
   // Local state + service.subscribe (registry changes are rare — plugin
   // load/unload — so a plain effect is enough; no external-store ceremony).
-  const [tabs, setTabs] = useState<TabDescriptor[]>(() => [...service.getTabs()].sort(tabOrder))
+  const [tabs, setTabs] = useState<TabDescriptor[]>(() => service.getTabs().filter(tab => tab.id !== 'diff').sort(tabOrder))
   const [viewers, setViewers] = useState<FileViewerDescriptor[]>(() => [...service.getFileViewers()].sort(viewerOrder))
   useEffect(() => service.subscribe(() => {
-    setTabs([...service.getTabs()].sort(tabOrder))
+    setTabs(service.getTabs().filter(tab => tab.id !== 'diff').sort(tabOrder))
     setViewers([...service.getFileViewers()].sort(viewerOrder))
   }), [service])
 

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -944,7 +944,9 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       store={store}
       visible={bottom ? state.bottomOpen && active : state.panelOpen && active}
       onSubagentJump={(childSessionId) => { subagentJumpRef.current = childSessionId }}
-      onOpenDiff={(diffTab) => { store.reduce(s => openDiffTab(s, paneId, diffTab)) }}
+      onOpenDiff={(diffTab) => {
+        if (ctx.betterSidebar?.isTabEnabled('git') === true) store.reduce(s => openDiffTab(s, paneId, diffTab))
+      }}
     />
   )
 

--- a/tests/side-card-section.spec.tsx
+++ b/tests/side-card-section.spec.tsx
@@ -56,6 +56,12 @@ function mount(): { store: SidebarStore; service: BetterSidebarService } {
     },
     component: () => null,
   })
+  service.registerTab({
+    id: 'diff',
+    title: () => 'Diff',
+    hidden: true,
+    component: () => null,
+  })
   service.registerFileViewer({
     id: 'image',
     title: () => 'Image',
@@ -89,6 +95,8 @@ describe('SideCardSection declarative inventory', () => {
     expect(html).toContain('>explorer<')
     expect(html).toContain('data-icon="subagent"')
     expect(html).toContain('>Subagents<')
+    expect(html).not.toContain('>Diff<')
+    expect(html).not.toContain('>diff<')
     // Default prefs: only the interceptOpenPath switch is checked (openByDefault
     // now defaults off), and both tabs + the image viewer cards pressed
     // (3 aria-pressed cards).
@@ -109,6 +117,14 @@ describe('SideCardSection declarative inventory', () => {
     expect(html).toContain('>File viewers</span><span')
     expect(html).toContain('>2</span>')
     expect(html).toContain('>1</span>')
+  })
+
+  it('keeps plugin-owned hidden tabs configurable while folding the built-in diff into git', () => {
+    const { store, service } = mount()
+    service.registerTab({ id: 'plugin:hidden', title: 'Plugin hidden tab', hidden: true, component: () => null })
+    const html = renderSection(store, service)
+    expect(html).toContain('>Plugin hidden tab<')
+    expect(html).not.toContain('>Diff<')
   })
 
   it('renders one small card per registered viewer: icon + title + exts', () => {


### PR DESCRIPTION
## 变更
- 设置页不再单独展示内置 `diff` 卡片
- 打开差异页时跟随 `git` 启用状态
- 保留第三方插件隐藏 Tab 的设置卡片语义

## 验证
- `pnpm test`（640 通过，5 跳过）
- `pnpm typecheck`