### PR TITLE
fix(git): hide spawned git windows on Windows

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -96,6 +96,7 @@ function runGit(cwd: string, args: string[], timeoutMs = 30_000): Promise<string
   return new Promise<string>((resolvePromise, reject) => {
     const child = spawn('git', full, {
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
       env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
     })
     let stdout = ''

--- a/tests/git-spawn.spec.ts
+++ b/tests/git-spawn.spec.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+import { isGitRepo } from '../src/git.ts'
+
+afterEach(() => {
+  spawnMock.mockReset()
+})
+
+describe('git subprocess spawning', () => {
+  it('hides spawned git windows', async () => {
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter()
+      const stdout = new PassThrough()
+      const stderr = new PassThrough()
+      Object.assign(child, { stdout, stderr, kill: vi.fn() })
+
+      queueMicrotask(() => {
+        stdout.end('true\n')
+        stderr.end()
+        child.emit('close', 0)
+      })
+
+      return child
+    })
+
+    await expect(isGitRepo('C:\\repo')).resolves.toBe(true)
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(spawnMock).toHaveBeenCalledWith(
+      'git',
+      ['-C', 'C:\\repo', '--no-pager', '-c', 'color.ui=false', 'rev-parse', '--is-inside-work-tree'],
+      expect.objectContaining({ windowsHide: true }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- set `windowsHide: true` on the shared `runGit()` spawn options
- add a focused regression test that verifies Git subprocesses use the hidden-window flag

## Why

On Windows, the sidebar periodically spawns `git` for repository status and related operations. Without `windowsHide`, those short-lived subprocesses can briefly create visible console windows. Since all Git operations go through `runGit()`, applying the option there covers the polling and action paths without changing Git behavior on other platforms.

Fixes #124.

## Validation

- reviewed the branch diff against current `main`: one production-line change plus one focused test
- test file passes Node's TypeScript syntax check (`node --experimental-strip-types --check`)
- full Vitest/typecheck/build could not be run in the current sandbox because repository dependencies are unavailable and external package fetching is blocked; the repository CI can exercise the normal test/build/plugin-mount gates

## AI Coding Disclosure

- [x] AI-assisted implementation and review

Model: GPT-5.6 Sol
Tool: ChatGPT
