### PR TITLE
feat(ci): DSH CLI 钉版平移至 0.1.1-rc.2（挂载冒烟验证基线）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       # (dsh-base / dsh-web-app) resolves from this installation. Keep in
       # step with the plugin's @deepseek-ai/* peer range when bumping.
       - name: Install dsh CLI (pinned)
-        run: npm install -g @deepseek-ai/dsh@0.1.1-rc.1
+        run: npm install -g @deepseek-ai/dsh@0.1.1-rc.2
 
       # lib/ is gitignored; the tarball is produced from this build.
       - name: Build and pack the npm tarball

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ better-sidebar 从 v0.4.0 起暴露 `ctx.betterSidebar` 服务（Cordis context 
 2. `scripts/e2e-mount.sh` 用官方 CLI 把它装进一个**全新 scratch profile**（`dsh plugin --profile web add file:<tarball>`，触发 `dsh.profile.bundles` 协调），然后启动真实 `dsh web`（keyless，`--port 0`）。
 3. `tests/e2e/mount.e2e.ts`（Playwright Chromium）加载页面，断言外壳与 `[data-dsh-better-sidebar]` 挂载、无 `dsh-better-sidebar:` 错误条、无 pageerror/插件 console 错误，显式展开面板（`openByDefault` 默认关）后通过「+ 菜单」逐个打开内置 tab（含终端懒加载 chunk）深扫，再经 Files 文件窗口的树打开 seed 文件强制加载 editor 懒加载 chunk（`client-editor.js`，独立模式：每个文件新开 tab，seed 的 home tab 保持资源管理器）——缺失的内置 tab 或 chunk 都会使门禁变红。
 
-本地跑：`pnpm build && pnpm pack && pnpm exec playwright install chromium && pnpm test:mount`（需 PATH 上有 `dsh` 或可经 npx 拉取）。DSH CLI 版本在 CI 钉住 `@deepseek-ai/dsh@0.1.1-rc.1`（插件 devDependencies 验证基线；peer 下限保持 `^0.1.0-rc.8`，rc.8 与 0.1.1-rc.1 双向兼容）。`tests/e2e` 的 spec 命名 `*.e2e.ts` + vitest `exclude` 双保险与 vitest 隔离；**改动 vitest `exclude` 时必须保留默认排除项**（`exclude` 会整体替换默认值）。
+本地跑：`pnpm build && pnpm pack && pnpm exec playwright install chromium && pnpm test:mount`（需 PATH 上有 `dsh` 或可经 npx 拉取）。DSH CLI 版本在 CI 钉住 `@deepseek-ai/dsh@0.1.1-rc.2`（挂载冒烟验证基线；peer 下限保持 `^0.1.0-rc.8`，rc.8 与 0.1.1-rc.x 双向兼容）。`tests/e2e` 的 spec 命名 `*.e2e.ts` + vitest `exclude` 双保险与 vitest 隔离；**改动 vitest `exclude` 时必须保留默认排除项**（`exclude` 会整体替换默认值）。
 
 ### npm 发版（GitHub Release → npm publish）
 


### PR DESCRIPTION
## 背景

上轮已完整验证插件 v0.14.2 与 DSH `0.1.1-rc.2` 兼容：

- **挂载冒烟（rc.2 真实运行）11/11 通过**：`pnpm test:mount` 用 PATH 上的 `dsh@0.1.1-rc.2` 装入全新 scratch profile、启动真实 `dsh web`，Playwright 无头渲染 + 内置 tab 深扫全绿
- **聚合双挂载回归（rc.2）通过**：无 duplicate prefix route，`/sidebar/api` 真实 handler 存活
- **rc.1 → rc.2 API 逐包 diff（16 包）**：13 包零变化；仅 client-runtime（`create` 系 opts 收窄，内部契约）与 client-ui-conversation（删除 3 个 `access.preset.*` locale 键）有变化，插件源码 grep 均零命中；dsh-llm 纯增量。无需代码改动

## 改动

- `.github/workflows/ci.yml`：`plugin-mount` job 的 DSH CLI 钉版 `0.1.1-rc.1` → `0.1.1-rc.2`（保持与最新验证基线一致）
- `AGENTS.md`：同步 CI 钉版描述（rc.8 与 0.1.1-rc.x 双向兼容）

## 备注

- devDependencies 仍钉 `0.1.1-rc.1`（本次不动，可后续单独平移）；peer 下限保持 `^0.1.0-rc.8`
- 本地已用 rc.2 跑通 CI 同款两条挂载 lane，CI 全绿预期