### PR TITLE
fix(explorer): 非文件拖拽不再触发文件树上传遮罩

### DIFF
--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -52,6 +52,13 @@ function parentOf(path: string): string {
   return at <= 0 ? path : path.slice(0, at)
 }
 
+/** Only OS file drags belong to the upload surface; in-app drags (tab reorder,
+ *  split zones) must pass through untouched to the pane's tab-drop handling
+ *  (mirror of Sidebar.tsx's panel-host shield gate). */
+function isFileDrag(event: DragEvent): boolean {
+  return event.dataTransfer?.types.includes('Files') ?? false
+}
+
 /** How long the row's "copied" label stays after a successful write. */
 const COPIED_MS = 1200
 
@@ -160,12 +167,14 @@ export function FileTree(props: {
     })
   }
   const handleBodyDrop = (event: DragEvent): void => {
+    if (!isFileDrag(event)) return
     event.preventDefault()
     event.stopPropagation()
     resetDrop()
     if (cwd !== undefined) reportDrop(cwd, event.dataTransfer)
   }
   const handleDirDrop = (event: DragEvent, dir: string): void => {
+    if (!isFileDrag(event)) return
     event.preventDefault()
     event.stopPropagation()
     resetDrop()
@@ -176,6 +185,7 @@ export function FileTree(props: {
     handleDirDrop(event, parentOf(path))
   }
   const handleBodyDragEnter = (event: DragEvent): void => {
+    if (!isFileDrag(event)) return
     event.preventDefault()
     event.stopPropagation()
     dropDepth.current += 1
@@ -195,6 +205,7 @@ export function FileTree(props: {
     setDropRect(null)
   }
   const handleBodyDragOver = (event: DragEvent): void => {
+    if (!isFileDrag(event)) return
     event.preventDefault()
     event.stopPropagation()
     event.dataTransfer.dropEffect = busy ? 'none' : 'copy'
@@ -205,6 +216,7 @@ export function FileTree(props: {
     setDropTarget(null)
   }
   const handleRowDragOver = (event: DragEvent, dir: string): void => {
+    if (!isFileDrag(event)) return
     event.preventDefault()
     event.stopPropagation()
     event.dataTransfer.dropEffect = busy ? 'none' : 'copy'

--- a/tests/file-tree-drop.spec.tsx
+++ b/tests/file-tree-drop.spec.tsx
@@ -14,6 +14,7 @@ import { createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react-dom/test-utils'
 import { FileTree } from '../src/client/FileTree.tsx'
+import { TAB_DRAG_TYPE } from '../src/client/TabBar.tsx'
 import type { UploadItem } from '../src/client/upload.ts'
 
 // The act() environment flag (React 18.2 reads it before flushing effects).
@@ -72,12 +73,12 @@ async function mountTree(busy = false): Promise<Harness> {
 }
 
 /** A bubbling drag event carrying a stub dataTransfer (jsdom has no DragEvent). */
-function dragEvent(type: string): Event {
+function dragEvent(type: string, dataTypes: string[] = ['Files']): Event {
   const event = new Event(type, { bubbles: true, cancelable: true })
   Object.defineProperty(event, 'dataTransfer', {
     // No entry API on the items, so drops fall back to the flat file list.
     value: {
-      types: ['Files'],
+      types: dataTypes,
       items: [],
       files: [new File(['x'], 'dropped.txt')],
       dropEffect: '',
@@ -87,8 +88,8 @@ function dragEvent(type: string): Event {
 }
 
 /** Dispatch inside act() so React flushes the state update. */
-function fire(target: Element, type: string): Event {
-  const event = dragEvent(type)
+function fire(target: Element, type: string, dataTypes?: string[]): Event {
+  const event = dragEvent(type, dataTypes)
   act(() => { target.dispatchEvent(event) })
   return event
 }
@@ -178,5 +179,27 @@ describe('FileTree drag-drop surface', () => {
     await act(async () => {})
     expect(busyHarness.uploads).toHaveLength(0)
     busyHarness.unmount()
+  })
+
+  it('ignores an in-app tab drag: no upload drop zone and events pass through', () => {
+    const enter = fire(harness.body, 'dragenter', [TAB_DRAG_TYPE])
+    expect(enter.defaultPrevented).toBe(false)
+    expect(dropZone()).toBeNull()
+    const over = fire(harness.body, 'dragover', [TAB_DRAG_TYPE])
+    expect(over.defaultPrevented).toBe(false)
+    expect(dropZone()).toBeNull()
+    // A row hover must not retarget the drop directory either.
+    const dir = rowByName(harness.container, 'src')
+    const rowOver = fire(dir, 'dragover', [TAB_DRAG_TYPE])
+    expect(rowOver.defaultPrevented).toBe(false)
+    expect(dir.className).not.toContain('explorerRowDropTarget')
+  })
+
+  it('passes an in-app tab drop through without reporting an upload', async () => {
+    const drop = fire(harness.body, 'drop', [TAB_DRAG_TYPE])
+    await act(async () => {})
+    expect(drop.defaultPrevented).toBe(false)
+    expect(harness.uploads).toHaveLength(0)
+    expect(dropZone()).toBeNull()
   })
 })


### PR DESCRIPTION
## 问题

资源管理器（文件树）Tab 在拖动其他 Tab（重排 / 跨 pane split）经过文件树区域时，会意外显示「拖拽文件/文件夹到此处上传」的遮罩（`uploadDropZone` 门户遮罩）。

## 根因

`src/client/FileTree.tsx` 的 `handleBodyDragEnter` / `handleBodyDragOver` / `handleRowDragOver` / `handleBodyDrop` / `handleDirDrop` 对**任何**拖拽事件都执行 `preventDefault` + `stopPropagation` 并设置 `dropOver`，没有按 `dataTransfer` 类型门控。Tab 拖拽只设置 `application/x-dsh-tab`（无 `Files`），指针经过文件树时同样命中这些 handler，于是：

1. 显示上传遮罩（误报）；
2. 事件被吞掉，pane 根（`split-pane.tsx` 的 `LeafView`）的 VSCode 式边/中 Tab-drop 遮罩与移动逻辑收不到——drop 落在文件树上无法移动 Tab。

`Sidebar.tsx` 的面板宿主 shield（`swallowOsFileDrag`）已按 `'Files'` 门控，注释明确「gated on the 'Files' type so in-app drags (tab reorder, split zones) propagate exactly as before」，但它只防 DSH 聊天区全屏摄入，未覆盖 FileTree 自身的 handler，这就是回归缺口。

## 修复

- FileTree 新增 `isFileDrag(event)`（与 Sidebar.tsx 相同的判断：`dataTransfer.types.includes('Files')`），在上述 5 个 handler 开头 early-return：
  - 非文件拖拽不再显示上传遮罩、不改 dropTarget、不 `preventDefault` / `stopPropagation` → 原样冒泡给 pane 根，Tab-drop 恢复与其他 Tab 内容一致的行为；
  - OS 文件拖拽（含 `Files`）行为完全不变：遮罩、目录高亮、上传、busy 抑制、enter/leave 深度计数保持。

## 测试

- `tests/file-tree-drop.spec.tsx` 新增回归用例（`TAB_DRAG_TYPE` 从 `TabBar.tsx` 导入）：
  - 应用内 Tab 拖拽进入树体/悬停目录行：不出现 `uploadDropZone`、行无 `explorerRowDropTarget`、`defaultPrevented === false`；
  - 应用内 Tab drop：`defaultPrevented === false`、不触发 `onUploadRequest`、遮罩保持隐藏。
- 本地验证：`pnpm typecheck` ✅；`pnpm test` 全量 74 个文件 / 761 用例通过（5 skipped）✅。