### PR TITLE
fix: add unrun devDependency for tsdown config loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "react-dom": "18.2.0",
     "tsdown": "^0.22.2",
     "typescript": "^5.6.0",
+    "unrun": "^0.3.1",
     "vitest": "^4.1.8"
   }
 }


### PR DESCRIPTION
## Problem

Git-hosted installs of this plugin fail at the prepare step:

```
.prepare: ERROR Error: Failed to import module "unrun". Please ensure it is installed.
```

tsdown 0.22 loads `tsdown.config.ts` via `unrun` (declared as a peerDependency of tsdown). pnpm 11 does not auto-install peer dependencies by default, so when pnpm fetches this repo from git and runs `pnpm install` + prepare inside it, `unrun` is missing and the build fails. Published npm tarballs are unaffected (prebuilt lib/ ships), but git-based installs (e.g. dsh plugin manager) break.

## Fix

Declare `unrun` as a devDependency so the prepare step can resolve it:

```json
"unrun": "^0.3.1"
```

## Verification

With this change, a fresh git-hosted `pnpm install` succeeds: prepare runs tsdown, which loads tsdown.config.ts via unrun, and lib/ artifacts are produced.