### PR TITLE
feat(catalog): add ego-browser to built-in tab catalog

### DIFF
--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -337,6 +337,7 @@ export const zh = {
   pluginTurnReviewDesc: '对「刚刚这一回合」的 diff 做 Approve / Request changes 的人闸门：只审上一回合，不 fork 会话；文件按主会话/子代理/未归因分组，按文件勾选打回 + 可选评语，点文件先看回合开始快照 vs 现在的 diff。不是 /rewind',
   pluginVideoPreviewDesc: '在 better-sidebar 编辑器内联预览视频文件（.mp4/.webm/.mov/.mkv/.avi 等），自带支持 HTTP Range（206）的 /video 宿主路由，可拖动进度条、不受 20MB mediaLimit 限制',
   pluginDocsPanelDesc: 'DSH 侧边栏里的「全局文档」：全局 Markdown 笔记，任何工作区随时可读——列表点选阅读、悬浮大纲跳转、Chrome / VS Code 外部打开、代码复制，目录可配置（默认 ~/.dsh/docs）',
+  pluginEgoBrowserDesc: '把 CitroLabs/ego-lite 接进 DeepSeek Harness 的 agent 浏览器：32 个 ego_* 工具驱动真实 Chromium，侧边栏原生「ego 浏览器」Tab 实时观察 agent 逛的每个页面，可直接点击/拖拽/输入接管；装 better-sidebar 时自动注册 Tab，没装则退回浮动浮窗',
 }
 
 /** The en dictionary (key-set-equal to zh, enforced by the type annotation). */
@@ -667,6 +668,7 @@ export const en: Record<keyof typeof zh, string> = {
   pluginTurnReviewDesc: 'A human gate on the just-finished turn: Approve / Request changes per path with an optional comment; paths grouped by main session / subagent / unattributed; inline snapshot-vs-now diff before you decide. No fork, no /rewind',
   pluginVideoPreviewDesc: 'Inline video preview (.mp4/.webm/.mov/.mkv/.avi etc.) for the better-sidebar editor, backed by a dedicated /video host route with HTTP Range (206) support — scrubbing works and files are not capped by the 20MB mediaLimit',
   pluginDocsPanelDesc: 'Global docs in the DSH sidebar: read your own Markdown notes from any workspace — a file list, an outline, open in Chrome / VS Code, and copy buttons; the docs directory is configurable (default ~/.dsh/docs)',
+  pluginEgoBrowserDesc: 'The agent browser for DeepSeek Harness: 32 ego_* tools drive a real Chromium, with a native sidebar "ego browser" tab giving a live view of every page the agent visits — you can click, drag, and type to take over. Registers the tab automatically when better-sidebar is present, otherwise falls back to a floating bubble',
 }
 
 /**

--- a/src/client/plugins-tabs.ts
+++ b/src/client/plugins-tabs.ts
@@ -25,6 +25,15 @@ export const builtinTabPlugins: readonly PluginEntry[] = [
     install: 'cd ~/.dsh && dsh plugin --profile web add "github:fuhefei/dsh-sentinel#v0.7.0"',
   },
   {
+    id: '@dsh-external/ego-browser',
+    name: 'ego-browser Agent 浏览器',
+    url: 'https://github.com/Fisfzy/ego-browser',
+    description: () => t('pluginEgoBrowserDesc'),
+    // Registers a sidebar tab for the agent browser; optional peer of
+    // better-sidebar (auto-tab when present, floating bubble when not).
+    install: 'cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar && dsh plugin --profile web add git+https://github.com/Fisfzy/ego-browser.git',
+  },
+  {
     id: 'dsh-docs-panel',
     name: 'dsh-docs-panel 全局文档',
     url: 'https://github.com/mlosun/dsh-docs-panel',


### PR DESCRIPTION
## 概述

把 **ego-browser**（agent 浏览器插件）加入内置「添加 Tab 插件」推荐目录（Side card 设置 → 侧边栏内容 → 虚线卡片添加 Tab）。

## 改动
- **`src/client/plugins-tabs.ts`**：追加 `@dsh-external/ego-browser` 条目（唯一 id、GitHub URL、i18n 描述键、以 `cd ~/.dsh` 开头且含 `dsh plugin` CLI 的安装脚本）。
- **`src/client/locales.ts`**：新增 `pluginEgoBrowserDesc`（中文 + 英文两条）。

## PluginEntry 契约核验（对照 `tests/plugin-list.spec.ts`）
- ✅ 唯一 id（npm 包名，无空格）
- ✅ name / GitHub URL 非空
- ✅ `description` 解析为非空 i18n 字符串
- ✅ `install` 以 `cd ~/.dsh` 开头 + 含 `dsh plugin`
- ✅ 未与现有 Tab 条目重复

## 插件说明
ego-browser 是 `dsh-better-sidebar` 的**可选 peer**：装了 better-sidebar 时自动注册侧边栏「ego 浏览器」本机 Tab（`ctx.get('betterSidebar')` 机会式消费），没装则退回浮动浮窗观察。安装脚本先装 better-sidebar 再装 ego-browser（`git+https` 源，ego 仓库是 git 源、非 npm 发布）。