### PR TITLE
fix(mermaid): suppress global error rendering

### DIFF
--- a/src/client/mermaid.tsx
+++ b/src/client/mermaid.tsx
@@ -48,6 +48,10 @@ function configureMermaid(): void {
     // forcing pure SVG text keeps labels visible and the HTML label channel
     // closed (strict already escapes label content).
     htmlLabels: false,
+    // Mermaid 11 renders a large error SVG into document.body before rejecting
+    // invalid diagrams. The component already has its own error fallback, so
+    // suppress that global side effect to keep the DSH shell intact.
+    suppressErrorRendering: true,
     theme: isDarkScheme() ? 'dark' : 'default',
   })
 }

--- a/tests/mermaid-markdown.spec.tsx
+++ b/tests/mermaid-markdown.spec.tsx
@@ -16,13 +16,14 @@ import { act } from 'react-dom/test-utils'
 
 vi.mock('mermaid', () => ({
   default: {
-    initialize: () => {},
+    initialize: vi.fn(),
     render: async () => ({
       svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>MOCK-DIAGRAM</text></svg>',
     }),
   },
 }))
 
+import mermaid from 'mermaid'
 import { MermaidMarkdown } from '../src/client/mermaid.tsx'
 
 const codeLabels = { copyLabel: 'Copy', copiedLabel: 'Copied' }
@@ -53,6 +54,15 @@ describe('MermaidMarkdown', () => {
     const diagram = container.querySelector('[data-mermaid-diagram] svg')
     expect(diagram, 'the mermaid fence must be swapped for a diagram').not.toBeNull()
     expect(diagram?.textContent).toContain('MOCK-DIAGRAM')
+    await unmount(root)
+  })
+
+  it('suppresses Mermaid global error rendering', async () => {
+    vi.mocked(mermaid.initialize).mockClear()
+    const { root } = await renderMarkdown('```mermaid\ngraph TD\n  A-->B\n```')
+    expect(mermaid.initialize).toHaveBeenCalledWith(expect.objectContaining({
+      suppressErrorRendering: true,
+    }))
     await unmount(root)
   })
 


### PR DESCRIPTION
## Summary

- Enable Mermaid's suppressErrorRendering option so invalid diagrams do not inject the large error SVG into document.body.
- Keep the existing component-level error fallback and source display.
- Add a regression test that locks the configuration.

## Validation

- pnpm exec vitest run tests/mermaid-markdown.spec.tsx — passed (4 tests).
- pnpm exec tsc -p tsconfig.build.json — passed.
- pnpm exec tsdown — passed.
- pnpm test — 816 passed, 4 unrelated environment-sensitive failures, 9 skipped. The failures are in existing Windows/Node 23 
ode-pty console handling, Git line-ending expectations, and plugin install command detection.

The package-level pnpm run build script itself uses POSIX m -rf and cannot run unchanged under PowerShell; the equivalent 	sc and 	sdown build steps passed.