### PR TITLE
feat: render file viewer icons in file chrome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,7 @@ interface FileViewerDescriptor {
   id: string
   /** 设置清单展示名（v0.4.1+，i18n 友好）；缺省回退到 id */
   title?: string | (() => string)
-  /** 设置清单图标（v0.4.1+）：ReactNode 或 (size: number) => ReactNode */
+  /** 设置清单、匹配的文件树行与编辑器 tab 图标：ReactNode 或 (size: number) => ReactNode */
   icon?: ReactNode | ((size: number) => ReactNode)
   /** 小写无点的扩展名数组：['png','jpg']。[] = catch-all（仅最低优先级有效） */
   exts: readonly string[]

--- a/docs/plans/2026-08-22-viewer-file-icons.md
+++ b/docs/plans/2026-08-22-viewer-file-icons.md
@@ -1,0 +1,60 @@
+# Viewer File Icons Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let file-viewer plugins provide file-tree and editor-tab icons through the existing `FileViewerDescriptor.icon` registry field.
+
+**Architecture:** Better Sidebar already owns extension matching through `matchFileViewer(path)` and viewer icons through `descriptor.icon`. Reuse that registry in the tree and tab render paths, then delete `dsh-lua-support`'s DOM observer. The Lua plugin remains a normal high-priority viewer that owns its CodeMirror grammar and Charmed icon.
+
+**Tech Stack:** React 18, TypeScript, Better Sidebar service registry, Vitest, CodeMirror 6.
+
+---
+
+### Task 1: Resolve viewer icons centrally
+
+**Files:**
+- Modify: `src/client/Sidebar.tsx`
+- Test: `tests/sidebar.spec.tsx`
+
+1. Add a failing test asserting an `editor` tab with `path: 'main.lua'` renders the matched viewer icon instead of the generic editor icon.
+2. Run `pnpm vitest run tests/sidebar.spec.tsx` and confirm failure.
+3. Update `tabIconOf` to resolve `service.matchFileViewer(tab.path)?.icon` for editor file tabs, falling back to the tab descriptor icon.
+4. Re-run the focused test and confirm it passes.
+
+### Task 2: Thread viewer icons into the file tree
+
+**Files:**
+- Modify: `src/client/FileTree.tsx`
+- Modify: `src/client/TreePanel.tsx`
+- Modify: `src/client/EditorHost.tsx`
+- Test: `tests/editor-host.spec.tsx`
+
+1. Add a failing test that registers a `.lua` viewer icon and asserts the tree row renders it.
+2. Run `pnpm vitest run tests/editor-host.spec.tsx` and confirm failure.
+3. Add an optional `fileIcon(path)` render prop to `FileTree`/`TreePanel`; have `EditorHost` resolve it from `ctx.betterSidebar.matchFileViewer(path)?.icon`, with the generic code icon as fallback.
+4. Re-run the focused test and confirm it passes.
+
+### Task 3: Remove the Lua plugin DOM shim
+
+**Files:**
+- Delete: `C:/Users/asher/dsh-lua-support/src/client/file-icons.ts`
+- Modify: `C:/Users/asher/dsh-lua-support/src/client/index.tsx`
+- Modify: `C:/Users/asher/dsh-lua-support/src/client/LuaEditor.tsx`
+- Modify: `C:/Users/asher/dsh-lua-support/tests/lua-support.spec.ts`
+
+1. Remove `installLuaFileIcons`; keep the Charmed glyph solely on the viewer descriptor.
+2. Replace CodeMirror's default highlight style with DSH's `--shiki-*` token variables so Lua matches native code surfaces.
+3. Update tests to cover descriptor extensions/icon and grammar parsing without DOM mutation.
+4. Run `pnpm typecheck && pnpm test && pnpm build` in both repositories.
+
+### Task 4: Activate and verify
+
+**Files:**
+- Build output: `lib/client.js` in both repositories
+- Profile mounts: `C:/Users/asher/.dsh/profiles/desktop/`
+
+1. Point the desktop profile's `dsh-better-sidebar` dependency at the local feature branch and reinstall.
+2. Rebuild both plugins and reinstall the local packages.
+3. Restart DSH Desktop once.
+4. Verify `http://127.0.0.1:54443/` boot metadata contains `dsh-lua-support`, open `.lua` and `.luau` fixtures, and confirm native-theme highlighting plus Charmed icons in both tree and tab.
+5. Commit the Better Sidebar change on a `feat/*` branch and open the required upstream PR.

--- a/src/client/EditorHost.tsx
+++ b/src/client/EditorHost.tsx
@@ -38,6 +38,7 @@ import { relativeTo } from './paths.ts'
 import { resolveSidebarPath } from './produced-files.ts'
 import type { EditorToolbarControls, EditorToolbarState, FileViewerDescriptor } from './service.ts'
 import { firstLeaf, insertLeafAt, leafWithTab, mintTabId, treeOf, type SidebarStore, type SidebarTab } from './state.ts'
+import { viewerIconForPath } from './viewer-icon.ts'
 import css from './sidebar.module.css'
 
 type EditorLoad =
@@ -256,6 +257,7 @@ export function EditorHost(props: {
     : toolbar.saveState === 'saving' ? t('loading')
       : toolbar.saveState === 'saved' ? t('saved')
         : toolbar.saveState === 'failed' ? t('saveFailed') : ''
+  const fileIcon = (filePath: string, size: number) => viewerIconForPath(ctx.betterSidebar, filePath, size)
 
   // Split mode: the path-less window IS the standalone explorer — the tree
   // panel fills the whole tab (search + FileTree, full form), no editor
@@ -273,6 +275,7 @@ export function EditorHost(props: {
           onOpenFileNewTab={openFileNewTab}
           onOpenFileSide={openFileSide}
           onReferenceFile={onReferenceFile}
+          fileIcon={fileIcon}
         />
       </div>
     )
@@ -366,6 +369,7 @@ export function EditorHost(props: {
               onOpenFileNewTab={openFileNewTab}
               onOpenFileSide={openFileSide}
               onReferenceFile={onReferenceFile}
+              fileIcon={fileIcon}
             />
           </div>
         )}

--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -104,6 +104,8 @@ export function FileTree(props: {
   onOpenFileSide?: (path: string) => void
   /** Insert `@<relative path>` into the composer draft. */
   onReferenceFile: (path: string) => void
+  /** Resolve a registered viewer icon for a file path. */
+  fileIcon?: (path: string, size: number) => ReactNode
   /** Bump to wipe the level cache and reload the visible set. */
   refreshTick: number
   /** Upload into `dir` (absolute, inside the workspace); runs in the caller. */
@@ -111,7 +113,7 @@ export function FileTree(props: {
   /** True while an upload is in flight (drops are ignored). */
   busy: boolean
 }) {
-  const { sessionId, cwd, expanded, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, onReferenceFile, refreshTick, onUploadRequest, busy } = props
+  const { sessionId, cwd, expanded, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, onReferenceFile, fileIcon, refreshTick, onUploadRequest, busy } = props
   const [data, setData] = useState<Record<string, LevelData>>({})
   const dataRef = useRef(data)
   /** The row whose path was just copied ("copied" label replaces its button). */
@@ -365,7 +367,7 @@ export function FileTree(props: {
           onDrop={(event) => { handleFileDrop(event, entry.path) }}
           onContextMenu={(event) => { openRowMenu(event, entry.path, false) }}
         >
-          <IconCodeOutline16 size={14} />
+          {fileIcon?.(entry.path, 14) ?? <IconCodeOutline16 size={14} />}
           <span className={css.explorerName}>{entry.name}</span>
           {entry.isSymlink && <IconLinkOutline16 size={12} className={css.explorerSymlink} />}
           {rowActions(entry)}

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -53,6 +53,7 @@ import { relativeTo } from './paths.ts'
 import { OrphanedTab } from './OrphanedTab.tsx'
 import { RenderBoundary } from './RenderBoundary.tsx'
 import { detectNewDirectSubagent } from './subagent-detect.ts'
+import { renderViewerIcon, viewerIconForPath } from './viewer-icon.ts'
 import { detectNewJob } from './subagent-jobs.ts'
 import { t } from './locales.ts'
 import { api, type SessionScope } from './api.ts'
@@ -964,11 +965,13 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
    * ctx and the conversation input service at click time; a missing service
    * or scope degrades to a logged no-op, never a crash.
    */
-  /** The tab icon from the tab-type registry (shared by every workbench). */
+  /** File tabs use their matched viewer icon; other tabs use their type icon. */
   const tabIconOf = (tab: SidebarTab): ReactNode => {
-    const descriptor = ctx.betterSidebar?.getTab(tab.type)
-    if (descriptor === undefined) return null
-    return typeof descriptor.icon === 'function' ? descriptor.icon(14) : descriptor.icon
+    if (tab.type === 'editor' && tab.path !== undefined && tab.path !== '') {
+      const fileIcon = viewerIconForPath(ctx.betterSidebar, tab.path, 14)
+      if (fileIcon !== null) return fileIcon
+    }
+    return renderViewerIcon(ctx.betterSidebar?.getTab(tab.type)?.icon, 14)
   }
 
   /**

--- a/src/client/TreePanel.tsx
+++ b/src/client/TreePanel.tsx
@@ -15,7 +15,7 @@
  * drop over the file window uploads here and never reaches DSH's chat
  * intake.
  */
-import { useEffect, useRef, useState, type InputHTMLAttributes } from 'react'
+import { useEffect, useRef, useState, type InputHTMLAttributes, type ReactNode } from 'react'
 import clsx from 'clsx'
 import { IconFolderOpen16, IconRefreshOutline16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { api } from './api.ts'
@@ -51,11 +51,13 @@ export function TreePanel(props: {
   /** File context-menu "open to the side" (passed through to FileTree). */
   onOpenFileSide?: (path: string) => void
   onReferenceFile: (path: string) => void
+  /** Resolve a registered viewer icon for a file path. */
+  fileIcon?: (path: string, size: number) => ReactNode
   /** Full-window presentation: the panel fills its host instead of docking
    *  at a fixed width. */
   full?: boolean
 }) {
-  const { sessionId, cwd, expanded, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, onReferenceFile, full } = props
+  const { sessionId, cwd, expanded, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, onReferenceFile, fileIcon, full } = props
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<{ matches: string[]; truncated: boolean } | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -218,6 +220,7 @@ export function TreePanel(props: {
           onOpenFileNewTab={onOpenFileNewTab}
           onOpenFileSide={onOpenFileSide}
           onReferenceFile={onReferenceFile}
+          fileIcon={fileIcon}
           refreshTick={refreshTick}
           onUploadRequest={startUpload}
           busy={busy}
@@ -237,6 +240,7 @@ export function TreePanel(props: {
               title={rel}
               onClick={() => { onOpenFile(resolveSidebarPath(cwd, rel)) }}
             >
+              {fileIcon?.(resolveSidebarPath(cwd, rel), 14)}
               {rel}
             </button>
           ))}

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -298,7 +298,7 @@ export interface FileViewerDescriptor {
   id: string
   /** Display name for the settings inventory (falls back to `id` when absent). */
   title?: string | (() => string)
-  /** Icon shown in the settings inventory. */
+  /** Icon shown in settings and on matched file rows/editor tabs. */
   icon?: ReactNode | ((size: number) => ReactNode)
   /** Lowercase extensions without leading dot (`['png','jpg']`). `[]` = match any (catch-all). */
   exts: readonly string[]

--- a/src/client/viewer-icon.ts
+++ b/src/client/viewer-icon.ts
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import type { BetterSidebarService, FileViewerDescriptor } from './service.ts'
+
+/** Render a descriptor icon at the requested file-chrome size. */
+export function renderViewerIcon(
+  icon: FileViewerDescriptor['icon'],
+  size: number,
+): ReactNode {
+  return typeof icon === 'function' ? icon(size) : icon ?? null
+}
+
+/** Resolve the registered viewer for a path and render its icon. */
+export function viewerIconForPath(
+  service: Pick<BetterSidebarService, 'matchFileViewer'> | undefined,
+  path: string,
+  size: number,
+): ReactNode {
+  return renderViewerIcon(service?.matchFileViewer(path)?.icon, size)
+}

--- a/tests/viewer-icon.spec.tsx
+++ b/tests/viewer-icon.spec.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderViewerIcon, viewerIconForPath } from '../src/client/viewer-icon.ts'
+
+describe('viewer file icons', () => {
+  it('renders static and sized descriptor icons', () => {
+    expect(renderViewerIcon('static', 14)).toBe('static')
+    expect(renderViewerIcon(size => `lua-${size}`, 14)).toBe('lua-14')
+    expect(renderViewerIcon(undefined, 14)).toBeNull()
+  })
+
+  it('uses the matched file viewer as the icon registry', () => {
+    const matchFileViewer = vi.fn(() => ({ icon: (size: number) => `lua-${size}` }))
+    expect(viewerIconForPath({ matchFileViewer } as never, 'src/init.luau', 14)).toBe('lua-14')
+    expect(matchFileViewer).toHaveBeenCalledWith('src/init.luau')
+  })
+})


### PR DESCRIPTION
## Summary
- resolve file-row and editor-tab icons from the existing `FileViewerDescriptor.icon` registry
- thread the resolver through standalone and docked explorer trees plus search results
- document the expanded icon contract and cover static/sized icon resolution

This lets consumer plugins such as Lua/Luau support remain fully modular instead of decorating Better Sidebar DOM nodes.

## Verification
- `pnpm typecheck`
- `pnpm exec vitest run tests/viewer-icon.spec.tsx tests/editor-host.spec.tsx` (10 passed)
- `pnpm build`
- live DSH Desktop smoke test: plugin bundle loaded and viewer-registry icon resolver present

## Full-suite note
`pnpm test` reached 869 passing tests but had unrelated Windows/environment failures in `pty-deps.spec.ts` and scratch Git cleanup/timeouts (`EPERM` under `%TEMP%`). The focused suites and typecheck pass.