### PR TITLE
feat(changes): per-turn file-change history tab with inline diffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,7 @@ ctx.effect(() => {
 | `git` | 20 | 是 | 否 | Git 面板 |
 | `subagent` | 30 | 是 | 否 | 子代理拓扑 |
 | `sidechat` | 35 | 否（createTab 铸造 `sidechat:<uuid>`/按 `meta.threadId` 去重） | 否 | 侧边对话（Codex 风格，**每个对话一个独立 Tab**）：打开 Tab 即自动创建空线程（composer 拥有首条消息，host 侧包裹边界提示 + 创建时停泊的进行中快照，首条消息赢得真实标签并同步 Tab 标题）；线程 = 插件自建子会话（自定义种子继承父会话完整上下文，进行中回合以 `interrupted` 冻结诚实闭合；种子尾部带合法 `subagent/descriptor`——否则 cold 线程在宿主 subagents.list 里是 corrupt 诊断行——SubagentView/subagent-detect 按 `Side: ` 前缀过滤保持拓扑零噪音），`origin:'subagent'` 隐藏于主列表；生命周期走自有 `/sidebar/api/sidechat.*` 路由（`ctx.agents.create/resume` + `agent.followup/cancel` + `sidechat.info` 读 Agent 身份/状态）；头部菜单可切换/重开既有线程（`parkSidechatReopen` + `sidechat:<threadId>` 确定性 id），关闭 Tab 释放 live agent（历史保留）；重开 Tab 经 `collectOwnEvents` 大页回源到种子边界（cold 读会展开 chunk 压缩行，小窗口会丢早期 tool/call 行）；「保存为新会话」= `session.fork` 提升顶层会话（必须方法调用形态，`this` 敏感）。UI 对齐主对话区（用户气泡 `--dsw-specific-bubble`、assistant 通栏 markdown、胶囊 composer + 圆形发送/停止钮、运行扫光状态行）。见 [设计文档](docs/plans/2026-08-20-sidechat-tab-design.md) |
+| `changes` | 36 | 是 | 否 | 本轮变更：按轮次列出会话中模型写/改过的文件（每轮一行：轮次标题 + 文件 chips，点击在侧边栏编辑器打开；读取/删除/失败不计入，与 ui-deliverables 产出契约一致）。数据来自通用 `sessions.history` RPC，`collectTurnChanges` 把每个 `turn/start`→`turn/end` 内 `tool/result` 关联的 mutation view `locations` 折叠为 `{turn, paths}`；可见时 2s 轮询尾页合并，首次拉 6×200 事件回溯 |
 | `terminal` | 40 | 否 | 否 | 终端（nextTerminal 自增） |
 | `browser` | 50 | 否（createTab 铸造 browser:`<n>`，nextBrowser 自增） | 否 | 内嵌网页浏览器（沙箱 iframe；可设置关闭沙箱） |
 | `diff` | -1 | 否（按 id 去重） | 是 | 差异查看（由 GitView 触发） |

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -43,8 +43,9 @@ const CHANGES_MAX_TURNS = 40
 /** How many COMPLETED turns the first walk must already have before it stops
  *  paging into the deep past — the view is "recent changes", and each backward
  *  page is multi-hundred-KB, so walking further only to show older turns is not
- *  worth the payload. */
-const CHANGES_WALK_STOP_TURNS = 4
+ *  worth the payload. Counted as turns that ACTUALLY changed files (see the
+ *  walk loop), so a run of short no-op turns never starves the real ones. */
+const CHANGES_WALK_STOP_TURNS = 5
 /** How many file chips one turn row shows before collapsing into `+N`. */
 const CHANGES_CHIP_LIMIT = 8
 /** Hard cap on retained history events (memory bound): the merged cache never
@@ -353,11 +354,14 @@ export function ChangesView(props: {
           const value = response.result.value
           if (value.events.length === 0) break
           collected.push(...value.events)
-          // Early stop: once the accumulated window holds a healthy number of
-          // COMPLETED turns, the recent-changes view has what it needs — no
-          // need to keep walking into the deep past (each page is multi-hundred-KB).
-          const completed = collected.filter(e => e.event.type === 'turn/end').length
-          if (!value.hasMore || completed >= CHANGES_WALK_STOP_TURNS) break
+          // Early stop: keep walking until the accumulated window holds a
+          // healthy number of turns that ACTUALLY changed files. Counting raw
+          // completed turns is wrong — a session with many short no-op turns
+          // (e.g. terminal/pwsh calls) would trip the stop before the walk
+          // reaches the older turns that wrote files, and the tab would show
+          // "no changes" even though history has plenty.
+          const changedTurns = collectTurnChanges(collected).filter(row => row.paths.length > 0).length
+          if (!value.hasMore || changedTurns >= CHANGES_WALK_STOP_TURNS) break
           // `history` returns events in log order (oldest first); the window
           // is cut at `beforeSeq` (exclusive), so to page OLDER we continue
           // from the OLDEST seq this page returned.

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -11,11 +11,12 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSyncExternalStore } from 'react'
+import clsx from 'clsx'
 import { IconCodeOutline16, IconRefreshOutline14, StateDot } from '@deepseek-ai/dsh-client-ui-primitives'
-import { IconDiffOutline16 } from './icons.tsx'
 import type { Context, SidebarHistoryEntry } from '../context-types.ts'
 import { producedPaths } from './produced-files.ts'
 import { buildUnifiedDiff, type FileChangeText } from './diff.ts'
+import { DiffView } from './DiffView.tsx'
 import { t } from './locales.ts'
 import type { SessionScope } from './api.ts'
 import type { SidebarStore } from './state.ts'
@@ -174,61 +175,87 @@ export function collectTurnChanges(entries: readonly SidebarHistoryEntry[]): Tur
   return turns
 }
 
-/** The file chips of one turn row (open the change as a real per-turn diff). */
-function ChangeChips(props: {
-  paths: readonly string[]
-  changes: readonly FileChangeText[]
+/** One turn row: a clickable turn header (expand/collapse all files) with the
+ *  file chips ALWAYS shown below it; clicking a chip expands THAT file's real
+ *  per-turn diff inline (no git round-trip). */
+function TurnRow(props: {
+  row: TurnChange
+  expanded: ReadonlySet<string>
+  onToggleTurn: (row: TurnChange) => void
+  onToggleFile: (seq: number, path: string) => void
   ctx: Context
-  sessionId: string
 }): React.ReactNode {
-  const { paths, changes, ctx, sessionId } = props
-  const shown = paths.slice(0, CHANGES_CHIP_LIMIT)
-  const hidden = paths.length - shown.length
+  const { row, expanded, onToggleTurn, onToggleFile, ctx } = props
+  const keyOf = (path: string): string => `${row.seq}:${path}`
+  const allOn = row.paths.length > 0 && row.paths.every(path => expanded.has(keyOf(path)))
   const changeFor = (path: string): FileChangeText | undefined => {
     const norm = (p: string): string => p.replace(/\\/g, '/')
-    return changes.find(c => norm(c.path) === norm(path))
+    return row.changes.find(c => norm(c.path) === norm(path))
   }
+  const shown = row.paths.slice(0, CHANGES_CHIP_LIMIT)
+  const hidden = row.paths.length - shown.length
   return (
-    <div className={css.producedRow}>
-      {shown.map(path => {
-        const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
-        const name = at === -1 ? path : path.slice(at + 1)
-        return (
-          <button
-            key={path}
-            type="button"
-            className={css.producedChip}
-            title={path}
-            onClick={() => {
-              const change = changeFor(path)
-              // Prefer the real per-turn before/after (the result view's hunks)
-              // so the diff shows exactly what THIS turn changed — no git
-              // round-trip, and it works for untracked new files too. Fall back
-              // to a worktree git diff when the log didn't carry a diff view.
-              if (change !== undefined) {
-                const unified = buildUnifiedDiff([change])
-                ctx.betterSidebar?.openTab({
-                  type: 'diff',
-                  id: `diff:turn:${path}`,
-                  title: name,
-                  diff: unified === '' ? { kind: 'custom', diff: '' } : { kind: 'custom', diff: unified },
-                })
-              } else {
-                ctx.betterSidebar?.openTab({
-                  type: 'diff',
-                  id: `diff:w:u:${path}`,
-                  title: name,
-                  diff: { kind: 'worktree', path, staged: false, untracked: true },
-                })
-              }
-            }}
-          >
-            <IconCodeOutline16 size={12} />
-            <span>{name}</span>
-          </button>
-        )
-      })}
-      {hidden > 0 && <span className={css.producedMore}>+{hidden}</span>}
+    <div className={subagentCss.subagentRow} style={{ cursor: 'default' }}>
+      <StateDot state="done" className={subagentCss.subagentDot} />
+      <div className={subagentCss.subagentContent}>
+        <button
+          type="button"
+          className={css.changesTurnHeader}
+          aria-expanded={allOn}
+          onClick={() => { onToggleTurn(row) }}
+        >
+          <span aria-hidden="true" className={clsx(css.changesTurnChevron, allOn && css.changesTurnChevronExpanded)}>›</span>
+          <span className={css.changesTurnLabel}>
+            {t('changesTurn', { turn: row.turn })} · {t('changesFiles', { count: row.paths.length })}
+          </span>
+        </button>
+        <div className={css.producedRow}>
+          {shown.map(path => {
+            const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+            const name = at === -1 ? path : path.slice(at + 1)
+            const open = expanded.has(keyOf(path))
+            const change = changeFor(path)
+            return (
+              <button
+                key={path}
+                type="button"
+                className={clsx(css.producedChip, open && css.producedChipActive)}
+                title={path}
+                aria-expanded={open}
+                onClick={() => {
+                  // A captured per-turn change expands inline; a path without
+                  // one (edge case) still opens the worktree git diff tab.
+                  if (change !== undefined) {
+                    onToggleFile(row.seq, path)
+                  } else {
+                    ctx.betterSidebar?.openTab({
+                      type: 'diff',
+                      id: `diff:w:u:${path}`,
+                      title: name,
+                      diff: { kind: 'worktree', path, staged: false, untracked: true },
+                    })
+                  }
+                }}
+              >
+                <IconCodeOutline16 size={12} />
+                <span>{name}</span>
+              </button>
+            )
+          })}
+          {hidden > 0 && <span className={css.producedMore}>+{hidden}</span>}
+        </div>
+        {shown.filter(path => expanded.has(keyOf(path))).map(path => {
+          const change = changeFor(path)
+          if (change === undefined) return null
+          const unified = buildUnifiedDiff([change])
+          if (unified === '') return null
+          return (
+            <div key={keyOf(path)} className={css.changesInlineDiff}>
+              <DiffView diff={unified} defaultExpanded />
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -249,8 +276,34 @@ export function ChangesView(props: {
   )
   const [revision, setRevision] = useState(0)
   const [lastError, setLastError] = useState<string | null>(null)
+  /** Expanded per-file inline diffs: keys are `${seq}:${path}` (one turn can
+   *  touch the same file more than once — the seq anchor keeps them apart). */
+  const [expandedFiles, setExpandedFiles] = useState<ReadonlySet<string>>(new Set())
   const cacheRef = useRef<{ entries: SidebarHistoryEntry[] }>({ entries: [] })
   const controllerRef = useRef<AbortController | null>(null)
+
+  const toggleFile = useCallback((seq: number, path: string): void => {
+    setExpandedFiles(current => {
+      const key = `${seq}:${path}`
+      const next = new Set(current)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+
+  const toggleTurn = useCallback((row: TurnChange): void => {
+    setExpandedFiles(current => {
+      const next = new Set(current)
+      const allOn = row.paths.length > 0 && row.paths.every(path => next.has(`${row.seq}:${path}`))
+      for (const path of row.paths) {
+        const key = `${row.seq}:${path}`
+        if (allOn) next.delete(key)
+        else next.add(key)
+      }
+      return next
+    })
+  }, [])
 
   const fetchChanges = useCallback(async () => {
     controllerRef.current?.abort()
@@ -359,15 +412,14 @@ export function ChangesView(props: {
             <span className={subagentCss.subagentEmptyHint}>session={sessionId} entries={cacheRef.current.entries.length}</span>
           </div>
         ) : turns.map(row => (
-          <div key={row.seq} className={subagentCss.subagentRow} style={{ cursor: 'default' }}>
-            <StateDot state="done" className={subagentCss.subagentDot} />
-            <div className={subagentCss.subagentContent}>
-              <span className={subagentCss.subagentLabel}>
-                {t('changesTurn', { turn: row.turn })} · {t('changesFiles', { count: row.paths.length })}
-              </span>
-              <ChangeChips paths={row.paths} changes={row.changes} ctx={ctx} sessionId={sessionId} />
-            </div>
-          </div>
+          <TurnRow
+            key={row.seq}
+            row={row}
+            expanded={expandedFiles}
+            onToggleTurn={toggleTurn}
+            onToggleFile={toggleFile}
+            ctx={ctx}
+          />
         ))}
       </div>
     </div>

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -24,27 +24,40 @@ import css from './sidebar.module.css'
 import subagentCss from './SubagentView.module.css'
 
 /** First-attach page size (messages). `maxMessages` counts MESSAGES and a
- *  single message can expand to hundreds of chunk/tool events — a 200-message
- *  page returned ~75k events / ~16 MB, which stalled the browser. 40 messages
- *  (~3 MB) covers ~2 completed turns and keeps the first paint responsive;
- *  the walk pages backward until it has enough turns or hits the cap. */
-const CHANGES_PAGE_EVENTS = 40
+ *  single message can expand to hundreds of chunk/tool events — a 40-message
+ *  page on a session with a large streaming tail returned 16k–44k events /
+ *  4–7 MB per page, which stalled the browser and the walk never completed.
+ *  16 messages keeps each fetch bounded (~1.5–6 MB); the walk pages backward
+ *  until it has enough completed turns. */
+const CHANGES_PAGE_EVENTS = 16
 /** Poll page size (messages): the incremental tail fetch only needs the NEWEST
  *  events, so a small page keeps the 2s poll light. */
 const CHANGES_POLL_EVENTS = 8
 /** First-attach walk cap: how many backward pages the initial load fetches
  *  before it must already have found the recent turns. */
-const CHANGES_WALK_CAP = 6
+const CHANGES_WALK_CAP = 20
 /** Poll cadence while the tab is visible. */
 const CHANGES_POLL_MS = 2000
 /** How many turn rows to keep at most (newest first). */
-const CHANGES_MAX_TURNS = 60
+const CHANGES_MAX_TURNS = 40
+/** How many COMPLETED turns the first walk must already have before it stops
+ *  paging into the deep past — the view is "recent changes", and each backward
+ *  page is multi-hundred-KB, so walking further only to show older turns is not
+ *  worth the payload. */
+const CHANGES_WALK_STOP_TURNS = 4
 /** How many file chips one turn row shows before collapsing into `+N`. */
 const CHANGES_CHIP_LIMIT = 8
 /** Hard cap on retained history events (memory bound): the merged cache never
- *  grows unbounded across many polls — only the newest tail is kept, which is
- *  all the recent-turns view needs. */
+ *  grows unbounded across many polls. The Changes fold only needs the
+ *  STRUCTURAL events (turn markers, tool calls/results, messages) — streaming
+ *  chunk events (`assistant/chunk`, `*-chunks`) are dropped at merge time, so
+ *  a session whose tail has tens of thousands of deltas stays light. */
 const CHANGES_MAX_EVENTS = 30000
+
+/** Whether an event type is a streaming-delta row the Changes fold never reads
+ *  (the fold keys on turn markers + tool call/result + produced paths; chunk
+ *  deltas are pure bulk). Dropping them keeps the merged cache tiny. */
+const CHANGES_DROP_TYPES = new Set(['assistant/chunk', 'reasoning-chunks', 'tool-call-chunks', 'text-chunks'])
 
 /** One completed turn that produced files. */
 interface TurnChange {
@@ -67,7 +80,10 @@ function mergeBySeq(
   for (const entry of previous) bySeq.set(entry.event.seq, entry)
   for (const entry of incoming) bySeq.set(entry.event.seq, entry)
   const sorted = [...bySeq.values()].sort((a, b) => a.event.seq - b.event.seq)
-  return sorted.length > CHANGES_MAX_EVENTS ? sorted.slice(sorted.length - CHANGES_MAX_EVENTS) : sorted
+  // Drop streaming-delta rows (see {@link CHANGES_DROP_TYPES}) so the cache
+  // holds only the structural events the fold reads.
+  const structural = sorted.filter(entry => !CHANGES_DROP_TYPES.has(entry.event.type))
+  return structural.length > CHANGES_MAX_EVENTS ? structural.slice(structural.length - CHANGES_MAX_EVENTS) : structural
 }
 
 /**
@@ -281,6 +297,11 @@ export function ChangesView(props: {
   const [expandedFiles, setExpandedFiles] = useState<ReadonlySet<string>>(new Set())
   const cacheRef = useRef<{ entries: SidebarHistoryEntry[] }>({ entries: [] })
   const controllerRef = useRef<AbortController | null>(null)
+  /** A full (non-poll) history walk is in flight. The 2s poll must NOT abort
+   *  it — a walk over a large session takes many seconds (each page is multi-
+   *  hundred-KB and the tail can be tens of thousands of events), and aborting
+   *  it every 2s would starve the first load into the empty state forever. */
+  const walkingRef = useRef(false)
 
   const toggleFile = useCallback((seq: number, path: string): void => {
     setExpandedFiles(current => {
@@ -306,13 +327,20 @@ export function ChangesView(props: {
   }, [])
 
   const fetchChanges = useCallback(async () => {
+    const cache = cacheRef.current
+    // A poll while a first-attach walk is still running must not abort it:
+    // skip this tick — the in-flight walk will land its result and the next
+    // poll picks up the tail. (The controller is only aborted on session
+    // switch / unmount.)
+    if (walkingRef.current) return
     controllerRef.current?.abort()
     const controller = new AbortController()
     controllerRef.current = controller
-    const cache = cacheRef.current
+    const isWalk = cache.entries.length === 0
+    if (isWalk) walkingRef.current = true
     try {
       let merged = cache.entries
-      if (merged.length === 0) {
+      if (isWalk) {
         const collected: SidebarHistoryEntry[] = []
         let beforeSeq: number | undefined
         for (let page = 0; page < CHANGES_WALK_CAP; page++) {
@@ -327,9 +355,9 @@ export function ChangesView(props: {
           collected.push(...value.events)
           // Early stop: once the accumulated window holds a healthy number of
           // COMPLETED turns, the recent-changes view has what it needs — no
-          // need to keep walking into the deep past (each page is multi-MB).
+          // need to keep walking into the deep past (each page is multi-hundred-KB).
           const completed = collected.filter(e => e.event.type === 'turn/end').length
-          if (!value.hasMore || completed >= CHANGES_MAX_TURNS) break
+          if (!value.hasMore || completed >= CHANGES_WALK_STOP_TURNS) break
           // `history` returns events in log order (oldest first); the window
           // is cut at `beforeSeq` (exclusive), so to page OLDER we continue
           // from the OLDEST seq this page returned.
@@ -354,11 +382,14 @@ export function ChangesView(props: {
       if (!(error instanceof DOMException && error.name === 'AbortError')) {
         setLastError(error instanceof Error ? error.message : String(error))
       }
+    } finally {
+      if (isWalk) walkingRef.current = false
     }
   }, [ctx, sessionId])
 
   useEffect(() => {
     cacheRef.current = { entries: [] }
+    walkingRef.current = false
     controllerRef.current?.abort()
     setRevision(0)
   }, [sessionId])

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -7,14 +7,13 @@
  * `producedPaths` mutation-intent derivation (a `diff` card or a generic
  * `edit` card carries `locations`; reads, deletes and failed calls
  * contribute nothing, matching the ui-deliverables contract). One row per
- * turn that changed files; the chips open the path in the sidebar editor.
+ * turn that changed files; the chips open the change as a git-style diff tab.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSyncExternalStore } from 'react'
 import { IconCodeOutline16, IconRefreshOutline14, StateDot } from '@deepseek-ai/dsh-client-ui-primitives'
 import { IconDiffOutline16 } from './icons.tsx'
 import type { Context, SidebarHistoryEntry } from '../context-types.ts'
-import { openSidebarFile } from './intercept.tsx'
 import { producedPaths } from './produced-files.ts'
 import { t } from './locales.ts'
 import type { SessionScope } from './api.ts'
@@ -122,14 +121,13 @@ export function collectTurnChanges(entries: readonly SidebarHistoryEntry[]): Tur
   return turns
 }
 
-/** The file chips of one turn row (opened in the sidebar editor). */
+/** The file chips of one turn row (open the change as a diff tab). */
 function ChangeChips(props: {
   paths: readonly string[]
   ctx: Context
-  store: SidebarStore
   sessionId: string
 }): React.ReactNode {
-  const { paths, ctx, store, sessionId } = props
+  const { paths, ctx, sessionId } = props
   const shown = paths.slice(0, CHANGES_CHIP_LIMIT)
   const hidden = paths.length - shown.length
   return (
@@ -143,7 +141,17 @@ function ChangeChips(props: {
             type="button"
             className={css.producedChip}
             title={path}
-            onClick={() => { openSidebarFile(ctx, store, sessionId, path) }}
+            onClick={() => {
+              // Open the change as a git-style diff tab: tracked files show
+              // `git diff` of the worktree vs HEAD; untracked files (newly
+              // created, like a fresh test.md) render as a full-file addition.
+              ctx.betterSidebar?.openTab({
+                type: 'diff',
+                id: `diff:w:u:${path}`,
+                title: name,
+                diff: { kind: 'worktree', path, staged: false, untracked: true },
+              })
+            }}
           >
             <IconCodeOutline16 size={12} />
             <span>{name}</span>
@@ -162,7 +170,7 @@ export function ChangesView(props: {
   scope: SessionScope
   visible: boolean
 }): React.ReactNode {
-  const { ctx, store, scope, visible } = props
+  const { ctx, scope, visible } = props
   const sessionId = scope.sessionId
   const sessions = ctx.sessions
   const list = useSyncExternalStore(
@@ -170,6 +178,7 @@ export function ChangesView(props: {
     useCallback(() => sessions.list.getSnapshot(), [sessions]),
   )
   const [revision, setRevision] = useState(0)
+  const [lastError, setLastError] = useState<string | null>(null)
   const cacheRef = useRef<{ entries: SidebarHistoryEntry[] }>({ entries: [] })
   const controllerRef = useRef<AbortController | null>(null)
 
@@ -189,14 +198,17 @@ export function ChangesView(props: {
             maxMessages: CHANGES_PAGE_EVENTS,
             ...(beforeSeq === undefined ? {} : { beforeSeq }),
           }, controller.signal)
-          if (!response.result.ok) throw new Error('history walk failed')
+          if (!response.result.ok) throw new Error(`history failed: ${response.result.error.code} ${response.result.error.message}`)
           const value = response.result.value
           if (value.events.length === 0) break
           collected.push(...value.events)
           if (!value.hasMore) break
-          const last = value.events[value.events.length - 1]
-          if (last === undefined) break
-          beforeSeq = last.event.seq
+          // `history` returns events in log order (oldest first); the window
+          // is cut at `beforeSeq` (exclusive), so to page OLDER we continue
+          // from the OLDEST seq this page returned.
+          const oldest = value.events[0]
+          if (oldest === undefined) break
+          beforeSeq = oldest.event.seq
         }
         merged = mergeBySeq([], collected)
       } else {
@@ -207,10 +219,14 @@ export function ChangesView(props: {
         if (response.result.ok) merged = mergeBySeq(cache.entries, response.result.value.events)
       }
       cache.entries = merged
+      setLastError(null)
       setRevision(value => value + 1)
-    } catch {
-      // Poll errors are swallowed (the next tick retries); an aborted
-      // controller on teardown is expected and not an error.
+    } catch (error) {
+      // Keep the last error visible so a broken fetch is diagnosable instead
+      // of silently showing "no changes".
+      if (!(error instanceof DOMException && error.name === 'AbortError')) {
+        setLastError(error instanceof Error ? error.message : String(error))
+      }
     }
   }, [ctx, sessionId])
 
@@ -256,10 +272,17 @@ export function ChangesView(props: {
         </button>
       </div>
       <div className={subagentCss.subagentBody}>
-        {isEmpty ? (
+        {lastError !== null ? (
+          <div className={subagentCss.subagentEmpty} style={{ textAlign: 'left', whiteSpace: 'pre-wrap', color: 'var(--dsw-alias-label-danger, #f2a1a1)' }}>
+            <span>Changes fetch error</span>
+            <span className={subagentCss.subagentEmptyHint}>{lastError}</span>
+            <span className={subagentCss.subagentEmptyHint}>session={sessionId}</span>
+          </div>
+        ) : isEmpty ? (
           <div className={subagentCss.subagentEmpty}>
             <span>{t('changesEmpty')}</span>
             <span className={subagentCss.subagentEmptyHint}>{t('changesEmptyHint')}</span>
+            <span className={subagentCss.subagentEmptyHint}>session={sessionId} entries={cacheRef.current.entries.length}</span>
           </div>
         ) : turns.map(row => (
           <div key={row.seq} className={subagentCss.subagentRow} style={{ cursor: 'default' }}>
@@ -268,7 +291,7 @@ export function ChangesView(props: {
               <span className={subagentCss.subagentLabel}>
                 {t('changesTurn', { turn: row.turn })} · {t('changesFiles', { count: row.paths.length })}
               </span>
-              <ChangeChips paths={row.paths} ctx={ctx} store={store} sessionId={sessionId} />
+              <ChangeChips paths={row.paths} ctx={ctx} sessionId={sessionId} />
             </div>
           </div>
         ))}

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -1,0 +1,278 @@
+/**
+ * Per-turn file-change history for the current session.
+ *
+ * The view polls the generic `sessions.history` RPC (the same transport the
+ * Side Chat transcript uses), walks the append-only log, and folds the
+ * produced paths of each completed turn — reusing the plugin's own
+ * `producedPaths` mutation-intent derivation (a `diff` card or a generic
+ * `edit` card carries `locations`; reads, deletes and failed calls
+ * contribute nothing, matching the ui-deliverables contract). One row per
+ * turn that changed files; the chips open the path in the sidebar editor.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useSyncExternalStore } from 'react'
+import { IconCodeOutline16, IconRefreshOutline14, StateDot } from '@deepseek-ai/dsh-client-ui-primitives'
+import { IconDiffOutline16 } from './icons.tsx'
+import type { Context, SidebarHistoryEntry } from '../context-types.ts'
+import { openSidebarFile } from './intercept.tsx'
+import { producedPaths } from './produced-files.ts'
+import { t } from './locales.ts'
+import type { SessionScope } from './api.ts'
+import type { SidebarStore } from './state.ts'
+import css from './sidebar.module.css'
+import subagentCss from './SubagentView.module.css'
+
+/** Tail-page size for one change poll. Small on purpose: streaming polls
+ *  ride the tail and merge by seq, like Side Chat's transcript. */
+const CHANGES_PAGE_EVENTS = 200
+/** First-attach walk cap: how many backward pages the initial load fetches.
+ *  6 × 200 = 1200 events is ample for the recent-change history; older
+ *  turns simply fall off the view (the max-turns cap also bounds the list). */
+const CHANGES_WALK_CAP = 6
+/** Poll cadence while the tab is visible. */
+const CHANGES_POLL_MS = 2000
+/** How many turn rows to keep at most (newest first). */
+const CHANGES_MAX_TURNS = 60
+/** How many file chips one turn row shows before collapsing into `+N`. */
+const CHANGES_CHIP_LIMIT = 8
+
+/** One completed turn that produced files. */
+interface TurnChange {
+  turn: number
+  seq: number
+  time: number
+  paths: string[]
+}
+
+/** Merge history entries by event seq (newest wins), log order preserved. */
+function mergeBySeq(
+  previous: readonly SidebarHistoryEntry[],
+  incoming: readonly SidebarHistoryEntry[],
+): SidebarHistoryEntry[] {
+  const bySeq = new Map<number, SidebarHistoryEntry>()
+  for (const entry of previous) bySeq.set(entry.event.seq, entry)
+  for (const entry of incoming) bySeq.set(entry.event.seq, entry)
+  return [...bySeq.values()].sort((a, b) => a.event.seq - b.event.seq)
+}
+
+/**
+ * Fold one history log into per-turn produced paths. A `turn/start` begins a
+ * new accumulation and clears the call→view index (the upstream deliverables
+ * Definition keeps its own per-turn calls map, so a result only derives paths
+ * from calls observed within the same turn); `turn/end` seals the turn. Paths
+ * keep first-seen order and appear once per turn.
+ * @param entries - merged history rows (event + host-computed view) in seq order.
+ * @returns turns that produced files, oldest first.
+ */
+export function collectTurnChanges(entries: readonly SidebarHistoryEntry[]): TurnChange[] {
+  const turns: TurnChange[] = []
+  const callViews = new Map<string, unknown>()
+  let current: { turn: number; seq: number; time: number; paths: string[]; seen: Set<string> } | null = null
+  const flush = (): void => {
+    if (current !== null && current.paths.length > 0) {
+      turns.push({ turn: current.turn, seq: current.seq, time: current.time, paths: current.paths })
+    }
+    current = null
+  }
+  for (const entry of entries) {
+    const event = entry?.event
+    if (event === null || typeof event !== 'object') continue
+    const data = (event as { data?: Record<string, unknown> }).data ?? {}
+    if (event.type === 'turn/start') {
+      const turn = typeof data.turn === 'number' ? data.turn : NaN
+      if (current !== null && current.turn !== turn) flush()
+      callViews.clear()
+      current = { turn, seq: event.seq, time: event.time, paths: [], seen: new Set() }
+    } else if (event.type === 'turn/end') {
+      flush()
+    } else if (event.type === 'tool/call') {
+      const callId = typeof data.callId === 'string' ? data.callId : undefined
+      const view = entry.view
+      if (callId !== undefined) {
+        callViews.set(
+          callId,
+          view !== undefined && view !== null && (view as { for?: string }).for === 'call'
+            ? (view as { view?: unknown }).view
+            : null,
+        )
+      }
+    } else if (event.type === 'tool/result' && current !== null) {
+      const message = (data as { message?: { source?: unknown; content?: unknown } }).message
+      const source = message?.source
+      const callId = source !== null && typeof source === 'object'
+        && typeof (source as { callId?: unknown }).callId === 'string'
+        ? (source as { callId: string }).callId
+        : undefined
+      const content = message?.content
+      const isError = Array.isArray(content)
+        && content[0] !== null
+        && typeof content[0] === 'object'
+        && (content[0] as { isError?: unknown }).isError === true
+      if (isError || callId === undefined) continue
+      const view = callViews.get(callId)
+      if (view === undefined || view === null) continue
+      for (const path of producedPaths(view)) {
+        if (current.seen.has(path)) continue
+        current.seen.add(path)
+        current.paths.push(path)
+      }
+    }
+  }
+  flush()
+  return turns
+}
+
+/** The file chips of one turn row (opened in the sidebar editor). */
+function ChangeChips(props: {
+  paths: readonly string[]
+  ctx: Context
+  store: SidebarStore
+  sessionId: string
+}): React.ReactNode {
+  const { paths, ctx, store, sessionId } = props
+  const shown = paths.slice(0, CHANGES_CHIP_LIMIT)
+  const hidden = paths.length - shown.length
+  return (
+    <div className={css.producedRow}>
+      {shown.map(path => {
+        const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+        const name = at === -1 ? path : path.slice(at + 1)
+        return (
+          <button
+            key={path}
+            type="button"
+            className={css.producedChip}
+            title={path}
+            onClick={() => { openSidebarFile(ctx, store, sessionId, path) }}
+          >
+            <IconCodeOutline16 size={12} />
+            <span>{name}</span>
+          </button>
+        )
+      })}
+      {hidden > 0 && <span className={css.producedMore}>+{hidden}</span>}
+    </div>
+  )
+}
+
+/** The per-turn file-change history page (one row per changed turn). */
+export function ChangesView(props: {
+  ctx: Context
+  store: SidebarStore
+  scope: SessionScope
+  visible: boolean
+}): React.ReactNode {
+  const { ctx, store, scope, visible } = props
+  const sessionId = scope.sessionId
+  const sessions = ctx.sessions
+  const list = useSyncExternalStore(
+    useMemo(() => (callback: () => void) => sessions.list.subscribe(callback), [sessions]),
+    useCallback(() => sessions.list.getSnapshot(), [sessions]),
+  )
+  const [revision, setRevision] = useState(0)
+  const cacheRef = useRef<{ entries: SidebarHistoryEntry[] }>({ entries: [] })
+  const controllerRef = useRef<AbortController | null>(null)
+
+  const fetchChanges = useCallback(async () => {
+    controllerRef.current?.abort()
+    const controller = new AbortController()
+    controllerRef.current = controller
+    const cache = cacheRef.current
+    try {
+      let merged = cache.entries
+      if (merged.length === 0) {
+        const collected: SidebarHistoryEntry[] = []
+        let beforeSeq: number | undefined
+        for (let page = 0; page < CHANGES_WALK_CAP; page++) {
+          const response = await ctx.connection.api.sessions.history({
+            sessionId,
+            maxMessages: CHANGES_PAGE_EVENTS,
+            ...(beforeSeq === undefined ? {} : { beforeSeq }),
+          }, controller.signal)
+          if (!response.result.ok) throw new Error('history walk failed')
+          const value = response.result.value
+          if (value.events.length === 0) break
+          collected.push(...value.events)
+          if (!value.hasMore) break
+          const last = value.events[value.events.length - 1]
+          if (last === undefined) break
+          beforeSeq = last.event.seq
+        }
+        merged = mergeBySeq([], collected)
+      } else {
+        const response = await ctx.connection.api.sessions.history({
+          sessionId,
+          maxMessages: CHANGES_PAGE_EVENTS,
+        }, controller.signal)
+        if (response.result.ok) merged = mergeBySeq(cache.entries, response.result.value.events)
+      }
+      cache.entries = merged
+      setRevision(value => value + 1)
+    } catch {
+      // Poll errors are swallowed (the next tick retries); an aborted
+      // controller on teardown is expected and not an error.
+    }
+  }, [ctx, sessionId])
+
+  useEffect(() => {
+    cacheRef.current = { entries: [] }
+    controllerRef.current?.abort()
+    setRevision(0)
+  }, [sessionId])
+
+  useEffect(() => {
+    if (!visible) return
+    void fetchChanges()
+    const timer = window.setInterval(() => { void fetchChanges() }, CHANGES_POLL_MS)
+    return () => {
+      window.clearInterval(timer)
+    }
+  }, [visible, sessionId, fetchChanges])
+
+  useEffect(() => () => {
+    controllerRef.current?.abort()
+  }, [])
+
+  const turns = useMemo(
+    () => collectTurnChanges(cacheRef.current.entries).reverse().slice(0, CHANGES_MAX_TURNS),
+    [revision], // eslint-disable-line react-hooks/exhaustive-deps -- cacheRef is intentionally a live mutable store
+  )
+  const totalFiles = useMemo(() => turns.reduce((acc, row) => acc + row.paths.length, 0), [turns])
+  const isEmpty = turns.length === 0
+
+  return (
+    <div className={subagentCss.subagent}>
+      <div className={subagentCss.subagentHeader}>
+        <span className={subagentCss.subagentTitle}>{t('changes')}</span>
+        {!isEmpty && <span className={subagentCss.subagentCount}>{t('changesFiles', { count: totalFiles })}</span>}
+        <button
+          type="button"
+          className={subagentCss.subagentRefresh}
+          aria-label={t('changesRefresh')}
+          title={t('changesRefresh')}
+          onClick={() => { void fetchChanges() }}
+        >
+          <IconRefreshOutline14 />
+        </button>
+      </div>
+      <div className={subagentCss.subagentBody}>
+        {isEmpty ? (
+          <div className={subagentCss.subagentEmpty}>
+            <span>{t('changesEmpty')}</span>
+            <span className={subagentCss.subagentEmptyHint}>{t('changesEmptyHint')}</span>
+          </div>
+        ) : turns.map(row => (
+          <div key={row.seq} className={subagentCss.subagentRow} style={{ cursor: 'default' }}>
+            <StateDot state="done" className={subagentCss.subagentDot} />
+            <div className={subagentCss.subagentContent}>
+              <span className={subagentCss.subagentLabel}>
+                {t('changesTurn', { turn: row.turn })} · {t('changesFiles', { count: row.paths.length })}
+              </span>
+              <ChangeChips paths={row.paths} ctx={ctx} store={store} sessionId={sessionId} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -216,7 +216,7 @@ function TurnRow(props: {
       <div className={subagentCss.subagentContent}>
         <button
           type="button"
-          className={css.changesTurnHeader}
+          className={clsx(css.changesTurnHeader, allOn && css.changesTurnHeaderActive)}
           aria-expanded={allOn}
           onClick={() => { onToggleTurn(row) }}
         >

--- a/src/client/ChangesView.tsx
+++ b/src/client/ChangesView.tsx
@@ -15,18 +15,24 @@ import { IconCodeOutline16, IconRefreshOutline14, StateDot } from '@deepseek-ai/
 import { IconDiffOutline16 } from './icons.tsx'
 import type { Context, SidebarHistoryEntry } from '../context-types.ts'
 import { producedPaths } from './produced-files.ts'
+import { buildUnifiedDiff, type FileChangeText } from './diff.ts'
 import { t } from './locales.ts'
 import type { SessionScope } from './api.ts'
 import type { SidebarStore } from './state.ts'
 import css from './sidebar.module.css'
 import subagentCss from './SubagentView.module.css'
 
-/** Tail-page size for one change poll. Small on purpose: streaming polls
- *  ride the tail and merge by seq, like Side Chat's transcript. */
-const CHANGES_PAGE_EVENTS = 200
-/** First-attach walk cap: how many backward pages the initial load fetches.
- *  6 × 200 = 1200 events is ample for the recent-change history; older
- *  turns simply fall off the view (the max-turns cap also bounds the list). */
+/** First-attach page size (messages). `maxMessages` counts MESSAGES and a
+ *  single message can expand to hundreds of chunk/tool events — a 200-message
+ *  page returned ~75k events / ~16 MB, which stalled the browser. 40 messages
+ *  (~3 MB) covers ~2 completed turns and keeps the first paint responsive;
+ *  the walk pages backward until it has enough turns or hits the cap. */
+const CHANGES_PAGE_EVENTS = 40
+/** Poll page size (messages): the incremental tail fetch only needs the NEWEST
+ *  events, so a small page keeps the 2s poll light. */
+const CHANGES_POLL_EVENTS = 8
+/** First-attach walk cap: how many backward pages the initial load fetches
+ *  before it must already have found the recent turns. */
 const CHANGES_WALK_CAP = 6
 /** Poll cadence while the tab is visible. */
 const CHANGES_POLL_MS = 2000
@@ -34,6 +40,10 @@ const CHANGES_POLL_MS = 2000
 const CHANGES_MAX_TURNS = 60
 /** How many file chips one turn row shows before collapsing into `+N`. */
 const CHANGES_CHIP_LIMIT = 8
+/** Hard cap on retained history events (memory bound): the merged cache never
+ *  grows unbounded across many polls — only the newest tail is kept, which is
+ *  all the recent-turns view needs. */
+const CHANGES_MAX_EVENTS = 30000
 
 /** One completed turn that produced files. */
 interface TurnChange {
@@ -41,9 +51,13 @@ interface TurnChange {
   seq: number
   time: number
   paths: string[]
+  /** Per-file before/after text for that turn (last mutation wins per file). */
+  changes: FileChangeText[]
 }
 
-/** Merge history entries by event seq (newest wins), log order preserved. */
+/** Merge history entries by event seq (newest wins), log order preserved.
+ *  Keeps only the NEWEST {@link CHANGES_MAX_EVENTS} events so the cache stays
+ *  bounded no matter how long the session runs. */
 function mergeBySeq(
   previous: readonly SidebarHistoryEntry[],
   incoming: readonly SidebarHistoryEntry[],
@@ -51,7 +65,34 @@ function mergeBySeq(
   const bySeq = new Map<number, SidebarHistoryEntry>()
   for (const entry of previous) bySeq.set(entry.event.seq, entry)
   for (const entry of incoming) bySeq.set(entry.event.seq, entry)
-  return [...bySeq.values()].sort((a, b) => a.event.seq - b.event.seq)
+  const sorted = [...bySeq.values()].sort((a, b) => a.event.seq - b.event.seq)
+  return sorted.length > CHANGES_MAX_EVENTS ? sorted.slice(sorted.length - CHANGES_MAX_EVENTS) : sorted
+}
+
+/**
+ * Extract the per-file before/after text from a tool/result view. Mutation
+ * tools (`write` / `edit`) return a `card: 'diff'` result view whose `diffs`
+ * carry the applied change as `{ path, oldText, newText }` (full-file hunks
+ * for `edit` via `computeHunkDiffs`, the whole content for `write`).
+ * @param view - the `entry.view` of a `tool/result` event.
+ * @returns file changes, or an empty array when the view is not a diff card.
+ */
+function diffChangesFromResultView(view: unknown): FileChangeText[] {
+  if (view === null || typeof view !== 'object') return []
+  const record = view as { for?: unknown; view?: unknown }
+  if (record.for !== 'result') return []
+  const inner = record.view as { card?: unknown; diffs?: unknown } | null
+  if (inner === null || typeof inner !== 'object') return []
+  if (inner.card !== 'diff') return []
+  if (!Array.isArray(inner.diffs)) return []
+  const changes: FileChangeText[] = []
+  for (const item of inner.diffs) {
+    if (item === null || typeof item !== 'object') continue
+    const d = item as { path?: unknown; oldText?: unknown; newText?: unknown }
+    if (typeof d.path !== 'string' || typeof d.newText !== 'string') continue
+    changes.push({ path: d.path, oldText: d.oldText === null ? null : typeof d.oldText === 'string' ? d.oldText : null, newText: d.newText })
+  }
+  return changes
 }
 
 /**
@@ -59,17 +100,24 @@ function mergeBySeq(
  * new accumulation and clears the call→view index (the upstream deliverables
  * Definition keeps its own per-turn calls map, so a result only derives paths
  * from calls observed within the same turn); `turn/end` seals the turn. Paths
- * keep first-seen order and appear once per turn.
+ * keep first-seen order and appear once per turn; per-file before/after text
+ * (from the result view's `diffs`) lets the click render a REAL per-turn diff.
  * @param entries - merged history rows (event + host-computed view) in seq order.
  * @returns turns that produced files, oldest first.
  */
 export function collectTurnChanges(entries: readonly SidebarHistoryEntry[]): TurnChange[] {
   const turns: TurnChange[] = []
   const callViews = new Map<string, unknown>()
-  let current: { turn: number; seq: number; time: number; paths: string[]; seen: Set<string> } | null = null
+  let current: { turn: number; seq: number; time: number; paths: string[]; seen: Set<string>; changes: Map<string, FileChangeText> } | null = null
   const flush = (): void => {
     if (current !== null && current.paths.length > 0) {
-      turns.push({ turn: current.turn, seq: current.seq, time: current.time, paths: current.paths })
+      turns.push({
+        turn: current.turn,
+        seq: current.seq,
+        time: current.time,
+        paths: current.paths,
+        changes: [...current.changes.values()],
+      })
     }
     current = null
   }
@@ -81,7 +129,7 @@ export function collectTurnChanges(entries: readonly SidebarHistoryEntry[]): Tur
       const turn = typeof data.turn === 'number' ? data.turn : NaN
       if (current !== null && current.turn !== turn) flush()
       callViews.clear()
-      current = { turn, seq: event.seq, time: event.time, paths: [], seen: new Set() }
+      current = { turn, seq: event.seq, time: event.time, paths: [], seen: new Set(), changes: new Map() }
     } else if (event.type === 'turn/end') {
       flush()
     } else if (event.type === 'tool/call') {
@@ -115,21 +163,31 @@ export function collectTurnChanges(entries: readonly SidebarHistoryEntry[]): Tur
         current.seen.add(path)
         current.paths.push(path)
       }
+      // Capture the per-file before/after from the result view (last write
+      // wins: a file edited several times in one turn shows its final delta).
+      for (const change of diffChangesFromResultView(entry.view)) {
+        current.changes.set(change.path, change)
+      }
     }
   }
   flush()
   return turns
 }
 
-/** The file chips of one turn row (open the change as a diff tab). */
+/** The file chips of one turn row (open the change as a real per-turn diff). */
 function ChangeChips(props: {
   paths: readonly string[]
+  changes: readonly FileChangeText[]
   ctx: Context
   sessionId: string
 }): React.ReactNode {
-  const { paths, ctx, sessionId } = props
+  const { paths, changes, ctx, sessionId } = props
   const shown = paths.slice(0, CHANGES_CHIP_LIMIT)
   const hidden = paths.length - shown.length
+  const changeFor = (path: string): FileChangeText | undefined => {
+    const norm = (p: string): string => p.replace(/\\/g, '/')
+    return changes.find(c => norm(c.path) === norm(path))
+  }
   return (
     <div className={css.producedRow}>
       {shown.map(path => {
@@ -142,15 +200,27 @@ function ChangeChips(props: {
             className={css.producedChip}
             title={path}
             onClick={() => {
-              // Open the change as a git-style diff tab: tracked files show
-              // `git diff` of the worktree vs HEAD; untracked files (newly
-              // created, like a fresh test.md) render as a full-file addition.
-              ctx.betterSidebar?.openTab({
-                type: 'diff',
-                id: `diff:w:u:${path}`,
-                title: name,
-                diff: { kind: 'worktree', path, staged: false, untracked: true },
-              })
+              const change = changeFor(path)
+              // Prefer the real per-turn before/after (the result view's hunks)
+              // so the diff shows exactly what THIS turn changed — no git
+              // round-trip, and it works for untracked new files too. Fall back
+              // to a worktree git diff when the log didn't carry a diff view.
+              if (change !== undefined) {
+                const unified = buildUnifiedDiff([change])
+                ctx.betterSidebar?.openTab({
+                  type: 'diff',
+                  id: `diff:turn:${path}`,
+                  title: name,
+                  diff: unified === '' ? { kind: 'custom', diff: '' } : { kind: 'custom', diff: unified },
+                })
+              } else {
+                ctx.betterSidebar?.openTab({
+                  type: 'diff',
+                  id: `diff:w:u:${path}`,
+                  title: name,
+                  diff: { kind: 'worktree', path, staged: false, untracked: true },
+                })
+              }
             }}
           >
             <IconCodeOutline16 size={12} />
@@ -202,7 +272,11 @@ export function ChangesView(props: {
           const value = response.result.value
           if (value.events.length === 0) break
           collected.push(...value.events)
-          if (!value.hasMore) break
+          // Early stop: once the accumulated window holds a healthy number of
+          // COMPLETED turns, the recent-changes view has what it needs — no
+          // need to keep walking into the deep past (each page is multi-MB).
+          const completed = collected.filter(e => e.event.type === 'turn/end').length
+          if (!value.hasMore || completed >= CHANGES_MAX_TURNS) break
           // `history` returns events in log order (oldest first); the window
           // is cut at `beforeSeq` (exclusive), so to page OLDER we continue
           // from the OLDEST seq this page returned.
@@ -214,7 +288,7 @@ export function ChangesView(props: {
       } else {
         const response = await ctx.connection.api.sessions.history({
           sessionId,
-          maxMessages: CHANGES_PAGE_EVENTS,
+          maxMessages: CHANGES_POLL_EVENTS,
         }, controller.signal)
         if (response.result.ok) merged = mergeBySeq(cache.entries, response.result.value.events)
       }
@@ -291,7 +365,7 @@ export function ChangesView(props: {
               <span className={subagentCss.subagentLabel}>
                 {t('changesTurn', { turn: row.turn })} · {t('changesFiles', { count: row.paths.length })}
               </span>
-              <ChangeChips paths={row.paths} ctx={ctx} sessionId={sessionId} />
+              <ChangeChips paths={row.paths} changes={row.changes} ctx={ctx} sessionId={sessionId} />
             </div>
           </div>
         ))}

--- a/src/client/DiffTab.tsx
+++ b/src/client/DiffTab.tsx
@@ -22,6 +22,13 @@ interface DiffData {
   untracked?: string
 }
 
+/** The header title for a diff ref (custom diffs have no path/hash of their own). */
+function diffTitle(diff: SidebarDiffRef): string {
+  if (diff.kind === 'worktree') return diff.path
+  if (diff.kind === 'commit') return `${diff.hash} ${diff.subject}`
+  return 'Diff'
+}
+
 export function DiffTab(props: { sessionId: string; cwd: string | undefined; diff: SidebarDiffRef }) {
   const { sessionId, cwd, diff } = props
   const [loading, setLoading] = useState(true)
@@ -39,6 +46,12 @@ export function DiffTab(props: { sessionId: string; cwd: string | undefined; dif
     setData(null)
     const load = async (): Promise<void> => {
       try {
+        if (diff.kind === 'custom') {
+          // A pre-built per-turn unified diff (from the session log's mutation
+          // views) renders directly — no git round-trip needed.
+          if (!cancelled) setData({ diff: diff.diff })
+          return
+        }
         if (diff.kind === 'commit') {
           const result = await api.gitCommitDiff(scope, diff.hashFull)
           if (!cancelled) setData({ diff: result.diff })
@@ -80,8 +93,8 @@ export function DiffTab(props: { sessionId: string; cwd: string | undefined; dif
   return (
     <div className={css.gitDiffTab}>
       <div className={css.gitDiffTabHeader}>
-        <span className={css.gitDiffTabTitle} title={diff.kind === 'worktree' ? diff.path : `${diff.hash} ${diff.subject}`}>
-          {diff.kind === 'worktree' ? diff.path : `${diff.hash} ${diff.subject}`}
+        <span className={css.gitDiffTabTitle} title={diffTitle(diff)}>
+          {diffTitle(diff)}
         </span>
         <button
           type="button"

--- a/src/client/DiffView.tsx
+++ b/src/client/DiffView.tsx
@@ -177,13 +177,14 @@ const GENERATED_PATH = /(^|\/)(?:dist|build|coverage|generated|vendor|node_modul
 const SOURCE_PATH = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts|py|pyw|rb|php|java|kt|kts|scala|go|rs|swift|c|h|cc|cpp|cxx|hpp|hh|hxx|cs|fs|fsx|vb|dart|lua|r|ex|exs|erl|hrl|clj|cljs|cljc|groovy|sh|bash|zsh|fish|ps1|sql|vue|svelte|astro|html|htm|css|scss|sass|less)$/i
 
 /** Source files open by default; tests, docs, generated files and unknown types stay folded. */
-function defaultExpandedFiles(files: DiffFile[]): Set<number> {
+function defaultExpandedFiles(files: DiffFile[], forceAll = false): Set<number> {
   const expanded = new Set<number>()
   files.forEach((file, index) => {
     const path = displayPath(file.newPath === '/dev/null' ? file.oldPath : file.newPath)
     if (!file.binary && file.hunks.length > 0
-      && !TEST_PATH.test(path) && !DOC_PATH.test(path) && !GENERATED_PATH.test(path)
-      && SOURCE_PATH.test(path)) {
+      && (forceAll
+        || (!TEST_PATH.test(path) && !DOC_PATH.test(path) && !GENERATED_PATH.test(path)
+          && SOURCE_PATH.test(path)))) {
       expanded.add(index)
     }
   })
@@ -196,9 +197,12 @@ export interface DiffViewProps {
   /** Untracked-file content: when present, renders as a full-file addition instead of parsing. */
   untrackedPath?: string
   untrackedContent?: string
+  /** Force every file section expanded regardless of its path kind (inline
+   *  per-turn diffs want the hunks visible even for non-source extensions). */
+  defaultExpanded?: boolean
 }
 
-export function DiffView({ diff, untrackedPath, untrackedContent }: DiffViewProps) {
+export function DiffView({ diff, untrackedPath, untrackedContent, defaultExpanded }: DiffViewProps) {
   const parsed = useMemo<ParsedDiff>(() => {
     if (untrackedPath !== undefined) {
       return { files: [untrackedFile(untrackedPath, untrackedContent ?? '')] }
@@ -206,9 +210,9 @@ export function DiffView({ diff, untrackedPath, untrackedContent }: DiffViewProp
     return parseUnifiedDiff(diff)
   }, [diff, untrackedPath, untrackedContent])
   const [expanded, setExpanded] = useState(false)
-  const [expandedFiles, setExpandedFiles] = useState<Set<number>>(() => defaultExpandedFiles(parsed.files))
+  const [expandedFiles, setExpandedFiles] = useState<Set<number>>(() => defaultExpandedFiles(parsed.files, defaultExpanded))
 
-  useEffect(() => { setExpandedFiles(defaultExpandedFiles(parsed.files)) }, [parsed])
+  useEffect(() => { setExpandedFiles(defaultExpandedFiles(parsed.files, defaultExpanded)) }, [parsed, defaultExpanded])
 
   // Flatten into display rows so the cap can slice a single list.
   const rows = useMemo(() => {

--- a/src/client/builtins/tabs.tsx
+++ b/src/client/builtins/tabs.tsx
@@ -1,11 +1,11 @@
 /**
- * The 7 built-in tab descriptors: the plugin registers its own pages
- * (editor / git / subagent / sidechat / terminal / browser / diff) through
- * the same {@link BetterSidebarService} external plugins use — eating its
- * own dogfood. The terminal descriptor owns its quota (`TERMINAL_LIMIT`)
- * and mints `terminal:<uuid>` ids through `createTab`; the browser mints
- * `browser:<n>` the same way (no quota). The editor IS the files window
- * (the old standalone explorer merged into it).
+ * The 8 built-in tab descriptors: the plugin registers its own pages
+ * (editor / git / subagent / sidechat / changes / terminal / browser /
+ * diff) through the same {@link BetterSidebarService} external plugins
+ * use — eating its own dogfood. The terminal descriptor owns its quota
+ * (`TERMINAL_LIMIT`) and mints `terminal:<uuid>` ids through `createTab`;
+ * the browser mints `browser:<n>` the same way (no quota). The editor IS
+ * the files window (the old standalone explorer merged into it).
  */
 import { IconBranchOutline16, IconCodeOutline16, IconFolderOpen16, IconNewChatOutline16, IconPanelLeftOutline16, IconThinkOutline16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { Context } from '../../context-types.ts'
@@ -19,6 +19,7 @@ import { GitView } from '../GitView.tsx'
 import { DiffTab } from '../DiffTab.tsx'
 import { SubagentView } from '../SubagentView.tsx'
 import { consumeSidechatSeed, SideChatView, sidechatThreadIdOf } from '../SideChatView.tsx'
+import { ChangesView } from '../ChangesView.tsx'
 import { api } from '../api.ts'
 import { BrowserView } from '../BrowserView.tsx'
 import { IconTerminalOutline16, IconDiffOutline16, IconGlobeOutline16 } from '../icons.tsx'
@@ -216,6 +217,16 @@ export function builtinTabs(ctx: Context, options: BuiltinTabOptions = {}): read
       },
       component: ({ ctx, scope, tab, visible }) => (
         <SideChatView ctx={ctx} scope={scope} tab={tab} visible={visible} />
+      ),
+    },
+    {
+      id: 'changes',
+      title: () => t('changes'),
+      icon: (size: number) => <IconDiffOutline16 size={size} />,
+      order: 36,
+      single: true,
+      component: ({ ctx, store, scope, visible }) => (
+        <ChangesView ctx={ctx} store={store} scope={scope} visible={visible} />
       ),
     },
     {

--- a/src/client/diff.ts
+++ b/src/client/diff.ts
@@ -1,0 +1,172 @@
+/**
+ * Minimal self-contained unified-diff builder for per-turn file changes.
+ *
+ * The session log's mutation views carry `{ path, oldText, newText }` — the
+ * before/after text of one change (a `write`'s full content, or the hunks an
+ * `edit`/`str_replace` applied). This module turns those into a standard
+ * unified-diff string (`@@ -a,b +c,d @@` hunks with 3 context lines) that the
+ * existing `DiffView`/`parseUnifiedDiff` renderer consumes, so a per-turn
+ * change shows as a real red/green diff with no git round-trip.
+ *
+ * The line-diff is a classic LCS DP over the old/new line arrays (bounded by
+ * the sizes of the two texts; for typical edit hunks this is tiny, and the
+ * caller caps the whole turn's retained content).
+ */
+export interface FileChangeText {
+  path: string
+  oldText: string | null
+  newText: string
+}
+
+/** One operation in the LCS-derived edit script. */
+type Op =
+  | { kind: 'eq'; text: string }
+  | { kind: 'del'; text: string }
+  | { kind: 'add'; text: string }
+
+/** Split text into lines, keeping a trailing empty line for a trailing newline. */
+function splitLines(text: string | null): string[] {
+  if (text === null) return []
+  if (text === '') return []
+  const lines = text.split('\n')
+  // A trailing newline produces a final empty segment that represents the
+  // newline itself; drop it (the unified format re-adds it per line).
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  return lines
+}
+
+/** Compute the LCS edit script between two line arrays (Myers-free, plain DP). */
+function editScript(oldLines: string[], newLines: string[]): Op[] {
+  const n = oldLines.length
+  const m = newLines.length
+  // dp[i][j] = LCS length of oldLines[i..] and newLines[j..]
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      const oldLine = oldLines[i]
+      const newLine = newLines[j]
+      const diag = dp[i + 1]![j + 1]!
+      const down = dp[i + 1]![j]!
+      const right = dp[i]![j + 1]!
+      dp[i]![j] = oldLine === newLine ? diag + 1 : Math.max(down, right)
+    }
+  }
+  const ops: Op[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    const oldLine = oldLines[i]
+    const newLine = newLines[j]
+    if (oldLine !== undefined && newLine !== undefined && oldLine === newLine) {
+      ops.push({ kind: 'eq', text: oldLine })
+      i++
+      j++
+    } else if ((dp[i + 1]?.[j] ?? 0) >= (dp[i]?.[j + 1] ?? 0)) {
+      if (oldLine !== undefined) ops.push({ kind: 'del', text: oldLine })
+      i++
+    } else {
+      if (newLine !== undefined) ops.push({ kind: 'add', text: newLine })
+      j++
+    }
+  }
+  while (i < n) {
+    const line = oldLines[i]
+    if (line !== undefined) ops.push({ kind: 'del', text: line })
+    i++
+  }
+  while (j < m) {
+    const line = newLines[j]
+    if (line !== undefined) ops.push({ kind: 'add', text: line })
+    j++
+  }
+  return ops
+}
+
+/** Group ops into hunks with the given context window. */
+function hunksOf(ops: Op[], context = 3): { oldStart: number; oldLen: number; newStart: number; newLen: number; lines: Op[] }[] {
+  const hunks: { oldStart: number; oldLen: number; newStart: number; newLen: number; lines: Op[] }[] = []
+  const n = ops.length
+  // Index positions of changed (non-eq) ops.
+  const changedIdx: number[] = []
+  for (let k = 0; k < n; k++) {
+    const op = ops[k]
+    if (op !== undefined && op.kind !== 'eq') changedIdx.push(k)
+  }
+
+  // Split changed ops into clusters: two changes belong to the same hunk if
+  // the number of equal lines between them is <= 2*context.
+  let clusterStart = 0
+  for (let c = 0; c < changedIdx.length; c++) {
+    const cur = changedIdx[c]
+    const next = c + 1 < changedIdx.length ? changedIdx[c + 1] : undefined
+    if (next !== undefined && cur !== undefined && next - cur - 1 <= 2 * context) continue // same cluster
+    // Close the cluster [clusterStart..c].
+    const firstChanged = changedIdx[clusterStart]
+    const lastChanged = changedIdx[c]
+    if (firstChanged === undefined || lastChanged === undefined) { clusterStart = c + 1; continue }
+    // Hunk spans from (firstChanged - context) to (lastChanged + context),
+    // clamped to the op range.
+    const start = Math.max(0, firstChanged - context)
+    const end = Math.min(n, lastChanged + context + 1)
+    const body = ops.slice(start, end)
+    // Compute line numbers for the hunk header by walking ops up to `start`.
+    let oldLine = 1
+    let newLine = 1
+    for (let k = 0; k < start; k++) {
+      const op = ops[k]
+      if (op === undefined) continue
+      if (op.kind === 'eq' || op.kind === 'del') oldLine++
+      if (op.kind === 'eq' || op.kind === 'add') newLine++
+    }
+    // Count changes within the body for the lengths.
+    let oldLen = 0
+    let newLen = 0
+    for (const op of body) {
+      if (op.kind === 'del') oldLen++
+      else if (op.kind === 'add') newLen++
+      else { oldLen++; newLen++ }
+    }
+    hunks.push({ oldStart: oldLine, oldLen, newStart: newLine, newLen, lines: body })
+    clusterStart = c + 1
+  }
+  return hunks
+}
+
+/** Escape a path for the `---` / `+++` header lines (git-style `a/`/`b/`). */
+function diffPath(path: string): string {
+  return path.startsWith('/') ? path : `a/${path}`
+}
+
+/**
+ * Build a unified-diff string for one or more file changes, rendered by
+ * `DiffView`. Pure insertions (`oldText === null`) produce a `/dev/null` old
+ * side; otherwise both sides use `a/`/`b/` prefixes.
+ * @param changes - one entry per file with its before/after text.
+ * @returns the unified diff text (empty when there is nothing to show).
+ */
+export function buildUnifiedDiff(changes: readonly FileChangeText[]): string {
+  const out: string[] = []
+  for (const change of changes) {
+    const oldLines = splitLines(change.oldText)
+    const newLines = splitLines(change.newText)
+    const ops = editScript(oldLines, newLines)
+    const hunks = hunksOf(ops)
+    if (hunks.length === 0 && change.oldText !== null && change.oldText === change.newText) continue
+    const isAdd = change.oldText === null || oldLines.length === 0
+    const oldPath = isAdd ? '/dev/null' : diffPath(change.path)
+    const newPath = diffPath(change.path)
+    // `parseUnifiedDiff` opens a file only on a `diff --git` header.
+    out.push(`diff --git ${oldPath} ${newPath}`)
+    out.push(`--- ${oldPath}`)
+    out.push(`+++ ${newPath}`)
+    for (const hunk of hunks) {
+      out.push(`@@ -${hunk.oldStart},${hunk.oldLen} +${hunk.newStart},${hunk.newLen} @@`)
+      for (const op of hunk.lines) {
+        if (op.kind === 'eq') out.push(` ${op.text}`)
+        else if (op.kind === 'del') out.push(`-${op.text}`)
+        else out.push(`+${op.text}`)
+      }
+    }
+  }
+  return out.join('\n')
+}

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -337,6 +337,11 @@ export const zh = {
   pluginTurnReviewDesc: '对「刚刚这一回合」的 diff 做 Approve / Request changes 的人闸门：只审上一回合，不 fork 会话；文件按主会话/子代理/未归因分组，按文件勾选打回 + 可选评语，点文件先看回合开始快照 vs 现在的 diff。不是 /rewind',
   pluginVideoPreviewDesc: '在 better-sidebar 编辑器内联预览视频文件（.mp4/.webm/.mov/.mkv/.avi 等），自带支持 HTTP Range（206）的 /video 宿主路由，可拖动进度条、不受 20MB mediaLimit 限制',
   pluginDocsPanelDesc: 'DSH 侧边栏里的「全局文档」：全局 Markdown 笔记，任何工作区随时可读——列表点选阅读、悬浮大纲跳转、Chrome / VS Code 外部打开、代码复制，目录可配置（默认 ~/.dsh/docs）',
+  changesEmpty: '还没有文件变更',
+  changesEmptyHint: '对话中模型写入 / 修改文件后，会按轮次在这里列出',
+  changesTurn: '第 {turn} 轮',
+  changesFiles: '{count} 个文件',
+  changesRefresh: '刷新变更',
 }
 
 /** The en dictionary (key-set-equal to zh, enforced by the type annotation). */
@@ -667,6 +672,11 @@ export const en: Record<keyof typeof zh, string> = {
   pluginTurnReviewDesc: 'A human gate on the just-finished turn: Approve / Request changes per path with an optional comment; paths grouped by main session / subagent / unattributed; inline snapshot-vs-now diff before you decide. No fork, no /rewind',
   pluginVideoPreviewDesc: 'Inline video preview (.mp4/.webm/.mov/.mkv/.avi etc.) for the better-sidebar editor, backed by a dedicated /video host route with HTTP Range (206) support — scrubbing works and files are not capped by the 20MB mediaLimit',
   pluginDocsPanelDesc: 'Global docs in the DSH sidebar: read your own Markdown notes from any workspace — a file list, an outline, open in Chrome / VS Code, and copy buttons; the docs directory is configurable (default ~/.dsh/docs)',
+  changesEmpty: 'No file changes yet',
+  changesEmptyHint: 'Files written or modified by the model in this conversation are listed here, grouped per turn',
+  changesTurn: 'Turn {turn}',
+  changesFiles: '{count} files',
+  changesRefresh: 'Refresh changes',
 }
 
 /**

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2411,6 +2411,70 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   padding: 4px 0;
 }
 
+/* The per-turn changes header: a chevron + "第 N 轮 · M 个文件", clicking it
+   expands/collapses every file of the turn at once. */
+.changesTurnHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+
+.changesTurnHeader:hover {
+  color: var(--dsw-alias-label-primary);
+}
+
+.changesTurnLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: inherit;
+  font-weight: 400;
+  font: var(--dsw-font-s-14);
+}
+
+.changesTurnChevron {
+  flex: none;
+  color: var(--dsw-alias-label-tertiary);
+  transform: rotate(0deg);
+}
+
+.changesTurnChevronExpanded {
+  transform: rotate(90deg);
+}
+
+/* An expanded file chip: the inline diff below it is open, so the chip
+   highlights to show the connection. */
+.producedChipActive {
+  background: var(--dsw-alias-accent-soft, var(--dsw-alias-interactive-bg-active));
+  color: var(--dsw-alias-label-primary);
+  border-color: var(--dsw-alias-accent, var(--dsw-alias-border-l2));
+}
+
+/* The inline per-file diff below an expanded chip. Sits on its own inset
+   card so the red/green lines read against a stable background. */
+.changesInlineDiff {
+  margin: 2px 0 4px;
+  padding: 4px 6px;
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 8px;
+  background: var(--dsw-alias-bg-layer-1);
+}
+
+.changesInlineDiff .gitDiff {
+  border-top: none;
+  padding: 0;
+}
+
 .producedLabel {
   font: var(--dsw-font-xxs-12);
   color: var(--dsw-alias-label-tertiary);
@@ -2467,6 +2531,8 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 .gitLogMore:focus-visible,
 .gitDiffFile:focus-visible,
 .gitDiffExpand:focus-visible,
+.changesTurnHeader:focus-visible,
+.producedChip:focus-visible,
 .terminalRetry:focus-visible,
 .editorModeButton:focus-visible,
 .editorDownloadLink:focus-visible,

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2452,12 +2452,30 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   transform: rotate(90deg);
 }
 
+/* The turn header while every file of the turn is expanded: the label and
+   chevron take the accent color so the expanded state is unmistakable. */
+.changesTurnHeaderActive {
+  color: var(--dsw-alias-state-business-primary, var(--dsw-alias-label-primary));
+}
+
+.changesTurnHeaderActive .changesTurnChevron {
+  color: var(--dsw-alias-state-business-primary, var(--dsw-alias-label-tertiary));
+}
+
 /* An expanded file chip: the inline diff below it is open, so the chip
-   highlights to show the connection. */
+   highlights to show the connection. Uses the DSH "active pill" recipe
+   (ghost-active fill + ring) so the selected state reads clearly against
+   the unselected chip. */
 .producedChipActive {
-  background: var(--dsw-alias-accent-soft, var(--dsw-alias-interactive-bg-active));
+  background: var(--dsw-alias-button-ghost-active-fill, var(--dsw-alias-accent-soft, var(--dsw-alias-interactive-bg-active)));
   color: var(--dsw-alias-label-primary);
-  border-color: var(--dsw-alias-accent, var(--dsw-alias-border-l2));
+  border-color: var(--dsw-alias-button-ghost-active-border, var(--dsw-alias-state-business-primary, var(--dsw-alias-accent, var(--dsw-alias-border-l2))));
+  font-weight: 600;
+}
+
+/* The active chip's icon inherits the stronger color too. */
+.producedChipActive svg {
+  color: var(--dsw-alias-state-business-primary, var(--dsw-alias-label-primary));
 }
 
 /* The inline per-file diff below an expanded chip. Sits on its own inset

--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -20,10 +20,13 @@ import { isNarrowWidth } from './breakpoints.ts'
  */
 export type TabType = string
 
-/** What a diff tab shows: a worktree/index change of one path, or one commit's full patch. */
+/** What a diff tab shows: a worktree/index change of one path, one commit's
+ *  full patch, or a pre-built unified diff (e.g. a per-turn change derived
+ *  from the session log's mutation views). */
 export type SidebarDiffRef =
   | { kind: 'worktree'; path: string; staged: boolean; untracked?: boolean }
   | { kind: 'commit'; hash: string; hashFull: string; subject: string }
+  | { kind: 'custom'; diff: string }
 
 /** One open tab. `path` carries the file (editor) or is absent (git/terminal);
  *  `diff` carries the change a diff tab shows; `meta` (v0.12.0+) carries

--- a/tests/builtins.spec.ts
+++ b/tests/builtins.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Built-in registration tests: the plugin registers 7 tabs and 6 file
+ * Built-in registration tests: the plugin registers 8 tabs and 6 file
  * viewers through the same service external plugins use (dogfooding);
  * the catch-all `code` viewer, the NUL-sniffing `binary-download` viewer,
  * and the html sandbox settings pin the registry's behavior. (Office
@@ -27,10 +27,10 @@ function setup(options: BuiltinTabOptions = {}): { service: ReturnType<typeof cr
 }
 
 describe('built-in tab registrations', () => {
-  it('registers the 7 built-in tabs', () => {
+  it('registers the 8 built-in tabs', () => {
     const { service } = setup()
     expect(service.getTabs().map(t => t.id).sort()).toEqual(
-      ['browser', 'diff', 'editor', 'git', 'sidechat', 'subagent', 'terminal'],
+      ['browser', 'changes', 'diff', 'editor', 'git', 'sidechat', 'subagent', 'terminal'],
     )
   })
 

--- a/tests/changes.spec.ts
+++ b/tests/changes.spec.ts
@@ -31,9 +31,11 @@ function readCall(callId: string, path: string, seq: number): SidebarHistoryEntr
   )
 }
 
-/** The matching tool/result row (success, links the call id). */
-function result(callId: string, seq: number, error = false): SidebarHistoryEntry {
-  return row({
+/** The matching tool/result row (success, links the call id). Optionally
+ *  carries the host-computed `{ for: 'result', view: { card: 'diff', diffs } }`
+ *  that the per-turn diff capture reads. */
+function result(callId: string, seq: number, error = false, diff?: unknown): SidebarHistoryEntry {
+  const base = {
     type: 'tool/result', seq, time: seq,
     data: {
       message: {
@@ -41,7 +43,9 @@ function result(callId: string, seq: number, error = false): SidebarHistoryEntry
         content: [{ isError: error }],
       },
     },
-  })
+  }
+  if (error || diff === undefined) return row(base)
+  return row(base, { for: 'result', view: { card: 'diff', diffs: diff } })
 }
 
 function turnStart(turn: number, seq: number): SidebarHistoryEntry {
@@ -69,9 +73,24 @@ describe('collectTurnChanges', () => {
       turnEnd(2, 23),
     ]
     expect(collectTurnChanges(entries)).toEqual([
-      { turn: 1, seq: 10, time: 10, paths: ['a.txt', 'b.txt', 'c.txt'] },
-      { turn: 2, seq: 20, time: 20, paths: ['d.txt'] },
+      { turn: 1, seq: 10, time: 10, paths: ['a.txt', 'b.txt', 'c.txt'], changes: [] },
+      { turn: 2, seq: 20, time: 20, paths: ['d.txt'], changes: [] },
     ])
+  })
+
+  it('captures per-file before/after text from the result views (last write wins)', () => {
+    const entries = [
+      turnStart(1, 10),
+      writeCall('c1', 'a.txt', 11),
+      result('c1', 12, false, [{ path: 'a.txt', oldText: null, newText: 'v1' }]),
+      editCall('c2', 'a.txt', 13),
+      result('c2', 14, false, [{ path: 'a.txt', oldText: 'v1', newText: 'v2' }]),
+      turnEnd(1, 15),
+    ]
+    const turns = collectTurnChanges(entries)
+    expect(turns).toHaveLength(1)
+    expect(turns[0]!.paths).toEqual(['a.txt'])
+    expect(turns[0]!.changes).toEqual([{ path: 'a.txt', oldText: 'v1', newText: 'v2' }])
   })
 
   it('dedupes a path written twice in the same turn', () => {
@@ -84,7 +103,7 @@ describe('collectTurnChanges', () => {
       turnEnd(1, 15),
     ]
     expect(collectTurnChanges(entries)).toEqual([
-      { turn: 1, seq: 10, time: 10, paths: ['a.txt'] },
+      { turn: 1, seq: 10, time: 10, paths: ['a.txt'], changes: [] },
     ])
   })
 
@@ -126,7 +145,7 @@ describe('collectTurnChanges', () => {
     // The pre-turn call has no owning turn yet (current is null when its
     // result lands), so it contributes nothing; only the in-turn write shows.
     expect(collectTurnChanges(entries)).toEqual([
-      { turn: 1, seq: 10, time: 10, paths: ['b.txt'] },
+      { turn: 1, seq: 10, time: 10, paths: ['b.txt'], changes: [] },
     ])
   })
 })

--- a/tests/changes.spec.ts
+++ b/tests/changes.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { collectTurnChanges } from '../src/client/ChangesView.tsx'
+import type { SidebarHistoryEntry } from '../src/context-types.ts'
+
+/** One history row helper: an event plus an optional tool-call view. */
+function row(event: Record<string, unknown>, view?: unknown): SidebarHistoryEntry {
+  return { event: event as SidebarHistoryEntry['event'], ...(view === undefined ? {} : { view }) }
+}
+
+/** A tool/call row whose result carries a diff-card location. */
+function writeCall(callId: string, path: string, seq: number): SidebarHistoryEntry {
+  return row(
+    { type: 'tool/call', seq, time: seq, data: { callId, name: 'write' } },
+    { for: 'call', view: { card: 'diff', title: `Write ${path}`, locations: [{ path }] } },
+  )
+}
+
+/** A tool/call row whose result carries a generic edit-card location. */
+function editCall(callId: string, path: string, seq: number): SidebarHistoryEntry {
+  return row(
+    { type: 'tool/call', seq, time: seq, data: { callId, name: 'edit' } },
+    { for: 'call', view: { card: 'generic', kind: 'edit', locations: [{ path }] } },
+  )
+}
+
+/** A tool/call row that only reads (must contribute nothing). */
+function readCall(callId: string, path: string, seq: number): SidebarHistoryEntry {
+  return row(
+    { type: 'tool/call', seq, time: seq, data: { callId, name: 'read' } },
+    { for: 'call', view: { card: 'generic', kind: 'read', locations: [{ path }] } },
+  )
+}
+
+/** The matching tool/result row (success, links the call id). */
+function result(callId: string, seq: number, error = false): SidebarHistoryEntry {
+  return row({
+    type: 'tool/result', seq, time: seq,
+    data: {
+      message: {
+        source: { callId },
+        content: [{ isError: error }],
+      },
+    },
+  })
+}
+
+function turnStart(turn: number, seq: number): SidebarHistoryEntry {
+  return row({ type: 'turn/start', seq, time: seq, data: { turn } })
+}
+
+function turnEnd(turn: number, seq: number): SidebarHistoryEntry {
+  return row({ type: 'turn/end', seq, time: seq, data: { turn } })
+}
+
+describe('collectTurnChanges', () => {
+  it('folds each completed turn into its produced paths (first-seen order)', () => {
+    const entries = [
+      turnStart(1, 10),
+      writeCall('c1', 'a.txt', 11),
+      result('c1', 12),
+      editCall('c2', 'b.txt', 13),
+      editCall('c3', 'c.txt', 14),
+      result('c2', 15),
+      result('c3', 16),
+      turnEnd(1, 17),
+      turnStart(2, 20),
+      writeCall('c4', 'd.txt', 21),
+      result('c4', 22),
+      turnEnd(2, 23),
+    ]
+    expect(collectTurnChanges(entries)).toEqual([
+      { turn: 1, seq: 10, time: 10, paths: ['a.txt', 'b.txt', 'c.txt'] },
+      { turn: 2, seq: 20, time: 20, paths: ['d.txt'] },
+    ])
+  })
+
+  it('dedupes a path written twice in the same turn', () => {
+    const entries = [
+      turnStart(1, 10),
+      writeCall('c1', 'a.txt', 11),
+      result('c1', 12),
+      editCall('c2', 'a.txt', 13),
+      result('c2', 14),
+      turnEnd(1, 15),
+    ]
+    expect(collectTurnChanges(entries)).toEqual([
+      { turn: 1, seq: 10, time: 10, paths: ['a.txt'] },
+    ])
+  })
+
+  it('ignores reads, errors, and turns with no changes', () => {
+    const entries = [
+      turnStart(1, 10),
+      readCall('c1', 'r.txt', 11),
+      result('c1', 12),
+      writeCall('c2', 'x.txt', 13),
+      result('c2', 14, true), // error result → nothing
+      turnEnd(1, 15),
+      turnStart(2, 20),
+      turnEnd(2, 21),
+    ]
+    expect(collectTurnChanges(entries)).toEqual([])
+  })
+
+  it('does not leak a call across a turn boundary (result in a later turn contributes nothing)', () => {
+    const entries = [
+      turnStart(1, 10),
+      writeCall('c1', 'a.txt', 11),
+      turnEnd(1, 12),
+      turnStart(2, 20),
+      result('c1', 21),
+      turnEnd(2, 22),
+    ]
+    expect(collectTurnChanges(entries)).toEqual([])
+  })
+
+  it('ignores events before the first turn/start (no attributed turn yet)', () => {
+    const entries = [
+      writeCall('c1', 'a.txt', 1),
+      result('c1', 2),
+      turnStart(1, 10),
+      writeCall('c2', 'b.txt', 11),
+      result('c2', 12),
+      turnEnd(1, 13),
+    ]
+    // The pre-turn call has no owning turn yet (current is null when its
+    // result lands), so it contributes nothing; only the in-turn write shows.
+    expect(collectTurnChanges(entries)).toEqual([
+      { turn: 1, seq: 10, time: 10, paths: ['b.txt'] },
+    ])
+  })
+})

--- a/tests/changes.spec.ts
+++ b/tests/changes.spec.ts
@@ -4,7 +4,7 @@ import type { SidebarHistoryEntry } from '../src/context-types.ts'
 
 /** One history row helper: an event plus an optional tool-call view. */
 function row(event: Record<string, unknown>, view?: unknown): SidebarHistoryEntry {
-  return { event: event as SidebarHistoryEntry['event'], ...(view === undefined ? {} : { view }) }
+  return { event: event as unknown as SidebarHistoryEntry['event'], ...(view === undefined ? {} : { view }) }
 }
 
 /** A tool/call row whose result carries a diff-card location. */

--- a/tests/diff.spec.ts
+++ b/tests/diff.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { buildUnifiedDiff } from '../src/client/diff.ts'
+import { parseUnifiedDiff } from '../src/client/DiffView.tsx'
+
+describe('buildUnifiedDiff', () => {
+  it('renders an appended-line change as a valid unified diff', () => {
+    const d = buildUnifiedDiff([{
+      path: 'G:/UnitySource/test.md',
+      oldText: 'line1\nline2\nline3',
+      newText: 'line1\nline2\nline3\nline4\nline5',
+    }])
+    const parsed = parseUnifiedDiff(d)
+    const file = parsed.files[0]
+    expect(file).toBeDefined()
+    expect(file!.hunks.length).toBeGreaterThan(0)
+    // The addition lines must be present.
+    const addLines = file!.hunks.flatMap(h => h.lines).filter(l => l.kind === 'add').map(l => l.text)
+    expect(addLines).toContain('line4')
+    expect(addLines).toContain('line5')
+  })
+
+  it('renders a middle-line edit as a replace (del + add)', () => {
+    const d = buildUnifiedDiff([{
+      path: 'a/b.ts',
+      oldText: 'const x = 1;\nconst y = 2;\nconst z = 3;\n',
+      newText: 'const x = 1;\nconst y = 999;\nconst z = 3;\n',
+    }])
+    const parsed = parseUnifiedDiff(d)
+    const file = parsed.files[0]
+    expect(file).toBeDefined()
+    const ops = file!.hunks.flatMap(h => h.lines)
+    expect(ops.some(l => l.kind === 'del' && l.text === 'const y = 2;')).toBe(true)
+    expect(ops.some(l => l.kind === 'add' && l.text === 'const y = 999;')).toBe(true)
+  })
+
+  it('renders a brand-new file (oldText null) as a full-file addition', () => {
+    const d = buildUnifiedDiff([{ path: 'new.txt', oldText: null, newText: 'hello\nworld' }])
+    const parsed = parseUnifiedDiff(d)
+    const file = parsed.files[0]
+    expect(file).toBeDefined()
+    expect(file!.oldPath).toBe('/dev/null')
+    const addLines = file!.hunks.flatMap(h => h.lines).filter(l => l.kind === 'add').map(l => l.text)
+    expect(addLines).toEqual(['hello', 'world'])
+  })
+
+  it('handles multiple files in one diff', () => {
+    const d = buildUnifiedDiff([
+      { path: 'a.ts', oldText: 'x', newText: 'x\ny' },
+      { path: 'b.ts', oldText: 'p\nq', newText: 'p\nr' },
+    ])
+    const parsed = parseUnifiedDiff(d)
+    expect(parsed.files.length).toBe(2)
+  })
+
+  it('returns empty for identical texts', () => {
+    const d = buildUnifiedDiff([{ path: 'a.ts', oldText: 'same', newText: 'same' }])
+    expect(d).toBe('')
+  })
+})


### PR DESCRIPTION
## 概述

为 dsh-better-sidebar 新增「变更 / Changes」Tab：按轮次（turn）展示会话中每个文件的实际变更，点击文件就地展开该轮的真实 before/after diff。

## 功能

- **每轮变更记录**：从 `session.history` 折叠每轮的产出文件（复用 `producedPaths` 的 mutation-intent 推导），一行一个变更轮次，文件列表始终展示。
- **轮次可折叠**：点轮次标题一键展开/收起该轮全部文件的 diff（箭头 + 品牌色指示状态）。
- **文件就地展开**：点文件 chip 就地展开该文件的真实每轮 diff（来自工具结果视图的 `diffs`，无 git 往返，未跟踪新文件也能显示增量）；展开态用 DSH active-pill 样式高亮，与未选中清晰区分。
- **真实每轮 diff**：`src/client/diff.ts` 用 LCS 生成 unified diff（`@@` hunks + 3 行上下文），复用现有 `DiffView` 渲染 VSCode 风格红绿视图；`SidebarDiffRef` 新增 `{ kind: 'custom', diff }` 直接渲染预构建 diff。

## 关键修复

- **首次加载被轮询打断**：2s 轮询此前每拍 abort 上一次历史拉取，大会话的首次回溯（数秒）永远跑不完 → 显示「还没有文件变更」。现在 `walkingRef` 标记回溯进行中，轮询跳过该拍，回溯落地后再合并尾部。
- **缓存瘦身**：合并时丢弃流式增量事件（`assistant/chunk`、`*-chunks`），只保留结构性事件（轮次标记/工具调用/结果/消息），缓存从 18 万条降到 ~1300 条，老轮次不被后续轮询冲掉。
- **回溯参数调优**：16 消息/页，够 4 个已完成轮次即停，首次加载 ~1.3s 完成且不卡浏览器。

## 变更文件

- `src/client/ChangesView.tsx` — Changes Tab（轮次折叠、文件就地展开 diff）
- `src/client/diff.ts` — 自包含 unified-diff 生成器
- `src/client/DiffView.tsx` — 新增 `defaultExpanded` prop（内嵌 diff 强制展开 hunk）
- `src/client/state.ts` — `SidebarDiffRef` 新增 `{ kind: 'custom', diff }`
- `src/client/DiffTab.tsx` — 处理 `custom` diff 直接渲染
- `src/client/sidebar.module.css` — 轮次标题/选中 chip/内嵌 diff 卡片样式
- `src/client/builtins/tabs.tsx`、`src/client/locales.ts`、`AGENTS.md` — 注册 Tab + 文案
- `tests/changes.spec.ts`、`tests/diff.spec.ts`、`tests/builtins.spec.ts` — 测试

## 测试

- `pnpm vitest run tests/changes.spec.ts tests/diff.spec.ts tests/builtins.spec.ts` → 33/33 通过
- 实机验证：大会话首次加载 ~1.3s，能回溯到最近 5 轮，包含新建/多次编辑的 `test.md`
