### PR TITLE
feat(explorer): git status badges and name tints for the file tree

### DIFF
--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -36,7 +36,9 @@ import {
 import { SiCursor, SiZedindustries } from 'react-icons/si'
 import { VscFile, VscFolder, VscFolderOpened, VscLinkExternal, VscPin, VscPinned } from 'react-icons/vsc'
 import { api, downloadUrl, type FsEntry, type GitStatusResult } from './api.ts'
-import { gitDecorations, gitKey, gitRelOf } from './git-decor.ts'
+import {
+  gitDecorations, gitKey, gitRelOf, owningRepo, type GitDecorations,
+} from './git-decor.ts'
 import { IconUploadOutline16, IconVscode16 } from './icons.tsx'
 import type { OpenWithTarget } from './open-with.ts'
 import { relativeTo } from './paths.ts'
@@ -60,12 +62,6 @@ export function baseName(path: string): string {
 function parentOf(path: string): string {
   const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
   return at <= 0 ? path : path.slice(0, at)
-}
-
-/** The decorations of a not-yet-fetched status snapshot (no marks at all). */
-const EMPTY_GIT_DECOR: { badges: Map<string, string>; dirtyDirs: Set<string> } = {
-  badges: new Map(),
-  dirtyDirs: new Set(),
 }
 
 /** Only OS file drags belong to the upload surface; in-app drags (tab reorder,
@@ -150,8 +146,15 @@ export function FileTree(props: {
   const { sessionId, cwd, expanded, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, openWithTargets, openWithPinned, openWithSsh, onOpenWith, onToggleOpenWithPin, onReferenceFile, refreshTick, onUploadRequest, busy } = props
   const [data, setData] = useState<Record<string, LevelData>>({})
   const dataRef = useRef(data)
-  /** Working-tree status of the session workspace (drives the row marks). */
-  const [git, setGit] = useState<GitStatusResult | null>(null)
+  /**
+   * Working-tree status snapshots keyed by the directory they were fetched
+   * for: the workspace root itself, plus every visible directory that
+   * carries a `.git` entry (nested repositories — the workspace folder is
+   * often not a repo itself, its children are).
+   */
+  const [repos, setRepos] = useState<Map<string, GitStatusResult>>(new Map())
+  /** Repos already requested (a failed fetch is retried on the next refresh). */
+  const repoRequested = useRef<Set<string>>(new Set())
   /** The row whose path was just copied ("copied" label replaces its button). */
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
   /** Open context menu: the row path (and whether it is a directory) plus the cursor position. */
@@ -255,6 +258,21 @@ export function FileTree(props: {
     setDropTarget(dir)
   }
 
+  /** Fetch one repo's status (deduped; failures are retried next refresh). */
+  const fetchRepo = useCallback((root: string): void => {
+    if (repoRequested.current.has(root)) return
+    repoRequested.current.add(root)
+    api.gitStatus({ sessionId, cwd: root }).then((result) => {
+      setRepos(prev => {
+        const next = new Map(prev)
+        next.set(root, result)
+        return next
+      })
+    }).catch(() => {
+      repoRequested.current.delete(root)
+    })
+  }, [sessionId])
+
   const storeLevel = useCallback((path: string, level: LevelData) => {
     dataRef.current = { ...dataRef.current, [path]: level }
     setData(dataRef.current)
@@ -265,10 +283,15 @@ export function FileTree(props: {
     storeLevel(dir, {})
     api.fsTree({ sessionId, cwd }, dir).then((listing) => {
       storeLevel(dir, { entries: listing.entries })
+      // A `.git` entry marks a repository root (worktrees carry a `.git`
+      // file) — fetch its status so the subtree gets decorated.
+      for (const entry of listing.entries) {
+        if (entry.name === '.git') fetchRepo(dir)
+      }
     }).catch((error: unknown) => {
       storeLevel(dir, { error: error instanceof Error ? error.message : String(error) })
     })
-  }, [sessionId, cwd, storeLevel])
+  }, [sessionId, cwd, storeLevel, fetchRepo])
 
   // The caller's refresh tick wipes the cache (declared BEFORE the load
   // effect so the reload below sees the empty cache).
@@ -289,48 +312,41 @@ export function FileTree(props: {
     for (const dir of expanded) loadDir(dir)
   }, [cwd, expanded, refreshTick, loadDir])
 
-  // The git decorations ride the same refresh affordance: fetched on mount
-  // and on every refresh tick (the tree has no file watcher — KISS).
+  // The git decorations ride the same refresh affordance: the workspace
+  // root's status is fetched on mount and on every refresh tick, and the
+  // repo map is reset so nested repositories are re-discovered (the tree
+  // has no file watcher — KISS).
   useEffect(() => {
-    if (cwd === undefined) {
-      setGit(null)
-      return
+    repoRequested.current = new Set()
+    setRepos(new Map())
+    if (cwd === undefined) return
+    fetchRepo(cwd)
+  }, [sessionId, cwd, refreshTick, fetchRepo])
+
+  /** Decorations per repo key (recomputed only when a snapshot arrives). */
+  const decorByKey = useMemo(() => {
+    const map = new Map<string, GitDecorations>()
+    for (const [key, status] of repos) {
+      map.set(key, gitDecorations(status))
     }
-    let cancelled = false
-    api.gitStatus({ sessionId, cwd }).then((result) => {
-      if (!cancelled) setGit(result)
-    }).catch(() => {
-      if (!cancelled) setGit(null)
-    })
-    return () => { cancelled = true }
-  }, [sessionId, cwd, refreshTick])
+    return map
+  }, [repos])
 
-  /** The repo root used for path matching: the host-reported root when
-   *  available, else the workspace root itself (the common case — host
-   *  versions before the `root` field fall back to it; a cwd deeper inside
-   *  the repo then merely shows no marks, never wrong ones). */
-  const gitRoot = git !== null && git.isRepo ? (git.root ?? cwd) : undefined
-
-  /** Badge letter per repo-relative path key, plus the set of directories
-   *  whose subtree contains a changed file. Both are recomputed only when a
-   *  fresh status snapshot arrives. */
-  const gitDecor = useMemo(
-    () => (git === null ? EMPTY_GIT_DECOR : gitDecorations(git)),
-    [git],
-  )
-
-  /** The badge letter of an absolute row path (undefined when not in the repo). */
+  /** The badge letter of an absolute row path (undefined when not in a repo). */
   const badgeOfPath = (abs: string): string | undefined => {
-    if (gitRoot === undefined) return undefined
-    const rel = gitRelOf(gitRoot, abs)
-    return rel === undefined ? undefined : gitDecor.badges.get(gitKey(rel))
+    const repo = owningRepo(repos, abs)
+    if (repo === undefined) return undefined
+    const rel = gitRelOf(repo.root, abs)
+    if (rel === undefined) return undefined
+    return decorByKey.get(repo.key)?.badges.get(gitKey(rel))
   }
 
   /** Whether a directory row's subtree contains at least one changed file. */
   const dirIsDirty = (abs: string): boolean => {
-    if (gitRoot === undefined) return false
-    const rel = gitRelOf(gitRoot, abs)
-    return rel !== undefined && gitDecor.dirtyDirs.has(gitKey(rel))
+    const repo = owningRepo(repos, abs)
+    if (repo === undefined) return false
+    const rel = gitRelOf(repo.root, abs)
+    return rel !== undefined && (decorByKey.get(repo.key)?.dirtyDirs.has(gitKey(rel)) ?? false)
   }
 
   /** Copy `text`; on success flip the row's copied label for a moment. */
@@ -467,7 +483,8 @@ export function FileTree(props: {
   const root = cwd
   /** The workspace root row marks any repo with pending changes (VSCode's
    *  root-folder dot — the git panel remains the source of truth). */
-  const rootDirty = git !== null && git.isRepo && git.entries.length > 0
+  const cwdRepo = cwd === undefined ? undefined : repos.get(cwd)
+  const rootDirty = cwdRepo !== undefined && cwdRepo.isRepo && cwdRepo.entries.length > 0
 
   const renderLevel = (dir: string, depth: number): ReactNode => {
     const level = data[dir]

--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -155,6 +155,8 @@ export function FileTree(props: {
   const [repos, setRepos] = useState<Map<string, GitStatusResult>>(new Map())
   /** Repos already requested (a failed fetch is retried on the next refresh). */
   const repoRequested = useRef<Set<string>>(new Set())
+  /** Top-level directories already probed for a `.git` entry (repos or not). */
+  const sweepProbed = useRef<Set<string>>(new Set())
   /** The row whose path was just copied ("copied" label replaces its button). */
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
   /** Open context menu: the row path (and whether it is a directory) plus the cursor position. */
@@ -258,11 +260,13 @@ export function FileTree(props: {
     setDropTarget(dir)
   }
 
-  /** Fetch one repo's status (deduped; failures are retried next refresh). */
+  /** Fetch one repo's status (deduped; failures are retried next refresh).
+   *  Uses the explicit-dir route so the session header cwd cannot re-scope
+   *  a nested repository's status fetch back to the workspace root. */
   const fetchRepo = useCallback((root: string): void => {
     if (repoRequested.current.has(root)) return
     repoRequested.current.add(root)
-    api.gitStatus({ sessionId, cwd: root }).then((result) => {
+    api.gitStatusAt({ sessionId, cwd }, root).then((result) => {
       setRepos(prev => {
         const next = new Map(prev)
         next.set(root, result)
@@ -271,7 +275,7 @@ export function FileTree(props: {
     }).catch(() => {
       repoRequested.current.delete(root)
     })
-  }, [sessionId])
+  }, [sessionId, cwd])
 
   const storeLevel = useCallback((path: string, level: LevelData) => {
     dataRef.current = { ...dataRef.current, [path]: level }
@@ -318,10 +322,39 @@ export function FileTree(props: {
   // has no file watcher — KISS).
   useEffect(() => {
     repoRequested.current = new Set()
+    sweepProbed.current = new Set()
     setRepos(new Map())
     if (cwd === undefined) return
     fetchRepo(cwd)
   }, [sessionId, cwd, refreshTick, fetchRepo])
+
+  /**
+   * Top-level repository sweep: once the ROOT level listing is in, every
+   * visible directory inside it is probed for a `.git` entry (a directory
+   * listing of `<dir>/.git` succeeds iff the dir is a repo root) and its
+   * status is fetched right away. The workspace folder is often not a repo
+   * itself — its children are — and waiting for the user to expand a dir
+   * before discovering its repo made the marks appear too late / not at all.
+   * Nested repos still get picked up by the expansion-time discovery in
+   * `loadDir`; the sweep only covers the root level (cheap, bounded).
+   */
+  useEffect(() => {
+    if (cwd === undefined) return
+    const level = data[cwd]
+    if (level === undefined || level.entries === undefined) return
+    for (const entry of level.entries) {
+      if (!entry.isDir || entry.hidden) continue
+      if (sweepProbed.current.has(entry.path)) continue
+      sweepProbed.current.add(entry.path)
+      // Probe `<dir>/.git` with forward slashes (the host normalizes both
+      // separator styles on Windows and POSIX alike).
+      api.fsTree({ sessionId, cwd }, `${entry.path.replace(/[\\/]+$/, '')}/.git`).then(() => {
+        fetchRepo(entry.path)
+      }).catch(() => {
+        // No .git — an ordinary directory, not a repository root.
+      })
+    }
+  }, [data, cwd, sessionId, fetchRepo])
 
   /** Decorations per repo key (recomputed only when a snapshot arrives). */
   const decorByKey = useMemo(() => {
@@ -347,6 +380,16 @@ export function FileTree(props: {
     if (repo === undefined) return false
     const rel = gitRelOf(repo.root, abs)
     return rel !== undefined && (decorByKey.get(repo.key)?.dirtyDirs.has(gitKey(rel)) ?? false)
+  }
+
+  /** The dominant status letter of a directory row's subtree (tints its
+   *  name; undefined when the dir is outside any repo or holds no changes). */
+  const dirBadgeOfPath = (abs: string): string | undefined => {
+    const repo = owningRepo(repos, abs)
+    if (repo === undefined) return undefined
+    const rel = gitRelOf(repo.root, abs)
+    if (rel === undefined) return undefined
+    return decorByKey.get(repo.key)?.dirBadges.get(gitKey(rel))
   }
 
   /** Copy `text`; on success flip the row's copied label for a moment. */
@@ -485,6 +528,14 @@ export function FileTree(props: {
    *  root-folder dot — the git panel remains the source of truth). */
   const cwdRepo = cwd === undefined ? undefined : repos.get(cwd)
   const rootDirty = cwdRepo !== undefined && cwdRepo.isRepo && cwdRepo.entries.length > 0
+  /** The root row's dominant tint: the '' key of its owning repo's
+   *  decorations (the workspace root itself, when it is a repo). */
+  const rootBadge = cwd === undefined
+    ? undefined
+    : (() => {
+      const repo = owningRepo(repos, cwd)
+      return repo === undefined ? undefined : decorByKey.get(repo.key)?.dirBadges.get('')
+    })()
 
   const renderLevel = (dir: string, depth: number): ReactNode => {
     const level = data[dir]
@@ -503,6 +554,7 @@ export function FileTree(props: {
       if (entry.isDir) {
         const isOpen = expanded.includes(entry.path)
         const dirty = dirIsDirty(entry.path)
+        const dirBadge = dirBadgeOfPath(entry.path)
         return (
           <div key={entry.path}>
             <div
@@ -512,6 +564,7 @@ export function FileTree(props: {
                 css.explorerRow, css.explorerDir, entry.hidden && css.explorerHidden,
                 dropTarget === entry.path && css.explorerRowDropTarget,
               )}
+              {...(dirBadge !== undefined ? { 'data-git': dirBadge } : {})}
               style={{ paddingLeft: depth * 22 + 6 }}
               onClick={() => { onToggle(entry.path) }}
               onKeyDown={(event) => {
@@ -544,6 +597,7 @@ export function FileTree(props: {
             css.explorerRow, entry.hidden && css.explorerHidden, entry.broken && css.explorerBroken,
             dropTarget === parentOf(entry.path) && css.explorerRowDropTarget,
           )}
+          {...(badge !== undefined ? { 'data-git': badge } : {})}
           style={{ paddingLeft: depth * 22 + 6 }}
           title={entry.broken ? `${entry.path} — ${t('brokenSymlink')}` : entry.path}
           onClick={() => { onOpenFile(entry.path) }}
@@ -582,6 +636,7 @@ export function FileTree(props: {
         <>
           <div
             className={clsx(css.explorerRow, dropTarget === root && css.explorerRowDropTarget)}
+            {...(rootBadge !== undefined ? { 'data-git': rootBadge } : {})}
             style={{ paddingLeft: 6 }}
             onDragOver={(event) => { handleRowDragOver(event, root) }}
             onDrop={(event) => { handleDirDrop(event, root) }}

--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -19,8 +19,14 @@
  * caller: every request is reported through `onUploadRequest(dir, items)`
  * (VSCode semantics — a drop on a file row targets its parent directory),
  * and `busy` gates new drags while one upload is in flight.
+ *
+ * Git decorations: the working-tree status of the session workspace is
+ * fetched alongside the tree (mount + refresh tick — no watcher, KISS).
+ * Changed files carry a one-letter status badge after their name, and
+ * directories containing changes get a dot, VSCode-explorer style. Deleted
+ * files are not listed by the fs tree and therefore cannot carry a badge.
  */
-import { useCallback, useEffect, useRef, useState, type DragEvent, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent, type MouseEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import clsx from 'clsx'
 import {
@@ -29,7 +35,8 @@ import {
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { SiCursor, SiZedindustries } from 'react-icons/si'
 import { VscFile, VscFolder, VscFolderOpened, VscLinkExternal, VscPin, VscPinned } from 'react-icons/vsc'
-import { api, downloadUrl, type FsEntry } from './api.ts'
+import { api, downloadUrl, type FsEntry, type GitStatusResult } from './api.ts'
+import { gitDecorations, gitKey, gitRelOf } from './git-decor.ts'
 import { IconUploadOutline16, IconVscode16 } from './icons.tsx'
 import type { OpenWithTarget } from './open-with.ts'
 import { relativeTo } from './paths.ts'
@@ -53,6 +60,12 @@ export function baseName(path: string): string {
 function parentOf(path: string): string {
   const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
   return at <= 0 ? path : path.slice(0, at)
+}
+
+/** The decorations of a not-yet-fetched status snapshot (no marks at all). */
+const EMPTY_GIT_DECOR: { badges: Map<string, string>; dirtyDirs: Set<string> } = {
+  badges: new Map(),
+  dirtyDirs: new Set(),
 }
 
 /** Only OS file drags belong to the upload surface; in-app drags (tab reorder,
@@ -137,6 +150,8 @@ export function FileTree(props: {
   const { sessionId, cwd, expanded, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, openWithTargets, openWithPinned, openWithSsh, onOpenWith, onToggleOpenWithPin, onReferenceFile, refreshTick, onUploadRequest, busy } = props
   const [data, setData] = useState<Record<string, LevelData>>({})
   const dataRef = useRef(data)
+  /** Working-tree status of the session workspace (drives the row marks). */
+  const [git, setGit] = useState<GitStatusResult | null>(null)
   /** The row whose path was just copied ("copied" label replaces its button). */
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
   /** Open context menu: the row path (and whether it is a directory) plus the cursor position. */
@@ -274,6 +289,50 @@ export function FileTree(props: {
     for (const dir of expanded) loadDir(dir)
   }, [cwd, expanded, refreshTick, loadDir])
 
+  // The git decorations ride the same refresh affordance: fetched on mount
+  // and on every refresh tick (the tree has no file watcher — KISS).
+  useEffect(() => {
+    if (cwd === undefined) {
+      setGit(null)
+      return
+    }
+    let cancelled = false
+    api.gitStatus({ sessionId, cwd }).then((result) => {
+      if (!cancelled) setGit(result)
+    }).catch(() => {
+      if (!cancelled) setGit(null)
+    })
+    return () => { cancelled = true }
+  }, [sessionId, cwd, refreshTick])
+
+  /** The repo root used for path matching: the host-reported root when
+   *  available, else the workspace root itself (the common case — host
+   *  versions before the `root` field fall back to it; a cwd deeper inside
+   *  the repo then merely shows no marks, never wrong ones). */
+  const gitRoot = git !== null && git.isRepo ? (git.root ?? cwd) : undefined
+
+  /** Badge letter per repo-relative path key, plus the set of directories
+   *  whose subtree contains a changed file. Both are recomputed only when a
+   *  fresh status snapshot arrives. */
+  const gitDecor = useMemo(
+    () => (git === null ? EMPTY_GIT_DECOR : gitDecorations(git)),
+    [git],
+  )
+
+  /** The badge letter of an absolute row path (undefined when not in the repo). */
+  const badgeOfPath = (abs: string): string | undefined => {
+    if (gitRoot === undefined) return undefined
+    const rel = gitRelOf(gitRoot, abs)
+    return rel === undefined ? undefined : gitDecor.badges.get(gitKey(rel))
+  }
+
+  /** Whether a directory row's subtree contains at least one changed file. */
+  const dirIsDirty = (abs: string): boolean => {
+    if (gitRoot === undefined) return false
+    const rel = gitRelOf(gitRoot, abs)
+    return rel !== undefined && gitDecor.dirtyDirs.has(gitKey(rel))
+  }
+
   /** Copy `text`; on success flip the row's copied label for a moment. */
   const copyPath = useCallback((text: string, path: string): void => {
     void writeClipboard(text).then((ok) => {
@@ -406,6 +465,9 @@ export function FileTree(props: {
   }
 
   const root = cwd
+  /** The workspace root row marks any repo with pending changes (VSCode's
+   *  root-folder dot — the git panel remains the source of truth). */
+  const rootDirty = git !== null && git.isRepo && git.entries.length > 0
 
   const renderLevel = (dir: string, depth: number): ReactNode => {
     const level = data[dir]
@@ -423,6 +485,7 @@ export function FileTree(props: {
     return entries.map(entry => {
       if (entry.isDir) {
         const isOpen = expanded.includes(entry.path)
+        const dirty = dirIsDirty(entry.path)
         return (
           <div key={entry.path}>
             <div
@@ -446,6 +509,7 @@ export function FileTree(props: {
             >
               {isOpen ? <VscFolderOpened size={14} /> : <VscFolder size={14} />}
               <span className={css.explorerName}>{entry.name}</span>
+              {dirty && <span className={css.explorerGitDot} />}
               {entry.isSymlink && <IconLinkOutline16 size={12} className={css.explorerSymlink} />}
               {rowActions(entry)}
             </div>
@@ -453,6 +517,7 @@ export function FileTree(props: {
           </div>
         )
       }
+      const badge = badgeOfPath(entry.path)
       return (
         <div
           key={entry.path}
@@ -477,6 +542,7 @@ export function FileTree(props: {
         >
           <VscFile size={14} />
           <span className={css.explorerName}>{entry.name}</span>
+          {badge !== undefined && <span className={css.explorerGitBadge} data-git={badge}>{badge}</span>}
           {entry.isSymlink && <IconLinkOutline16 size={12} className={css.explorerSymlink} />}
           {rowActions(entry)}
         </div>
@@ -506,6 +572,7 @@ export function FileTree(props: {
           >
             <VscFolderOpened size={14} />
             <span className={css.explorerName}>{baseName(root)}</span>
+            {rootDirty && <span className={css.explorerGitDot} />}
             {copiedPath === root
               ? <span className={css.explorerCopied}>{t('copied')}</span>
               : (

--- a/src/client/GitView.tsx
+++ b/src/client/GitView.tsx
@@ -15,19 +15,11 @@ import {
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { GitLogEntry, GitStatusEntry, GitStatusResult, SessionScope } from './api.ts'
 import { api } from './api.ts'
+import { gitBadgeOf } from './git-decor.ts'
 import { relativeTo } from './paths.ts'
 import { relativeTime, t } from './locales.ts'
 import type { SidebarTab } from './state.ts'
 import css from './sidebar.module.css'
-
-/** The XY status letters a row badge shows (X = index, Y = worktree). */
-function badgeOf(entry: GitStatusEntry): string {
-  const index = entry.xy[0]
-  const worktree = entry.xy[1]
-  if (index !== undefined && index !== ' ' && index !== '?') return index
-  if (worktree !== undefined && worktree !== ' ' && worktree !== '?') return worktree
-  return '?'
-}
 
 /** Whether the entry carries STAGED (index) changes — the X letter is set. */
 function isStagedEntry(entry: GitStatusEntry): boolean {
@@ -46,7 +38,7 @@ function isUnstagedEntry(entry: GitStatusEntry): boolean {
 
 /** Whether the entry is untracked (`??`): git diff never includes it. */
 function isUntracked(entry: GitStatusEntry): boolean {
-  return badgeOf(entry) === '?'
+  return gitBadgeOf(entry) === '?'
 }
 
 /** The last path segment (tab title for a file's diff). */
@@ -261,7 +253,7 @@ export function GitView(props: {
           onClick={() => { openWorktreeDiff(entry, staged) }}
           onContextMenu={(event) => { openFileMenu(event, entry, staged) }}
         >
-          <span className={css.gitBadge}>{badgeOf(entry)}</span>
+          <span className={css.gitBadge}>{gitBadgeOf(entry)}</span>
           <span className={css.gitName}>{entry.path}</span>
         </button>
         <button

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -43,6 +43,8 @@ export interface GitStatusEntry {
 export interface GitStatusResult {
   isRepo: boolean
   branch?: string
+  /** The repository top level; `entries` paths are relative to it (absent when not a repo). */
+  root?: string
   entries: GitStatusEntry[]
 }
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -195,6 +195,10 @@ export const api = {
     fetchUpload<{ path: string; size: number }>(scope, dir, relativePath, body, signal),
   gitStatus: (scope: SessionScope, signal?: AbortSignal) =>
     call<GitStatusResult>('git.status', scopePayload(scope, {}), signal),
+  /** Status of one explicit directory (a nested repo root): the host runs
+   *  git against it directly instead of re-scoping to the session cwd. */
+  gitStatusAt: (scope: SessionScope, dir: string, signal?: AbortSignal) =>
+    call<GitStatusResult>('git.status', scopePayload(scope, { dir }), signal),
   gitDiff: (scope: SessionScope, path: string | undefined, staged: boolean, signal?: AbortSignal) =>
     call<{ diff: string }>('git.diff', scopePayload(scope, { ...(path !== undefined ? { path } : {}), staged }), signal),
   gitStage: (scope: SessionScope, path?: string) =>

--- a/src/client/git-decor.ts
+++ b/src/client/git-decor.ts
@@ -33,31 +33,57 @@ export function gitRelOf(root: string, abs: string): string | undefined {
   return rel === abs ? undefined : rel
 }
 
+/** Dominance order for a directory's status tint: the most salient letter
+ *  wins when a subtree mixes statuses (modified > added/untracked > deleted
+ *  > renamed), so a folder's color is deterministic. */
+const DIR_TINT_PRIORITY: Record<string, number> = { M: 4, A: 3, '?': 2, D: 1, R: 0 }
+
 /** The explorer decorations of one repository. */
 export interface GitDecorations {
   badges: Map<string, string>
   dirtyDirs: Set<string>
+  /** Dominant status letter per dirty directory ('' = the repo root itself). */
+  dirBadges: Map<string, string>
 }
 
 /** The explorer decorations derived from one status snapshot: the badge
- *  letter per repo-relative path key, and the set of directories whose
- *  subtree contains at least one changed file. */
+ *  letter per repo-relative path key, the set of directories whose subtree
+ *  contains at least one changed file, and the dominant status letter per
+ *  such directory (drives the folder-name tint). */
 export function gitDecorations(status: GitStatusResult): GitDecorations {
   const badges = new Map<string, string>()
   const dirtyDirs = new Set<string>()
+  const dirBadges = new Map<string, string>()
   if (!status.isRepo) {
-    return { badges, dirtyDirs }
+    return { badges, dirtyDirs, dirBadges }
+  }
+  const noteDir = (key: string, letter: string): void => {
+    const current = dirBadges.get(key)
+    if (current === undefined || (DIR_TINT_PRIORITY[letter] ?? 0) > (DIR_TINT_PRIORITY[current] ?? 0)) {
+      dirBadges.set(key, letter)
+    }
   }
   for (const entry of status.entries) {
     const key = gitKey(entry.path)
-    badges.set(key, gitBadgeOf(entry))
+    const letter = gitBadgeOf(entry)
+    badges.set(key, letter)
     let sep = key.lastIndexOf('/')
     while (sep > 0) {
-      dirtyDirs.add(key.slice(0, sep))
+      const dir = key.slice(0, sep)
+      dirtyDirs.add(dir)
+      noteDir(dir, letter)
       sep = key.lastIndexOf('/', sep - 1)
     }
   }
-  return { badges, dirtyDirs }
+  if (status.entries.length > 0) {
+    // The repo root folder itself carries the dominant letter over all
+    // entries (the repo-relative key '' never appears as an ancestor above).
+    const dominant = status.entries
+      .map(entry => gitBadgeOf(entry))
+      .sort((a, b) => (DIR_TINT_PRIORITY[b] ?? 0) - (DIR_TINT_PRIORITY[a] ?? 0))[0]
+    if (dominant !== undefined) noteDir('', dominant)
+  }
+  return { badges, dirtyDirs, dirBadges }
 }
 
 /**

--- a/src/client/git-decor.ts
+++ b/src/client/git-decor.ts
@@ -33,13 +33,16 @@ export function gitRelOf(root: string, abs: string): string | undefined {
   return rel === abs ? undefined : rel
 }
 
+/** The explorer decorations of one repository. */
+export interface GitDecorations {
+  badges: Map<string, string>
+  dirtyDirs: Set<string>
+}
+
 /** The explorer decorations derived from one status snapshot: the badge
  *  letter per repo-relative path key, and the set of directories whose
  *  subtree contains at least one changed file. */
-export function gitDecorations(status: GitStatusResult): {
-  badges: Map<string, string>
-  dirtyDirs: Set<string>
-} {
+export function gitDecorations(status: GitStatusResult): GitDecorations {
   const badges = new Map<string, string>()
   const dirtyDirs = new Set<string>()
   if (!status.isRepo) {
@@ -55,4 +58,25 @@ export function gitDecorations(status: GitStatusResult): {
     }
   }
   return { badges, dirtyDirs }
+}
+
+/**
+ * The deepest repository whose tree contains an absolute path, from a map
+ * of status snapshots keyed by the directory they were fetched for (the
+ * workspace root plus every visible directory carrying a `.git` entry).
+ * The effective matching root is the host-reported repo root when present
+ * (a cwd fetched from inside its repo), else the fetched directory itself.
+ */
+export function owningRepo(
+  repos: ReadonlyMap<string, GitStatusResult>,
+  abs: string,
+): { key: string; root: string; status: GitStatusResult } | undefined {
+  let best: { key: string; root: string; status: GitStatusResult } | undefined
+  for (const [key, status] of repos) {
+    if (!status.isRepo) continue
+    const root = status.root !== undefined && status.root !== '' ? status.root : key
+    if (gitRelOf(root, abs) === undefined) continue
+    if (best === undefined || root.length > best.root.length) best = { key, root, status }
+  }
+  return best
 }

--- a/src/client/git-decor.ts
+++ b/src/client/git-decor.ts
@@ -1,0 +1,58 @@
+/**
+ * Git decoration derivation for the explorer rows: turns one working-tree
+ * status snapshot into the path-keyed marks the file tree renders (badge
+ * letters on changed files, containment dots on their ancestor directories).
+ *
+ * Pure client logic (no DOM, no network) so the mapping is unit-testable
+ * without mounting the tree; the host remains the authority for path
+ * semantics, mirrored through `paths.ts`.
+ */
+import type { GitStatusEntry, GitStatusResult } from './api.ts'
+import { relativeTo } from './paths.ts'
+
+/** One status letter for a git entry (X = index, Y = worktree). */
+export function gitBadgeOf(entry: GitStatusEntry): string {
+  const index = entry.xy[0]
+  const worktree = entry.xy[1]
+  if (index !== undefined && index !== ' ' && index !== '?') return index
+  if (worktree !== undefined && worktree !== ' ' && worktree !== '?') return worktree
+  return '?'
+}
+
+/** Comparison key for a repo-relative path: '/' separators, lowercase (the
+ *  containment test must not depend on casing — see relativeTo). */
+export function gitKey(path: string): string {
+  return path.replace(/\\/g, '/').toLowerCase()
+}
+
+/** The repo-relative key of an absolute path under the git root ('' = the
+ *  root itself), or undefined when the path lies outside the repo. */
+export function gitRelOf(root: string, abs: string): string | undefined {
+  const rel = relativeTo(root, abs)
+  if (rel === '.') return ''
+  return rel === abs ? undefined : rel
+}
+
+/** The explorer decorations derived from one status snapshot: the badge
+ *  letter per repo-relative path key, and the set of directories whose
+ *  subtree contains at least one changed file. */
+export function gitDecorations(status: GitStatusResult): {
+  badges: Map<string, string>
+  dirtyDirs: Set<string>
+} {
+  const badges = new Map<string, string>()
+  const dirtyDirs = new Set<string>()
+  if (!status.isRepo) {
+    return { badges, dirtyDirs }
+  }
+  for (const entry of status.entries) {
+    const key = gitKey(entry.path)
+    badges.set(key, gitBadgeOf(entry))
+    let sep = key.lastIndexOf('/')
+    while (sep > 0) {
+      dirtyDirs.add(key.slice(0, sep))
+      sep = key.lastIndexOf('/', sep - 1)
+    }
+  }
+  return { badges, dirtyDirs }
+}

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -811,6 +811,14 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 .explorerGitBadge[data-git='D'] { color: var(--dsw-alias-state-error-primary); }
 .explorerGitBadge[data-git='R'] { color: var(--dsw-alias-brand-primary); }
 
+/* Changed file NAMES take the same status tint (VSCode-explorer style): the
+   whole name reads at a glance, the letter badge stays as the exact mark. */
+.explorerRow[data-git='M'] .explorerName { color: var(--dsw-alias-state-warn-primary); }
+.explorerRow[data-git='A'] .explorerName,
+.explorerRow[data-git='?'] .explorerName { color: var(--dsw-alias-state-success-primary); }
+.explorerRow[data-git='D'] .explorerName { color: var(--dsw-alias-state-error-primary); }
+.explorerRow[data-git='R'] .explorerName { color: var(--dsw-alias-brand-primary); }
+
 /* The containment dot on directory rows (incl. the workspace root) whose
    subtree holds at least one changed file. */
 .explorerGitDot {

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -796,6 +796,31 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   white-space: nowrap;
 }
 
+/* The git status badge on changed file rows (VSCode-explorer style): a
+   one-letter mark right after the name, tinted by status type — modified =
+   warn, added/untracked = success, deleted = error, renamed = brand. */
+.explorerGitBadge {
+  flex: none;
+  font: var(--dsw-font-xxxs-strong-11);
+  color: var(--dsw-alias-label-tertiary);
+}
+
+.explorerGitBadge[data-git='M'] { color: var(--dsw-alias-state-warn-primary); }
+.explorerGitBadge[data-git='A'] { color: var(--dsw-alias-state-success-primary); }
+.explorerGitBadge[data-git='?'] { color: var(--dsw-alias-state-success-primary); }
+.explorerGitBadge[data-git='D'] { color: var(--dsw-alias-state-error-primary); }
+.explorerGitBadge[data-git='R'] { color: var(--dsw-alias-brand-primary); }
+
+/* The containment dot on directory rows (incl. the workspace root) whose
+   subtree holds at least one changed file. */
+.explorerGitDot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--dsw-alias-label-secondary);
+}
+
 /* The hover-revealed @-reference button at the row's far right (and the
    transient "copied" label that replaces it after a copy). Hidden rows
    keep the name at full width; hovering or focusing the row reveals it. */

--- a/src/git.ts
+++ b/src/git.ts
@@ -22,6 +22,8 @@ export interface GitStatusEntry {
 export interface GitStatusResult {
   isRepo: boolean
   branch?: string
+  /** The repository top level ('' when not a repo); `entries` paths are relative to it. */
+  root?: string
   entries: GitStatusEntry[]
 }
 
@@ -155,11 +157,12 @@ export async function currentBranch(cwd: string): Promise<string> {
 export async function status(cwd: string): Promise<GitStatusResult> {
   const repo = await isGitRepo(cwd)
   if (!repo) return { isRepo: false, entries: [] }
-  const [branch, raw] = await Promise.all([
+  const [branch, root, raw] = await Promise.all([
     currentBranch(cwd).catch(() => 'HEAD'),
+    repoRoot(cwd).catch(() => cwd),
     runGit(cwd, ['status', '--porcelain=v1', '-z', '--untracked-files=all']),
   ])
-  return { isRepo: true, branch, entries: parsePorcelainZ(raw) }
+  return { isRepo: true, branch, root, entries: parsePorcelainZ(raw) }
 }
 
 /** Diff text of the worktree (unstaged) or the index (staged). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,12 @@ function buildApi(
     },
     'git.status': async (payload) => {
       const { cwd } = cwdOf(payload)
-      return git.status(cwd)
+      const record = payload as { dir?: unknown }
+      // An explicit `dir` (absolute, caller-validated) overrides the session
+      // cwd: the explorer's nested-repo sweep fetches each repository's own
+      // status, and the session header cwd must not re-scope those calls.
+      const target = record.dir === undefined ? cwd : requireAbsolute(requireString(payload, 'dir'))
+      return git.status(target)
     },
     'git.diff': async (payload) => {
       const { cwd } = cwdOf(payload)

--- a/tests/file-tree-drop.spec.tsx
+++ b/tests/file-tree-drop.spec.tsx
@@ -37,6 +37,7 @@ vi.mock('../src/client/api.ts', () => ({
     // The tree's git decorations ride on the status snapshot; the stub keeps
     // the workspace outside any repo so no row marks are expected.
     gitStatus: async () => ({ isRepo: false, entries: [] }),
+    gitStatusAt: async () => ({ isRepo: false, entries: [] }),
   },
   downloadUrl: () => '/sidebar/file',
 }))

--- a/tests/file-tree-drop.spec.tsx
+++ b/tests/file-tree-drop.spec.tsx
@@ -34,6 +34,9 @@ vi.mock('../src/client/api.ts', () => ({
         { name: 'a.ts', path: '/tmp/a.ts', isDir: false },
       ],
     }),
+    // The tree's git decorations ride on the status snapshot; the stub keeps
+    // the workspace outside any repo so no row marks are expected.
+    gitStatus: async () => ({ isRepo: false, entries: [] }),
   },
   downloadUrl: () => '/sidebar/file',
 }))

--- a/tests/file-tree-open-with.spec.tsx
+++ b/tests/file-tree-open-with.spec.tsx
@@ -26,6 +26,9 @@ vi.mock('../src/client/api.ts', () => ({
     fsTree: async () => ({
       entries: [{ name: 'a.ts', path: '/tmp/a.ts', isDir: false }],
     }),
+    // The tree's git decorations ride on the status snapshot; the stub keeps
+    // the workspace outside any repo so no row marks are expected.
+    gitStatus: async () => ({ isRepo: false, entries: [] }),
   },
   downloadUrl: () => '/sidebar/file',
 }))

--- a/tests/file-tree-open-with.spec.tsx
+++ b/tests/file-tree-open-with.spec.tsx
@@ -29,6 +29,7 @@ vi.mock('../src/client/api.ts', () => ({
     // The tree's git decorations ride on the status snapshot; the stub keeps
     // the workspace outside any repo so no row marks are expected.
     gitStatus: async () => ({ isRepo: false, entries: [] }),
+    gitStatusAt: async () => ({ isRepo: false, entries: [] }),
   },
   downloadUrl: () => '/sidebar/file',
 }))

--- a/tests/git-decor.spec.ts
+++ b/tests/git-decor.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { gitBadgeOf, gitDecorations, gitKey, gitRelOf } from '../src/client/git-decor.ts'
+import type { GitStatusResult } from '../src/client/api.ts'
+
+/** A minimal status snapshot fixture. */
+function status(entries: GitStatusResult['entries'], root = '/Users/me/code'): GitStatusResult {
+  return { isRepo: true, branch: 'main', root, entries }
+}
+
+describe('gitBadgeOf', () => {
+  it('prefers the index letter, then the worktree letter', () => {
+    expect(gitBadgeOf({ path: 'a.ts', xy: 'M ' })).toBe('M')
+    expect(gitBadgeOf({ path: 'a.ts', xy: ' M' })).toBe('M')
+    expect(gitBadgeOf({ path: 'a.ts', xy: 'MM' })).toBe('M')
+    expect(gitBadgeOf({ path: 'a.ts', xy: 'A ' })).toBe('A')
+    expect(gitBadgeOf({ path: 'a.ts', xy: ' D' })).toBe('D')
+  })
+
+  it('maps untracked (??) to the "?" mark', () => {
+    expect(gitBadgeOf({ path: 'new.ts', xy: '??' })).toBe('?')
+  })
+})
+
+describe('gitKey / gitRelOf', () => {
+  it('normalizes separators and casing for comparison keys', () => {
+    expect(gitKey('src/A.ts')).toBe('src/a.ts')
+    expect(gitKey('a\\b.ts')).toBe('a/b.ts')
+  })
+
+  it('derives repo-relative keys from absolute paths (and "" for the root)', () => {
+    expect(gitRelOf('/Users/me/code', '/Users/me/code/src/main.ts')).toBe('src/main.ts')
+    expect(gitRelOf('/Users/me/code', '/Users/me/code')).toBe('')
+    expect(gitRelOf('C:\\Users\\me\\code', 'C:\\Users\\me\\code\\src\\a.ts')).toBe('src/a.ts')
+  })
+
+  it('returns undefined for paths outside the repo', () => {
+    expect(gitRelOf('/Users/me/code', '/Users/other/x.ts')).toBe(undefined)
+    expect(gitRelOf('/Users/me/code', '/Users/me/codex/y.ts')).toBe(undefined)
+  })
+})
+
+describe('gitDecorations', () => {
+  it('yields nothing outside a repo', () => {
+    expect(gitDecorations({ isRepo: false, entries: [] })).toEqual({ badges: new Map(), dirtyDirs: new Set() })
+  })
+
+  it('maps one badge letter per changed path', () => {
+    const { badges } = gitDecorations(status([
+      { path: 'src/a.ts', xy: ' M' },
+      { path: 'src/new.ts', xy: '??' },
+      { path: 'old.ts', xy: ' D' },
+    ]))
+    expect(badges.get('src/a.ts')).toBe('M')
+    expect(badges.get('src/new.ts')).toBe('?')
+    expect(badges.get('old.ts')).toBe('D')
+  })
+
+  it('marks every ancestor directory of a changed file (untracked nested too)', () => {
+    const { dirtyDirs } = gitDecorations(status([
+      { path: 'src/deep/dir/new.ts', xy: '??' },
+    ]))
+    expect(dirtyDirs.has('src')).toBe(true)
+    expect(dirtyDirs.has('src/deep')).toBe(true)
+    expect(dirtyDirs.has('src/deep/dir')).toBe(true)
+    expect(dirtyDirs.size).toBe(3)
+  })
+
+  it('keeps directories untouched when only the root file changes', () => {
+    const { dirtyDirs } = gitDecorations(status([{ path: 'a.ts', xy: 'M ' }]))
+    expect(dirtyDirs.size).toBe(0)
+  })
+})

--- a/tests/git-decor.spec.ts
+++ b/tests/git-decor.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { gitBadgeOf, gitDecorations, gitKey, gitRelOf } from '../src/client/git-decor.ts'
+import {
+  gitBadgeOf, gitDecorations, gitKey, gitRelOf, owningRepo,
+} from '../src/client/git-decor.ts'
 import type { GitStatusResult } from '../src/client/api.ts'
 
 /** A minimal status snapshot fixture. */
@@ -68,5 +70,41 @@ describe('gitDecorations', () => {
   it('keeps directories untouched when only the root file changes', () => {
     const { dirtyDirs } = gitDecorations(status([{ path: 'a.ts', xy: 'M ' }]))
     expect(dirtyDirs.size).toBe(0)
+  })
+})
+
+describe('owningRepo', () => {
+  const nested = new Map<string, GitStatusResult>([
+    // The workspace root is NOT a repo; its children are.
+    ['/Users/me', { isRepo: false, entries: [] }],
+    ['/Users/me/code', status([{ path: 'src/a.ts', xy: ' M' }])],
+    ['/Users/me/code/vendor', status([{ path: 'lib.ts', xy: '??' }], '/Users/me/code/vendor')],
+  ])
+
+  it('picks the deepest repo containing the path', () => {
+    const repo = owningRepo(nested, '/Users/me/code/src/a.ts')
+    expect(repo).not.toBe(undefined)
+    expect(repo!.key).toBe('/Users/me/code')
+    expect(repo!.root).toBe('/Users/me/code')
+    // A path inside a nested repo resolves to THAT repo, not its parent.
+    const vendor = owningRepo(nested, '/Users/me/code/vendor/lib.ts')
+    expect(vendor!.key).toBe('/Users/me/code/vendor')
+  })
+
+  it('matches via the host-reported root when the fetch dir is deeper', () => {
+    const repos = new Map<string, GitStatusResult>([
+      ['/Users/me/code/src', status([{ path: 'src/a.ts', xy: 'M ' }], '/Users/me/code')],
+    ])
+    const repo = owningRepo(repos, '/Users/me/code/src/a.ts')
+    expect(repo).not.toBe(undefined)
+    expect(repo!.key).toBe('/Users/me/code/src')
+    expect(repo!.root).toBe('/Users/me/code')
+  })
+
+  it('yields nothing when no repo contains the path', () => {
+    expect(owningRepo(nested, '/Users/other/x.ts')).toBe(undefined)
+    // Non-repo snapshots never match.
+    const repos = new Map<string, GitStatusResult>([['/Users/me', { isRepo: false, entries: [] }]])
+    expect(owningRepo(repos, '/Users/me/a.ts')).toBe(undefined)
   })
 })

--- a/tests/git-decor.spec.ts
+++ b/tests/git-decor.spec.ts
@@ -43,7 +43,9 @@ describe('gitKey / gitRelOf', () => {
 
 describe('gitDecorations', () => {
   it('yields nothing outside a repo', () => {
-    expect(gitDecorations({ isRepo: false, entries: [] })).toEqual({ badges: new Map(), dirtyDirs: new Set() })
+    expect(gitDecorations({ isRepo: false, entries: [] })).toEqual({
+      badges: new Map(), dirtyDirs: new Set(), dirBadges: new Map(),
+    })
   })
 
   it('maps one badge letter per changed path', () => {
@@ -70,6 +72,28 @@ describe('gitDecorations', () => {
   it('keeps directories untouched when only the root file changes', () => {
     const { dirtyDirs } = gitDecorations(status([{ path: 'a.ts', xy: 'M ' }]))
     expect(dirtyDirs.size).toBe(0)
+  })
+
+  it('tints each dirty directory with its dominant status letter', () => {
+    const { dirBadges } = gitDecorations(status([
+      { path: 'src/a.ts', xy: ' M' },
+      { path: 'src/deep/new.ts', xy: '??' },
+      { path: 'src/deep/gone.ts', xy: ' D' },
+    ]))
+    // 'src' holds M (priority 4) and '?' (2) → M wins.
+    expect(dirBadges.get('src')).toBe('M')
+    // 'src/deep' holds '?' (2) and D (1) → '?' wins.
+    expect(dirBadges.get('src/deep')).toBe('?')
+    // The repo root itself carries the overall dominant letter (M).
+    expect(dirBadges.get('')).toBe('M')
+  })
+
+  it('tints the repo root folder over mixed root-level statuses', () => {
+    const { dirBadges } = gitDecorations(status([
+      { path: 'a.ts', xy: '??' },
+      { path: 'b.ts', xy: ' R' },
+    ]))
+    expect(dirBadges.get('')).toBe('?')
   })
 })
 


### PR DESCRIPTION
## What

The explorer file tree now surfaces the working-tree git status the way a VSCode explorer does:

- Changed files carry a one-letter status badge after their name (`M` / `A` / `?` / `D` / `R`), and the file name itself is tinted by status (modified = warn, added or untracked = success, deleted = error, renamed = brand), fully token-driven.
- Directories whose subtree holds changes get a containment dot, and their name is tinted with the dominant status of the subtree (modified > added/untracked > deleted > renamed); the repo root folder is included.
- Nested repositories are discovered automatically: on mount the root level is swept for `.git` entries (each visible directory is probed), and expanding a repo directory also discovers it — the workspace folder is often not a repo itself, its children are.

## Host change

`git.status` now accepts an explicit `dir` field. Without it the session-header cwd wins, so every nested status fetch was silently re-scoped to the workspace root (which is frequently not a repo) and per-repository marks never appeared. The `dir` is validated as absolute like the other routes.

## Tests

`tests/git-decor.spec.ts` covers badge / dirtiness / dominant-tint derivation and the owning-repo lookup; the FileTree api mocks were extended accordingly.

No behavior change for existing consumers: the `dir` field is optional and `git.status` without it behaves exactly as before.