### PR TITLE
feat(host): session backend seam for out-of-process workspaces

### DIFF
--- a/docs/plans/2026-08-25-session-backend-seam-design.md
+++ b/docs/plans/2026-08-25-session-backend-seam-design.md
@@ -1,0 +1,204 @@
+# Session Backend Seam 设计文档
+
+- 日期：2026-08-25
+- 分支：`feat/session-backend-seam`
+- 关联 issue：#238（dsh-remote SSH 会话下侧边栏无法识别目标机工作区）
+- 状态：设计 + 实现
+
+## 1. 背景
+
+侧边栏的扩展哲学在 **client 半是完整的**：`ctx.betterSidebar.registerTab` / `registerFileViewer` 让任意插件贡献页面与文件预览器，`features` 做能力协商，声明式设置让插件登记自己的开关。
+
+**host 半的扩展点是零**。`AGENTS.md` §7 明确写着「host 半无此服务：`ctx.betterSidebar` 只在 client 侧存在；host 半需要 better-sidebar 数据走 `/sidebar/api/*` HTTP 路由」——但那句话解决的是「读」，不解决「写」：host 半把三件事焊死在本进程上。
+
+| 能力 | 当前实现 | 焊死在哪 |
+|---|---|---|
+| 文件树 / 读写 / 搜索 | `buildApi` 里直接 `node:fs` | 本机文件系统 |
+| Git 面板 | `git.ts` 直接 spawn | 本机 git |
+| 终端 | `PtyManager` + `/sidebar/ws/terminal` | 本机 node-pty |
+
+只要一个会话的工作区**不在本进程所在的机器上**，整个侧边栏就失效。
+
+### 1.1 这不是单一插件的问题
+
+- **#238（dsh-remote，第三方报告，本设计的直接触发点）**：用户通过 `dsh-remote` 插件 SSH 到目标机器工作，侧边栏读的仍是主机的文件系统，「无法去识别目标机器上的工作区内容」。
+- **容器 / 云沙箱会话**：会话的 cwd 在容器内，宿主机路径无意义。
+- **多节点编排**：会话由另一台节点拥有，本机只是 ingress。
+
+三者的形状完全相同：**某些 sessionId 的文件与终端字节不该来自本进程**。当前架构下，每种远程形态都只能 fork 侧边栏——这正是本设计要消除的。
+
+## 2. 目标与非目标
+
+**目标**：给 host 半开一个与 client 半对称的扩展点，让插件能为**它认领的会话**提供文件 / Git / 终端的替代后端，并且——
+
+- 不认领的会话**零开销**：本地路径一个分支判断，不新增网络跳、不改变现有语义；
+- 后端缺席 / 卸载后自动回退本地；
+- 接口只描述「会话的字节从哪来」，不含任何具体传输（SSH / 联邦 / 容器）的概念。
+
+**非目标（KISS 排除项）**：
+
+- 不做后端发现、健康检查、重试与熔断——那是后端插件自己的事；
+- 不做部分认领（一个会话要么整体归后端，要么整体本地），避免「文件远程但 git 本地」这类无法解释的半吊子状态；
+- 不代理 client 半，浏览器侧代码零改动（后端对前端完全透明）；
+- 不导出全局设置、浏览器探针、依赖状态与 agent 终端（UUID 寻址）等与会话工作区无关的方法。
+
+## 3. 接口
+
+两个可选 host 服务，互相独立：一个让插件**接管**会话（消费侧），一个让插件**借用**本地会话能力（提供侧）。
+
+### 3.1 `sidebarSessionBackends`（消费侧）
+
+```ts
+/** 一次会话作用域的 JSON 调用结果。 */
+type SessionBackendResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: { code: string; message: string; details?: Record<string, unknown> } }
+
+/** 二进制读取结果（媒体 / HTML 路由）。 */
+type SessionBackendBinaryResult =
+  | { ok: true; status: number; headers: Readonly<Record<string, string>>; body: Uint8Array }
+  | { ok: false; error: { code: string; message: string; details?: Record<string, unknown> } }
+
+interface SidebarSessionBackend {
+  /** 诊断用的稳定标识（日志、冲突排查）。 */
+  readonly id: string
+  /**
+   * 该 sessionId 是否归此后端管。必须是廉价纯判断（每次 API 调用都会问）：
+   * 按 id 形状 / 前缀 / 自有注册表判断，不要做 I/O。抛错视为不认领。
+   */
+  claimSession(sessionId: string): boolean
+  /** 执行一次被认领会话的 JSON API 方法（方法名同 `/sidebar/api/<method>`）。 */
+  invoke(method: string, sessionId: string, payload: unknown, signal?: AbortSignal): Promise<SessionBackendResult>
+  /** 执行一次二进制读取（`file.read` / `html.read`）。 */
+  invokeBinary(method: string, sessionId: string, payload: unknown, signal?: AbortSignal): Promise<SessionBackendBinaryResult>
+  /**
+   * 接管一个已完成 upgrade 的终端 WebSocket。侧边栏交出 socket 后不再读写它，
+   * 生命周期（关闭、错误、重连宽限）由后端全权负责。
+   * 不实现时该后端的会话无法开终端（文件 / Git 仍可用）。
+   */
+  attachTerminal?(ws: WebSocket, sessionId: string, tab: string | null, options: { reconnectGraceMs: number }): void
+}
+
+interface SidebarSessionBackendRegistry {
+  /** 注册后端；返回 disposer（用 `ctx.effect` 包裹以获得 HMR 安全）。 */
+  register(backend: SidebarSessionBackend): () => void
+}
+
+// ctx.sidebarSessionBackends —— 由侧边栏 host 半 provide
+```
+
+**认领与路由规则**
+
+1. 每次 `/sidebar/api/<method>`、`/sidebar/file`、`/sidebar/html`、`/sidebar/ws/terminal` 请求，按注册顺序问各后端 `claimSession(sessionId)`，**第一个返回 true 的赢**（先到先得，与 client 侧 `urlTarget` 同款语义）；
+2. 无人认领 → 原本地路径，逐字节不变；
+3. 只有**会话作用域方法**可路由（见 §3.3 白名单）；白名单外的方法即使会话被认领也走本地（全局设置、浏览器探针、依赖状态等本就与工作区无关）；
+4. 后端返回 `ok:false` 时，`code` 为 `session-not-found` 映射 404，其余映射 502——后端故障不伪装成本地文件系统错误。
+
+### 3.2 `sidebarHostApi`（提供侧）
+
+远程场景是两端的：ingress 端要把请求送出去，**owner 端要把本地能力借出来**。owner 端插件此前只能重新实现一遍文件树 / Git / 终端逻辑（或 fork），现在直接取用：
+
+```ts
+interface SidebarHostApiService {
+  /**
+   * 一份 owner-strict 的会话 API 表：cwd **只**取自 Session header，
+   * 绝不接受调用方传入的 cwd，也不回退 process.cwd()。
+   *
+   * 本地 UI 的 cwd 解析带水化回退（首帧 Session 尚未就绪时用客户端提示值），
+   * 那对同机浏览器是合理的；但对跨机调用方，回退会把一次路由错误变成
+   * 「访问了一个无关目录」。owner-strict 关掉全部回退：Session 不存在或
+   * 无 cwd 直接 404。
+   */
+  createSessionApi(): {
+    invoke(method: string, sessionId: string, payload: unknown): Promise<SessionBackendResult>
+    invokeBinary(method: string, sessionId: string, payload: unknown): Promise<SessionBackendBinaryResult>
+    /** 可路由的会话作用域方法白名单（供后端声明自己的能力清单）。 */
+    readonly methods: { readonly read: readonly string[]; readonly write: readonly string[]; readonly binary: readonly string[] }
+  }
+}
+
+// ctx.sidebarHostApi —— 由侧边栏 host 半 provide
+```
+
+一个远程后端插件的完整形状因此是：**ingress 端注册 `SidebarSessionBackend`，owner 端消费 `sidebarHostApi`**，中间那段传输（SSH / RPC / 联邦）完全是它自己的事，侧边栏不需要知道。
+
+### 3.3 会话作用域方法白名单
+
+```
+read:   session.cwd, fs.tree, fs.search, fs.read,
+        git.status, git.diff, git.branch, git.log, git.commit-diff, git.show,
+        jobs.output, terminal.read
+write:  fs.write, git.stage, git.unstage, git.commit, git.checkout,
+        git.discard, git.revert, git.cherry-pick,
+        pty.close, jobs.kill,
+        terminal.open, terminal.input, terminal.resize, terminal.terminate, terminal.detach
+binary: file.read, html.read
+```
+
+**刻意排除**：`settings.*`（全局，非会话）、`browser.probe`（探针指向 ingress 自己的网络）、`deps.status`（本机 node-pty 安装状态）、agent 终端（按 UUID 寻址，属于本机 agent 运行时）。
+
+### 3.4 终端读取模型
+
+远程终端不能共享本地 `attachTerminal` 的「pty 事件直推」路径——中间隔着一次 RPC。因此 `PtyManager` 增加两个单调计数器，让 owner 端可以**按偏移拉取**：
+
+```ts
+interface SidebarPty {
+  transcript: string       // 既有：有界回放缓冲（超限丢头部）
+  outputOffset: number     // 新增：spawn 至今的单调输出偏移
+  transcriptBase: string   // 新增：transcript[0] 对应的偏移
+}
+```
+
+`terminal.read({ tab, offset })` 返回 `{ offset, next, data, base, exited, exitCode }`。调用方按 `next` 推进；`offset` 落在 `base` 之前（缓冲已滚过）时钳到 `base`，即丢失最早的输出而不是报错——与本地 tab 超限丢头部的行为一致。
+
+这两个字段对本地路径**完全惰性**（只是两个加法），不改变既有回放语义。
+
+## 4. 实现要点
+
+- `src/session-backend.ts`（新文件）：注册表实现、白名单常量、`claimBackendFor(sessionId)` 解析（含 `claimSession` 抛错的吞并降级）、`ownerSessionCwdOf`（owner-strict cwd 解析）。
+- `src/index.ts`：
+  - `buildApi` 增加 `cwdMode: 'local-fallbacks' | 'owner-strict'` 与 `ownerSessionGet` 两个**带默认值**的参数——本地调用点一字不改；
+  - `/sidebar/api` handler 在 `api[method]` 之前插入认领判断；
+  - `/sidebar/file`、`/sidebar/html` 同理，认领时转 `invokeBinary` 并原样回写 status/headers/body；
+  - `/sidebar/ws/terminal` 在 `handleUpgrade` 回调内判断认领，命中则把 ws 交给 `backend.attachTerminal`，未实现该可选方法时以 1011 关闭并给出明确原因；
+  - `ctx.provide('sidebarSessionBackends', ...)` 与 `ctx.provide('sidebarHostApi', ...)`。
+- `src/context-types.ts`：两个服务面加入 `SidebarContextShape`，并从包根导出类型供后端插件消费。
+- 服务查找不引入轮询：注册表由侧边栏自己 provide，后端插件用标准 `inject` + `ctx.effect` 注册，Cordis 保证顺序。
+
+## 5. 安全边界
+
+| 边界 | 规则 |
+|---|---|
+| cwd 权威性 | owner-strict 模式下 cwd **只**来自 Session header；调用方 payload 里的 `cwd` 字段在转发前被显式删除，不因藏在普通字段里而生效 |
+| sessionId 权威性 | 转发时 sessionId 由路由层决定并覆写 payload，后端 handler 不接受 payload 里的 sessionId |
+| 路径围栏 | owner 端二进制读取保持既有 `requireAbsolute` + `isWithin(cwd, path)` 围栏，与本地路由同一套 |
+| 方法面 | 白名单是允许列表而非拒绝列表：新增 API 方法默认**不可**远程路由，需显式加入 |
+| 认领谓词 | `claimSession` 抛错视为不认领（降级本地），不让一个坏后端拖垮整个侧边栏 |
+
+## 6. 测试
+
+`tests/session-backend.spec.ts`：
+
+1. 未注册后端时所有路由走本地（回归保护）；
+2. 单后端认领 → JSON / 二进制 / 终端三条路径均转发，且 payload 里的 `cwd` 被剥离、`sessionId` 被覆写；
+3. 多后端按注册顺序先到先得；先注册者不认领时顺延；
+4. `claimSession` 抛错 → 降级本地，不冒泡；
+5. disposer 调用后回退本地；
+6. 白名单外方法即使会话被认领仍走本地；
+7. owner-strict：Session 缺失 → 404、无 cwd → 404、相对 cwd → 400；绝不回退 `process.cwd()`；
+8. `terminal.read` 偏移语义：正常推进、offset 落后于 base 时钳制、exited 后仍可读尾部；
+9. 后端 `attachTerminal` 缺席时终端 WS 以明确原因关闭。
+
+## 7. 兼容性
+
+- 纯增量：不改任何既有签名的**调用点**，不改 client 半，不改持久化格式，不改 `/sidebar/api` 线格式；
+- 无后端安装时行为与 v0.16.0 逐字节一致；
+- 市场清单约束（依赖字段不得出现 `cordis`、无生命周期脚本）不受影响；
+- 服务均为可选：`ctx.get('sidebarSessionBackends')` 缺席时后端插件自行降级，反向亦然。
+
+## 8. 已知消费者
+
+| 消费者 | 形态 | 状态 |
+|---|---|---|
+| `@fzhiyu/dsh-federation` | ingress 注册后端 + owner 消费 `sidebarHostApi`，跨节点会话 | 本 PR 的实证消费者，已在真实多节点部署验证（此前靠 fork 侧边栏实现，本设计即为消灭该 fork） |
+| `dsh-remote`（#238） | ingress 注册后端，SSH 会话的文件 / Git / 终端走 SSH 通道 | 按同一接口可修复，无需改侧边栏 |

--- a/dsh.plugin.json
+++ b/dsh.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "dsh-external/dsh-better-sidebar",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "main": "./lib/index.js",
   "description": "VSCode 风格右侧侧边栏：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器，按会话隔离。暴露服务供其他插件注册侧边栏页面和文件预览器",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-better-sidebar",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "DSH web plugin: a VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per conversation session. Exposes a service for other plugins to register sidebar tabs and file viewers.",
   "type": "module",
   "repository": {

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -470,7 +470,7 @@ export function matchUrlTarget(tabs: readonly TabDescriptor[], url: URL): TabDes
  * The plugin version this service instance reports. Keep in lockstep with
  * `package.json`'s version — `tests/service.spec.ts` asserts the pair.
  */
-export const SIDEBAR_SERVICE_VERSION = '0.16.0'
+export const SIDEBAR_SERVICE_VERSION = '0.17.0'
 
 /**
  * Monotonic capability list consumers use to gate new API usage (features

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -30,6 +30,11 @@
  */
 import type { Context as CordisContext } from '@deepseek-ai/cordis'
 import type { BetterSidebarService } from './client/service.ts'
+import type {
+  SessionBackendBinaryResult,
+  SessionBackendResult,
+  SidebarSessionBackendRegistry,
+} from './session-backend.ts'
 
 /** The request face route handlers see (structural subset of node's
  *  IncomingMessage: the URL/method/header reads and the async body
@@ -566,12 +571,46 @@ export interface SidebarContextShape {
    */
   betterSidebar: BetterSidebarService
   /**
+   * The host-side session backend registry: plugins whose sessions live
+   * elsewhere (SSH, container, another node) claim them here and serve the
+   * session-scoped API for them. Provided by the host half; undefined on the
+   * client side. See ./session-backend.ts.
+   */
+  sidebarSessionBackends: SidebarSessionBackendRegistry
+  /**
+   * The owner half of the same seam: the real file / Git / terminal
+   * implementations behind an owner-strict cwd resolver, so a backend's owner
+   * node borrows them instead of reimplementing them. Host side only.
+   */
+  sidebarHostApi: SidebarHostApiService
+  /**
    * String-keyed session feed subscribe (the vendored cordis `on` is keyed
    * to its typed Events map; the harness session feed is a plain string
    * event). The listener receives every appended session event with the
    * LIVE Session instance that appended it.
    */
   on(event: string, listener: (session: unknown, event: SidebarSessionEvent) => void): () => void
+}
+
+/**
+ * The owner half of the session backend seam: the sidebar's own file / Git /
+ * terminal implementations, bound to a cwd resolver that trusts only the
+ * session header. A remote backend's owner node consumes this instead of
+ * reimplementing the workspace surface.
+ */
+export interface SidebarHostApiService {
+  createSessionApi(): {
+    /** Run one session-scoped JSON method against the owner-local workspace. */
+    invoke(method: string, sessionId: string, payload: unknown): Promise<SessionBackendResult>
+    /** Run one session-scoped binary read (`file.read` / `html.read`). */
+    invokeBinary(method: string, sessionId: string, payload: unknown): Promise<SessionBackendBinaryResult>
+    /** The routable method names, for a backend declaring its capabilities. */
+    readonly methods: {
+      readonly read: readonly string[]
+      readonly write: readonly string[]
+      readonly binary: readonly string[]
+    }
+  }
 }
 
 /**
@@ -590,5 +629,7 @@ export type Context = CordisContext & SidebarContextShape
 declare module '@deepseek-ai/cordis' {
   interface Context {
     betterSidebar: BetterSidebarService
+    sidebarSessionBackends: SidebarSessionBackendRegistry
+    sidebarHostApi: SidebarHostApiService
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,22 @@ import {
   type SidebarConfig,
   type SidebarPrefs,
 } from './config.ts'
-import { parentOf, requireAbsolute, listDirectory, rootLabel } from './fs-tree.ts'
+import { isWithin, parentOf, requireAbsolute, listDirectory, rootLabel } from './fs-tree.ts'
+import {
+  forwardablePayload,
+  isRoutableSessionMethod,
+  ownerSessionCwdOf,
+  SessionBackendRegistry,
+  sessionBackendError,
+  SESSION_SCOPED_BINARY_METHODS,
+  SESSION_SCOPED_READ_METHODS,
+  SESSION_SCOPED_WRITE_METHODS,
+  type CwdMode,
+  type OwnerSessionGet,
+  type SessionBackendBinaryResult,
+  type SessionBackendResult,
+  type SidebarSessionBackendRegistry,
+} from './session-backend.ts'
 import { writeWorkspaceUpload } from './fs-operations.ts'
 import { ensureWorkspacePath, ensureWorkspaceWritePath } from './path-security.ts'
 import { searchFiles } from './fs-search.ts'
@@ -70,6 +85,22 @@ export type {
   FileViewerProps,
   FileFetchStrategy,
 } from './client/service.ts'
+// The host-half extension seam (see docs/plans/2026-08-25-session-backend-seam-design.md):
+// a plugin serving sessions whose workspace lives elsewhere types its backend
+// against these without reaching into the source tree.
+export type { SidebarHostApiService } from './context-types.ts'
+export type {
+  SidebarSessionBackend,
+  SidebarSessionBackendRegistry,
+  SessionBackendSocket,
+  SessionBackendResult,
+  SessionBackendBinaryResult,
+} from './session-backend.ts'
+export {
+  SESSION_SCOPED_READ_METHODS,
+  SESSION_SCOPED_WRITE_METHODS,
+  SESSION_SCOPED_BINARY_METHODS,
+} from './session-backend.ts'
 
 /** Plugin identity for cordis.yml rows. */
 export const name = 'dsh-better-sidebar'
@@ -239,9 +270,14 @@ function buildApi(
   resolved: ResolvedSidebarConfig,
   terminalShell: string,
   getSettings: () => SidebarSettingsFace | undefined,
+  cwdMode: CwdMode = 'local-fallbacks',
+  ownerSessionGet: OwnerSessionGet = (sessionId) => ctx.sessions.get(sessionId),
 ): Record<string, ApiMethod> {
   const cwdOf = (payload: unknown): { sessionId: string; cwd: string } => {
     const sessionId = requireString(payload, 'sessionId')
+    // Owner-strict callers (a remote backend's owner half) get no hydration
+    // fallbacks: the session header is the only source of truth.
+    if (cwdMode === 'owner-strict') return { sessionId, cwd: ownerSessionCwdOf(ownerSessionGet, sessionId) }
     const record = payload as { cwd?: unknown } | null
     const clientCwd = typeof record?.cwd === 'string' && record.cwd !== '' ? record.cwd : undefined
     return { sessionId, cwd: sessionCwdOf(ctx, sessionId, clientCwd) }
@@ -408,6 +444,70 @@ function buildApi(
       // no-op ok is the honest answer — never an error the client must show.
       ptyManager?.close(`${sessionId}:${tab}`)
       return { ok: true }
+    },
+    // Terminal lifecycle as session-scoped API methods. The local browser
+    // drives terminals over the WebSocket (pty events push straight into the
+    // socket); these routes are the pull-shaped equivalent a session backend's
+    // owner half needs, because pty events cannot cross a transport.
+    'terminal.open': (payload) => {
+      if (ptyManager === null) throw new SidebarError('pty-deps-missing', PTY_DEPS_MISSING, 503)
+      const { sessionId, cwd } = cwdOf(payload)
+      const tab = requireString(payload, 'tab')
+      const record = payload as { cols?: unknown; rows?: unknown }
+      const dims = clampDims(typeof record.cols === 'number' ? record.cols : 80, typeof record.rows === 'number' ? record.rows : 24)
+      const handle = ptyManager.open(sessionId, tab, cwd, dims.cols, dims.rows)
+      return { base: handle.transcriptBase, next: handle.outputOffset, exited: handle.exited, exitCode: handle.exitCode ?? null }
+    },
+    // Read output by offset. An offset that fell behind the retained
+    // transcript is clamped to its base: the earliest output is lost exactly
+    // as it is for a local tab whose buffer rolled over, never an error.
+    'terminal.read': (payload) => {
+      if (ptyManager === null) throw new SidebarError('pty-deps-missing', PTY_DEPS_MISSING, 503)
+      const sessionId = requireString(payload, 'sessionId')
+      const tab = requireString(payload, 'tab')
+      const handle = ptyManager.get(`${sessionId}:${tab}`)
+      if (handle === undefined) throw new SidebarError('not-found', 'terminal not found', 404)
+      const record = payload as { offset?: unknown }
+      const requested = typeof record.offset === 'number' && Number.isInteger(record.offset) ? record.offset : handle.transcriptBase
+      const offset = Math.max(handle.transcriptBase, Math.min(requested, handle.outputOffset))
+      return {
+        offset, next: handle.outputOffset,
+        data: handle.transcript.slice(offset - handle.transcriptBase),
+        base: handle.transcriptBase, exited: handle.exited, exitCode: handle.exitCode ?? null,
+      }
+    },
+    'terminal.input': (payload) => {
+      const sessionId = requireString(payload, 'sessionId')
+      const tab = requireString(payload, 'tab')
+      const data = requireString(payload, 'data')
+      const handle = ptyManager?.get(`${sessionId}:${tab}`)
+      if (handle === undefined) throw new SidebarError('not-found', 'terminal not found', 404)
+      if (!handle.exited) handle.pty.write(data)
+      return { accepted: true }
+    },
+    'terminal.resize': (payload) => {
+      const sessionId = requireString(payload, 'sessionId')
+      const tab = requireString(payload, 'tab')
+      const record = payload as { cols?: unknown; rows?: unknown }
+      const handle = ptyManager?.get(`${sessionId}:${tab}`)
+      if (handle === undefined) throw new SidebarError('not-found', 'terminal not found', 404)
+      if (typeof record.cols === 'number' && typeof record.rows === 'number' && !handle.exited) {
+        const dims = clampDims(record.cols, record.rows)
+        handle.pty.resize(dims.cols, dims.rows)
+      }
+      return { accepted: true }
+    },
+    'terminal.terminate': (payload) => {
+      const sessionId = requireString(payload, 'sessionId')
+      ptyManager?.close(`${sessionId}:${requireString(payload, 'tab')}`)
+      return { terminated: true }
+    },
+    // Detach keeps the pty alive for the reconnect grace, matching what the
+    // local WebSocket close path does for a UI tab.
+    'terminal.detach': (payload) => {
+      const sessionId = requireString(payload, 'sessionId')
+      ptyManager?.scheduleClose(`${sessionId}:${requireString(payload, 'tab')}`, resolved.reconnectGraceMs)
+      return { detached: true }
     },
     // Release an agent terminal by uuid. The WS close frame already does
     // this while the socket is open; this route covers the tab-close that
@@ -662,6 +762,80 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
 
   // ── JSON API ────────────────────────────────────────────────────────────
   const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, terminalShell, () => settingsFace)
+
+  // ── Session backend seam ────────────────────────────────────────────────
+  // Plugins claim the sessions whose workspace does not live in this process
+  // (SSH-attached machines, containers, other nodes) and serve the
+  // session-scoped API for them. An unclaimed session costs one predicate
+  // call and keeps the local path byte for byte. See
+  // docs/plans/2026-08-25-session-backend-seam-design.md.
+  const sessionBackends = new SessionBackendRegistry()
+  ctx.provide('sidebarSessionBackends', sessionBackends satisfies SidebarSessionBackendRegistry)
+  // The owner half of the same seam: a remote backend's owner node borrows
+  // the real file/Git/terminal implementations instead of reimplementing
+  // them, but through a strict cwd resolver (no client cwd, no process cwd).
+  const ownerSessionGet: OwnerSessionGet = (sessionId) => ctx.sessions.get(sessionId)
+  let ownerApi: Record<string, ApiMethod> | undefined
+  ctx.provide('sidebarHostApi', {
+    createSessionApi: () => {
+      ownerApi ??= buildApi(ctx, ptyManager, agentPtyRegistry, resolved, terminalShell, () => settingsFace, 'owner-strict', ownerSessionGet)
+      const table = ownerApi
+      const run = async (method: string, sessionId: string, payload: unknown): Promise<SessionBackendResult> => {
+        const handler = table[method]
+        if (handler === undefined || !isRoutableSessionMethod(method)) {
+          return { ok: false, error: { code: 'not-found', message: `unknown session-scoped sidebar method "${method}"` } }
+        }
+        try {
+          return { ok: true, value: await handler({ ...forwardablePayload(payload), sessionId }) }
+        } catch (error) {
+          if (error instanceof SidebarError) return { ok: false, error: { code: error.code, message: error.message } }
+          return { ok: false, error: { code: 'internal', message: error instanceof Error ? error.message : String(error) } }
+        }
+      }
+      return {
+        invoke: run,
+        invokeBinary: async (method, sessionId, payload): Promise<SessionBackendBinaryResult> => {
+          try {
+            const cwd = ownerSessionCwdOf(ownerSessionGet, sessionId)
+            const record = payload as { path?: unknown; download?: unknown } | null
+            const path = requireAbsolute(requireString(record, 'path'))
+            if (!isWithin(cwd, path)) {
+              throw new SidebarError('fs-error', 'path outside the session working directory', 403)
+            }
+            const info = await stat(path)
+            if (!info.isFile() || info.size > resolved.mediaLimit) {
+              throw new SidebarError('fs-error', 'not a file or too large', 400)
+            }
+            const body = new Uint8Array(await readFile(path))
+            if (method === 'html.read') {
+              return { ok: true, status: 200, headers: {
+                'content-type': mediaTypeForPath(path), 'cache-control': 'no-cache',
+                'x-content-type-options': 'nosniff', 'referrer-policy': 'no-referrer',
+                'content-security-policy': "sandbox allow-scripts allow-popups allow-downloads allow-modals; object-src 'none'",
+              }, body }
+            }
+            if (method !== 'file.read') {
+              return { ok: false, error: { code: 'not-found', message: `unknown binary sidebar method "${method}"` } }
+            }
+            const headers: Record<string, string> = { 'content-type': mediaTypeForPath(path), 'cache-control': 'no-cache' }
+            if (record?.download === true) {
+              headers['content-disposition'] = `attachment; filename*=UTF-8''${encodeURIComponent(basename(path))}`
+            }
+            return { ok: true, status: 200, headers, body }
+          } catch (error) {
+            if (error instanceof SidebarError) return { ok: false, error: { code: error.code, message: error.message } }
+            return { ok: false, error: { code: 'internal', message: error instanceof Error ? error.message : String(error) } }
+          }
+        },
+        methods: {
+          read: SESSION_SCOPED_READ_METHODS,
+          write: SESSION_SCOPED_WRITE_METHODS,
+          binary: SESSION_SCOPED_BINARY_METHODS,
+        },
+      }
+    },
+  })
+
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
     path: '/sidebar/api',
@@ -682,6 +856,14 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       }
       try {
         const payload = await readJsonBody(req)
+        const sessionId = (payload as { sessionId?: unknown } | null)?.sessionId
+        const backend = isRoutableSessionMethod(method) ? sessionBackends.claim(sessionId as string) : undefined
+        if (backend !== undefined) {
+          const result = await backend.invoke(method, sessionId as string, forwardablePayload(payload))
+          if (!result.ok) throw sessionBackendError(result.error)
+          writeOk(res, result.value)
+          return
+        }
         const handler = api[method]
         if (handler === undefined) {
           throw new SidebarError('not-found', `unknown sidebar API method "${method}"`, 404)
@@ -760,6 +942,16 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         const sessionId = url.searchParams.get('sessionId')
         const raw = url.searchParams.get('path')
         if (sessionId === null || raw === null) throw new SidebarError('bad-request', 'sessionId and path are required')
+        const backend = sessionBackends.claim(sessionId)
+        if (backend !== undefined) {
+          const result = await backend.invokeBinary('file.read', sessionId, {
+            path: raw, download: url.searchParams.get('download') === '1',
+          })
+          if (!result.ok) throw sessionBackendError(result.error)
+          res.writeHead(result.status, result.headers)
+          res.end(Buffer.from(result.body))
+          return
+        }
         const cwd = sessionCwdOf(ctx, sessionId, url.searchParams.get('cwd') ?? undefined)
         const path = await ensureWorkspacePath(cwd, raw)
         const info = await stat(path)
@@ -814,6 +1006,14 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
           return
         }
         const { sessionId, path } = decoded.ref
+        const backend = sessionBackends.claim(sessionId)
+        if (backend !== undefined) {
+          const result = await backend.invokeBinary('html.read', sessionId, { path })
+          if (!result.ok) throw sessionBackendError(result.error)
+          res.writeHead(result.status, result.headers)
+          res.end(Buffer.from(result.body))
+          return
+        }
         // The session's authoritative cwd (client cwd cannot ride in the URL
         // — the path encoding has no query; a detached first request falls
         // back to the process cwd and is normally refused by the workspace
@@ -863,6 +1063,18 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
       // The structural request/socket/head faces satisfy the shared fence;
       // the `ws` package wants the real Node types — cast at this boundary.
       wss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
+        const url = new URL(req.url ?? '/', 'http://dsh.internal')
+        const sessionId = url.searchParams.get('sessionId')
+        const backend = sessionBackends.claim(sessionId)
+        if (backend !== undefined) {
+          // Handing the socket over is final: the backend owns its lifecycle.
+          if (backend.attachTerminal === undefined) {
+            ws.close(1011, `backend "${backend.id}" serves no terminals`)
+            return
+          }
+          backend.attachTerminal(ws, sessionId as string, url.searchParams.get('tab'), { reconnectGraceMs: resolved.reconnectGraceMs })
+          return
+        }
         void attachTerminal(ctx, ptyManager, agentPtyRegistry, ws, req, resolved, () => settingsFace)
       })
     },

--- a/src/pty-manager.ts
+++ b/src/pty-manager.ts
@@ -56,6 +56,14 @@ export interface SidebarPty {
   pty: IPty
   /** Output accumulated since spawn (bounded; head dropped when over the limit). */
   transcript: string
+  /**
+   * Monotonic UTF-16 output offset past the retained transcript. Lets an
+   * owner-side reader (session backend seam) pull output by offset instead of
+   * riding the local pty event path, which cannot cross a transport.
+   */
+  outputOffset: number
+  /** The offset `transcript[0]` represents (advances as the head is dropped). */
+  transcriptBase: number
   /** Whether the top-level process exited (transcript stays replayable). */
   exited: boolean
   exitCode?: number | null
@@ -161,13 +169,17 @@ export class PtyManager {
         env: { ...process.env },
       }),
       transcript: '',
+      outputOffset: 0,
+      transcriptBase: 0,
       exited: false,
     }
     handle.pty.onData((data) => {
       handle.transcript += data
+      handle.outputOffset += data.length
       if (handle.transcript.length > TRANSCRIPT_LIMIT) {
         handle.transcript = handle.transcript.slice(handle.transcript.length - TRANSCRIPT_LIMIT)
       }
+      handle.transcriptBase = handle.outputOffset - handle.transcript.length
     })
     handle.pty.onExit(({ exitCode }) => {
       handle.exited = true

--- a/src/session-backend.ts
+++ b/src/session-backend.ts
@@ -1,0 +1,194 @@
+/**
+ * Session backend seam — the host-half counterpart of the client-half
+ * `registerTab` / `registerFileViewer` extension points.
+ *
+ * The sidebar's host half resolves a session's files, Git state and terminals
+ * against THIS process: `node:fs`, a spawned `git`, and a local `node-pty`.
+ * That is wrong for any session whose working directory lives somewhere else —
+ * an SSH-attached machine (issue #238), a container, a sandbox, or another
+ * node in a multi-node deployment. Those deployments could previously only
+ * fork the sidebar.
+ *
+ * A backend claims the session ids it owns and serves the session-scoped API
+ * for them. Everything else keeps the original local path byte for byte: an
+ * unclaimed session costs one predicate call.
+ */
+import { SidebarError } from './wire.ts'
+import { requireAbsolute } from './fs-tree.ts'
+
+/**
+ * The socket face a backend takes over. Structural on purpose: the type lives
+ * in the client-reachable declaration graph, which must stay Node-free
+ * (scripts/check-consumer-types.sh), and a real `ws` WebSocket satisfies it.
+ */
+export interface SessionBackendSocket {
+  send(data: string): void
+  close(code?: number, reason?: string): void
+  on(event: 'message', listener: (data: unknown) => void): unknown
+  on(event: 'close', listener: () => void): unknown
+  readonly readyState: number
+}
+
+/** One session-scoped JSON call result. */
+export type SessionBackendResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: { code: string; message: string; details?: Record<string, unknown> } }
+
+/** One session-scoped binary read result (media / HTML routes). */
+export type SessionBackendBinaryResult =
+  | { ok: true; status: number; headers: Readonly<Record<string, string>>; body: Uint8Array }
+  | { ok: false; error: { code: string; message: string; details?: Record<string, unknown> } }
+
+/**
+ * A backend serving the sidebar's session-scoped API for the sessions it
+ * claims. Registered through {@link SidebarSessionBackendRegistry}; wrap the
+ * registration in `ctx.effect` so disposal is HMR-safe.
+ */
+export interface SidebarSessionBackend {
+  /** Stable identifier for diagnostics (logs, claim conflicts). */
+  readonly id: string
+  /**
+   * Whether this backend owns the session. Called on every routed request, so
+   * it must be a cheap pure predicate (id shape, prefix, own registry) — no
+   * I/O. A throw is treated as "not claimed": one bad backend must not take
+   * the whole sidebar down with it.
+   */
+  claimSession(sessionId: string): boolean
+  /** Run one session-scoped JSON API method (names mirror `/sidebar/api/<method>`). */
+  invoke(method: string, sessionId: string, payload: unknown, signal?: AbortSignal): Promise<SessionBackendResult>
+  /** Run one session-scoped binary read (`file.read` / `html.read`). */
+  invokeBinary(method: string, sessionId: string, payload: unknown, signal?: AbortSignal): Promise<SessionBackendBinaryResult>
+  /**
+   * Take over an upgraded terminal WebSocket. The sidebar stops reading and
+   * writing the socket once it is handed over: closing it, surfacing errors
+   * and honouring the reconnect grace are the backend's responsibility.
+   * Backends that omit this serve files and Git but no terminals.
+   */
+  attachTerminal?(ws: SessionBackendSocket, sessionId: string, tab: string | null, options: { reconnectGraceMs: number }): void
+}
+
+/** The host service backends register through (`ctx.sidebarSessionBackends`). */
+export interface SidebarSessionBackendRegistry {
+  /** Register a backend; returns its disposer. */
+  register(backend: SidebarSessionBackend): () => void
+}
+
+/**
+ * Session-scoped methods a backend may serve. An allow list, not a deny list:
+ * a newly added API method is NOT routable until it is named here.
+ *
+ * Deliberately absent: `settings.*` (global, not session-scoped),
+ * `browser.probe` (probes the ingress's own network), `deps.status` (this
+ * process's node-pty install), and the agent terminal routes (addressed by
+ * agent UUID — they belong to the local agent runtime, not to a workspace).
+ */
+export const SESSION_SCOPED_READ_METHODS = [
+  'session.cwd', 'fs.tree', 'fs.search', 'fs.read',
+  'git.status', 'git.diff', 'git.branch', 'git.log', 'git.commit-diff', 'git.show',
+  'jobs.output', 'terminal.read',
+] as const
+
+/** Session-scoped methods that mutate owner-side state. */
+export const SESSION_SCOPED_WRITE_METHODS = [
+  'fs.write', 'git.stage', 'git.unstage', 'git.commit', 'git.checkout',
+  'git.discard', 'git.revert', 'git.cherry-pick', 'pty.close', 'jobs.kill',
+  'terminal.open', 'terminal.input', 'terminal.resize', 'terminal.terminate', 'terminal.detach',
+] as const
+
+/** Session-scoped methods answering with raw bytes. */
+export const SESSION_SCOPED_BINARY_METHODS = ['file.read', 'html.read'] as const
+
+const ROUTABLE_JSON_METHODS: ReadonlySet<string> = new Set<string>([
+  ...SESSION_SCOPED_READ_METHODS,
+  ...SESSION_SCOPED_WRITE_METHODS,
+])
+
+/** Whether a JSON API method may be served by a session backend. */
+export function isRoutableSessionMethod(method: string): boolean {
+  return ROUTABLE_JSON_METHODS.has(method)
+}
+
+/** The registry implementation the sidebar provides. */
+export class SessionBackendRegistry implements SidebarSessionBackendRegistry {
+  readonly #backends: SidebarSessionBackend[] = []
+
+  register(backend: SidebarSessionBackend): () => void {
+    this.#backends.push(backend)
+    return () => {
+      const index = this.#backends.indexOf(backend)
+      if (index >= 0) this.#backends.splice(index, 1)
+    }
+  }
+
+  /**
+   * The backend owning this session, or undefined for the local path.
+   * First claim wins (registration order), mirroring the client half's
+   * `urlTarget` semantics.
+   */
+  claim(sessionId: string | undefined | null): SidebarSessionBackend | undefined {
+    if (typeof sessionId !== 'string' || sessionId === '') return undefined
+    for (const backend of this.#backends) {
+      try {
+        if (backend.claimSession(sessionId)) return backend
+      } catch {
+        // A throwing predicate does not claim; the local path still serves.
+      }
+    }
+    return undefined
+  }
+
+  /** Registered backend count (diagnostics and tests). */
+  get size(): number {
+    return this.#backends.length
+  }
+}
+
+/**
+ * Strip the fields the route layer owns before handing a payload to a backend.
+ *
+ * `sessionId` is decided by routing, and a caller-supplied `cwd` must never
+ * reach an owner: for the local UI a client cwd is a legitimate hydration hint,
+ * but across a transport it would turn a routing mistake into filesystem
+ * access on an unrelated directory.
+ */
+export function forwardablePayload(payload: unknown): Record<string, unknown> {
+  const source = payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload as Record<string, unknown>
+    : {}
+  const forwarded: Record<string, unknown> = { ...source }
+  delete forwarded.sessionId
+  delete forwarded.cwd
+  return forwarded
+}
+
+/** Turn a backend error into the sidebar's own error shape. */
+export function sessionBackendError(error: { code: string; message: string }): SidebarError {
+  const missing = error.code === 'session-not-found' || error.code === 'not-found'
+  return new SidebarError(missing ? 'not-found' : 'internal', error.message, missing ? 404 : 502)
+}
+
+/** How a session's cwd is resolved. */
+export type CwdMode = 'local-fallbacks' | 'owner-strict'
+
+/** The session lookup an owner-strict API is bound to. */
+export type OwnerSessionGet = (sessionId: string) => { header: { cwd?: string } } | undefined
+
+/**
+ * Resolve a session cwd strictly from its own header.
+ *
+ * The local UI path falls back to a client-supplied cwd and ultimately to the
+ * process cwd, which is reasonable for a same-machine browser during the first
+ * frame. A remote caller gets none of that: an unknown session is a 404, never
+ * an unrelated directory.
+ */
+export function ownerSessionCwdOf(getSession: OwnerSessionGet, sessionId: string): string {
+  const cwd = getSession(sessionId)?.header.cwd
+  if (cwd === undefined || cwd === '') {
+    throw new SidebarError('not-found', `session "${sessionId}" has no owner-local working directory`, 404)
+  }
+  try {
+    return requireAbsolute(cwd)
+  } catch {
+    throw new SidebarError('fs-error', `session "${sessionId}" has an invalid working directory`, 400)
+  }
+}

--- a/tests/session-backend.spec.ts
+++ b/tests/session-backend.spec.ts
@@ -1,0 +1,378 @@
+/**
+ * Session backend seam: claim resolution, request routing, payload fencing,
+ * owner-strict cwd resolution and the local-path regression guard.
+ *
+ * The invariant every case here protects: a deployment with no backend
+ * installed must behave exactly as it did before the seam existed.
+ */
+import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { apply } from '../src/index.ts'
+import {
+  forwardablePayload,
+  isRoutableSessionMethod,
+  ownerSessionCwdOf,
+  SessionBackendRegistry,
+  sessionBackendError,
+  type SidebarSessionBackend,
+} from '../src/session-backend.ts'
+import { defaultShell, PtyManager } from '../src/pty-manager.ts'
+import type { SidebarWebRoute, SidebarWebUpgradeRoute } from '../src/context-types.ts'
+
+/** A backend stub recording every call it receives. */
+function stubBackend(id: string, claims: (sessionId: string) => boolean): SidebarSessionBackend & {
+  calls: { method: string; sessionId: string; payload: unknown }[]
+  binaryCalls: { method: string; sessionId: string; payload: unknown }[]
+  terminals: { sessionId: string; tab: string | null }[]
+} {
+  const calls: { method: string; sessionId: string; payload: unknown }[] = []
+  const binaryCalls: { method: string; sessionId: string; payload: unknown }[] = []
+  const terminals: { sessionId: string; tab: string | null }[] = []
+  return {
+    id,
+    calls,
+    binaryCalls,
+    terminals,
+    claimSession: claims,
+    invoke: async (method, sessionId, payload) => {
+      calls.push({ method, sessionId, payload })
+      return { ok: true, value: { servedBy: id, method } }
+    },
+    invokeBinary: async (method, sessionId, payload) => {
+      binaryCalls.push({ method, sessionId, payload })
+      return { ok: true, status: 200, headers: { 'content-type': 'text/plain' }, body: new TextEncoder().encode(id) }
+    },
+    attachTerminal: (_ws, sessionId, tab) => { terminals.push({ sessionId, tab }) },
+  }
+}
+
+/** Mount the host plugin and hand back its routes plus the seam services. */
+function mountHost(sessions: Record<string, { cwd?: string }> = {}): {
+  routes: SidebarWebRoute[]
+  upgrades: SidebarWebUpgradeRoute[]
+  services: Record<string, unknown>
+  dispose: () => void
+} {
+  const routes: SidebarWebRoute[] = []
+  const upgrades: SidebarWebUpgradeRoute[] = []
+  const effects: Array<() => void> = []
+  const services: Record<string, unknown> = {}
+  const ctx = {
+    webRuntime: { trustedHosts: [] },
+    webServer: {
+      register: (route: SidebarWebRoute) => { routes.push(route); return () => {} },
+      registerUpgrade: (route: SidebarWebUpgradeRoute) => { upgrades.push(route); return () => {} },
+    },
+    sessions: { get: (id: string) => (sessions[id] === undefined ? undefined : { header: sessions[id]! }) },
+    tools: { register: () => () => {} },
+    effect: (fn: () => void | (() => void)) => {
+      const cleanup = fn()
+      if (typeof cleanup === 'function') effects.push(cleanup)
+    },
+    inject: () => () => {},
+    get: () => undefined,
+    provide: (key: string, value: unknown) => { services[key] = value },
+  }
+  apply(ctx as never)
+  return { routes, upgrades, services, dispose: () => { for (const cleanup of effects) cleanup() } }
+}
+
+/** Drive one `/sidebar/api/<method>` request through the mounted route. */
+async function callApi(route: SidebarWebRoute, method: string, payload: unknown): Promise<{
+  status: number
+  body: unknown
+}> {
+  let status = 200
+  let body: unknown
+  const req = {
+    method: 'POST',
+    url: `/sidebar/api/${method}`,
+    headers: { host: 'localhost' },
+    socket: { remoteAddress: '127.0.0.1' },
+    [Symbol.asyncIterator]: async function* () { yield Buffer.from(JSON.stringify(payload)) },
+  }
+  const res = {
+    writeHead: (code: number) => { status = code },
+    end: (chunk?: unknown) => { if (chunk !== undefined) body = String(chunk) },
+    setHeader: () => {},
+  }
+  await route.handler(req as never, res as never)
+  return { status, body: typeof body === 'string' ? JSON.parse(body) as unknown : body }
+}
+
+describe('session backend registry', () => {
+  it('resolves no backend when none is registered (local path intact)', () => {
+    const registry = new SessionBackendRegistry()
+    expect(registry.size).toBe(0)
+    expect(registry.claim('session-a')).toBeUndefined()
+  })
+
+  it('claims by predicate and ignores unclaimed sessions', () => {
+    const registry = new SessionBackendRegistry()
+    const backend = stubBackend('remote', id => id.startsWith('remote:'))
+    registry.register(backend)
+    expect(registry.claim('remote:one')?.id).toBe('remote')
+    expect(registry.claim('local-session')).toBeUndefined()
+  })
+
+  it('gives the first registered claimer priority and falls through otherwise', () => {
+    const registry = new SessionBackendRegistry()
+    registry.register(stubBackend('first', id => id.startsWith('shared')))
+    registry.register(stubBackend('second', id => id.startsWith('shared') || id === 'only-second'))
+    expect(registry.claim('shared-1')?.id).toBe('first')
+    expect(registry.claim('only-second')?.id).toBe('second')
+  })
+
+  it('treats a throwing predicate as "not claimed" instead of failing the request', () => {
+    const registry = new SessionBackendRegistry()
+    registry.register({
+      id: 'broken',
+      claimSession: () => { throw new Error('backend is confused') },
+      invoke: async () => ({ ok: true, value: null }),
+      invokeBinary: async () => ({ ok: true, status: 200, headers: {}, body: new Uint8Array() }),
+    })
+    registry.register(stubBackend('healthy', id => id === 'claimed'))
+    expect(() => registry.claim('anything')).not.toThrow()
+    expect(registry.claim('anything')).toBeUndefined()
+    expect(registry.claim('claimed')?.id).toBe('healthy')
+  })
+
+  it('stops routing to a disposed backend', () => {
+    const registry = new SessionBackendRegistry()
+    const dispose = registry.register(stubBackend('temp', () => true))
+    expect(registry.claim('any')?.id).toBe('temp')
+    dispose()
+    expect(registry.size).toBe(0)
+    expect(registry.claim('any')).toBeUndefined()
+  })
+
+  it('ignores blank session ids', () => {
+    const registry = new SessionBackendRegistry()
+    registry.register(stubBackend('greedy', () => true))
+    expect(registry.claim(undefined)).toBeUndefined()
+    expect(registry.claim(null)).toBeUndefined()
+    expect(registry.claim('')).toBeUndefined()
+  })
+})
+
+describe('routable method allow list', () => {
+  it('accepts session-scoped workspace methods', () => {
+    for (const method of ['fs.tree', 'fs.read', 'fs.write', 'git.status', 'git.commit', 'terminal.open', 'terminal.read']) {
+      expect(isRoutableSessionMethod(method)).toBe(true)
+    }
+  })
+
+  it('refuses methods that are not about a session workspace', () => {
+    // Global settings, ingress-local probes, this process's pty install and
+    // uuid-addressed agent terminals must never leave for a remote owner.
+    for (const method of ['settings.get', 'settings.update', 'browser.probe', 'deps.status', 'agent-pty.close', 'shell.get']) {
+      expect(isRoutableSessionMethod(method)).toBe(false)
+    }
+  })
+})
+
+describe('payload fencing', () => {
+  it('strips caller-supplied sessionId and cwd before forwarding', () => {
+    const forwarded = forwardablePayload({ sessionId: 'spoofed', cwd: '/etc', path: 'README.md', depth: 2 })
+    expect(forwarded).toEqual({ path: 'README.md', depth: 2 })
+  })
+
+  it('normalises non-object payloads to an empty record', () => {
+    expect(forwardablePayload(null)).toEqual({})
+    expect(forwardablePayload('nope')).toEqual({})
+    expect(forwardablePayload([1, 2])).toEqual({})
+  })
+
+  it('maps a missing session to 404 and any other backend fault to 502', () => {
+    expect(sessionBackendError({ code: 'session-not-found', message: 'gone' }).status).toBe(404)
+    expect(sessionBackendError({ code: 'not-found', message: 'gone' }).status).toBe(404)
+    expect(sessionBackendError({ code: 'transport-failure', message: 'ssh died' }).status).toBe(502)
+  })
+})
+
+describe('owner-strict cwd resolution', () => {
+  it('resolves the session header cwd', () => {
+    const get = (id: string) => (id === 'live' ? { header: { cwd: process.cwd() } } : undefined)
+    expect(ownerSessionCwdOf(get, 'live')).toBe(process.cwd())
+  })
+
+  it('never falls back to the process cwd for an unknown session', () => {
+    const get = () => undefined
+    expect(() => ownerSessionCwdOf(get, 'ghost')).toThrowError(/no owner-local working directory/)
+    try {
+      ownerSessionCwdOf(get, 'ghost')
+    } catch (error) {
+      expect((error as { status: number }).status).toBe(404)
+    }
+  })
+
+  it('rejects a session whose cwd is blank or relative', () => {
+    expect(() => ownerSessionCwdOf(() => ({ header: { cwd: '' } }), 's')).toThrowError(/no owner-local working directory/)
+    try {
+      ownerSessionCwdOf(() => ({ header: { cwd: 'relative/path' } }), 's')
+    } catch (error) {
+      expect((error as { status: number }).status).toBe(400)
+    }
+  })
+})
+
+describe('mounted host routing', () => {
+  it('provides both halves of the seam', () => {
+    const host = mountHost()
+    expect(host.services.sidebarSessionBackends).toBeDefined()
+    expect(host.services.sidebarHostApi).toBeDefined()
+    host.dispose()
+  })
+
+  it('serves the local path when no backend claims the session', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-seam-local-'))
+    mkdirSync(join(dir, 'sub'))
+    writeFileSync(join(dir, 'sub', 'note.txt'), 'local bytes')
+    try {
+      const host = mountHost({ 'local-session': { cwd: dir } })
+      const api = host.routes.find(route => route.path === '/sidebar/api')!
+      const result = await callApi(api, 'fs.tree', { sessionId: 'local-session', path: dir })
+      const value = (result.body as { ok: boolean; value: { entries: { name: string }[] } })
+      expect(value.ok).toBe(true)
+      expect(value.value.entries.some(entry => entry.name === 'sub')).toBe(true)
+      host.dispose()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('routes a claimed session to its backend and fences the payload', async () => {
+    const host = mountHost()
+    const registry = host.services.sidebarSessionBackends as SessionBackendRegistry
+    const backend = stubBackend('remote', id => id.startsWith('remote:'))
+    registry.register(backend)
+    const api = host.routes.find(route => route.path === '/sidebar/api')!
+    const result = await callApi(api, 'fs.tree', { sessionId: 'remote:one', cwd: '/etc/passwd', path: 'src' })
+    expect((result.body as { ok: boolean; value: { servedBy: string } }).value.servedBy).toBe('remote')
+    expect(backend.calls).toHaveLength(1)
+    expect(backend.calls[0]!.sessionId).toBe('remote:one')
+    // The caller's cwd never reaches the owner, even riding an ordinary payload.
+    expect(backend.calls[0]!.payload).toEqual({ path: 'src' })
+    host.dispose()
+  })
+
+  it('keeps non-routable methods local even for a claimed session', async () => {
+    const host = mountHost()
+    const registry = host.services.sidebarSessionBackends as SessionBackendRegistry
+    const backend = stubBackend('remote', () => true)
+    registry.register(backend)
+    const api = host.routes.find(route => route.path === '/sidebar/api')!
+    await callApi(api, 'settings.get', { sessionId: 'remote:one' })
+    expect(backend.calls).toHaveLength(0)
+    host.dispose()
+  })
+
+  it('hands a claimed terminal socket to the backend', () => {
+    const host = mountHost()
+    const registry = host.services.sidebarSessionBackends as SessionBackendRegistry
+    const backend = stubBackend('remote', id => id.startsWith('remote:'))
+    registry.register(backend)
+    const upgrade = host.upgrades.find(route => route.path === '/sidebar/ws/terminal')!
+    // The upgrade handler runs the ws handshake; drive the claim decision by
+    // calling the registry the same way the route does.
+    expect(registry.claim('remote:one')?.id).toBe('remote')
+    backend.attachTerminal!({ send: () => {}, close: () => {}, on: () => undefined, readyState: 1 }, 'remote:one', 'term-1', { reconnectGraceMs: 0 })
+    expect(backend.terminals).toEqual([{ sessionId: 'remote:one', tab: 'term-1' }])
+    expect(upgrade).toBeDefined()
+    host.dispose()
+  })
+})
+
+describe('owner-side session API', () => {
+  it('reads the workspace through the session header, refusing a caller cwd', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-seam-owner-'))
+    writeFileSync(join(dir, 'file.txt'), 'owner bytes')
+    try {
+      const host = mountHost({ owned: { cwd: dir } })
+      const hostApi = host.services.sidebarHostApi as {
+        createSessionApi: () => {
+          invoke: (method: string, sessionId: string, payload: unknown) => Promise<{ ok: boolean; value?: unknown; error?: { code: string } }>
+          methods: { read: readonly string[]; write: readonly string[]; binary: readonly string[] }
+        }
+      }
+      const sessionApi = hostApi.createSessionApi()
+      const result = await sessionApi.invoke('fs.read', 'owned', { path: join(dir, 'file.txt'), cwd: '/somewhere/else' })
+      expect(result.ok).toBe(true)
+      expect((result.value as { content: string }).content).toBe('owner bytes')
+      // The capability lists a backend advertises are the routable methods.
+      expect(sessionApi.methods.read).toContain('fs.tree')
+      expect(sessionApi.methods.binary).toEqual(['file.read', 'html.read'])
+      host.dispose()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses an unknown session instead of reading the process cwd', async () => {
+    const host = mountHost()
+    const hostApi = host.services.sidebarHostApi as {
+      createSessionApi: () => { invoke: (m: string, s: string, p: unknown) => Promise<{ ok: boolean; error?: { code: string } }> }
+    }
+    const result = await hostApi.createSessionApi().invoke('fs.tree', 'ghost', {})
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('not-found')
+    host.dispose()
+  })
+
+  it('refuses methods outside the session-scoped allow list', async () => {
+    const host = mountHost({ owned: { cwd: process.cwd() } })
+    const hostApi = host.services.sidebarHostApi as {
+      createSessionApi: () => { invoke: (m: string, s: string, p: unknown) => Promise<{ ok: boolean; error?: { code: string } }> }
+    }
+    const result = await hostApi.createSessionApi().invoke('settings.update', 'owned', { patch: {} })
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('not-found')
+    host.dispose()
+  })
+
+  it('fences binary reads to the session workspace', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-seam-binary-'))
+    writeFileSync(join(dir, 'page.html'), '<p>hi</p>')
+    try {
+      const host = mountHost({ owned: { cwd: dir } })
+      const hostApi = host.services.sidebarHostApi as {
+        createSessionApi: () => { invokeBinary: (m: string, s: string, p: unknown) => Promise<{ ok: boolean; status?: number; headers?: Record<string, string>; body?: Uint8Array; error?: { code: string } }> }
+      }
+      const sessionApi = hostApi.createSessionApi()
+      const inside = await sessionApi.invokeBinary('html.read', 'owned', { path: join(dir, 'page.html') })
+      expect(inside.ok).toBe(true)
+      // The HTML previewer's sandbox CSP rides the owner response too.
+      expect(inside.headers?.['content-security-policy']).toContain('sandbox')
+      const outside = await sessionApi.invokeBinary('file.read', 'owned', { path: join(tmpdir(), 'not-in-workspace.txt') })
+      expect(outside.ok).toBe(false)
+      host.dispose()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('terminal offsets', () => {
+  it('tracks a monotonic output offset alongside the bounded transcript', async () => {
+    const manager = new PtyManager(defaultShell(), 2)
+    try {
+      const handle = manager.open('s1', 't1', process.cwd(), 80, 24)
+      expect(handle.outputOffset).toBe(0)
+      expect(handle.transcriptBase).toBe(0)
+      handle.pty.write('echo seam-offset-probe\r')
+      const deadline = Date.now() + 5000
+      while (handle.outputOffset === 0 && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+      }
+      // The offset advances with output, and base + transcript length is the
+      // invariant an offset reader relies on.
+      expect(handle.outputOffset).toBeGreaterThan(0)
+      expect(handle.transcriptBase + handle.transcript.length).toBe(handle.outputOffset)
+    } finally {
+      manager.disposeAll()
+    }
+  })
+})

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -44,6 +44,8 @@ interface FakeContext {
   inject: (deps: readonly string[], callback: (sctx: never) => void) => () => void
   /** Optional services (jobs/agents) are read lazily; absent → undefined. */
   get: (key: string) => undefined
+  /** Host services the plugin publishes (the session backend seam). */
+  provide: (key: string, value: unknown) => void
 }
 
 /**
@@ -101,6 +103,8 @@ describe('host plugin smoke', () => {
       inject: () => () => {},
       // No jobs/agents services: the jobs routes degrade to a 503.
       get: () => undefined,
+      // The session backend seam publishes its two host services here.
+      provide: () => {},
     }
     apply(ctx as never)
     expect(routes.map(route => route.path)).toEqual([
@@ -451,6 +455,7 @@ describe('session cwd resolution over the API route', () => {
       inject: () => () => {},
       // No jobs/agents services in the smoke context: the routes degrade.
       get: () => undefined,
+      provide: () => {},
     }
     apply(ctx as never)
     return routes
@@ -771,6 +776,8 @@ describe('side card settings routes', () => {
       },
       // No jobs/agents services: the jobs routes degrade to a 503.
       get: () => undefined,
+      // The session backend seam publishes its two host services here.
+      provide: () => {},
     }
     apply(ctx as never)
     return routes.find(route => route.path === '/sidebar/api')!
@@ -994,6 +1001,8 @@ describe('agent terminal tool gating', () => {
       },
       // No jobs/agents services: the jobs routes degrade to a 503.
       get: () => undefined,
+      // The session backend seam publishes its two host services here.
+      provide: () => {},
     }
     apply(ctx as never)
     // Default off: no tools are registered even though the settings service is mounted.

--- a/tests/trusted-hosts.spec.ts
+++ b/tests/trusted-hosts.spec.ts
@@ -78,6 +78,7 @@ function mount(initialTrustedHosts: readonly string[] = []): {
     },
     inject: () => () => {},
     get: () => undefined,
+    provide: () => {},
   }
   apply(ctx as never)
   const api = routes.find(route => route.path === '/sidebar/api')?.handler


### PR DESCRIPTION
Enables the fix for #238 (`dsh-remote` implements the backend; the sidebar never learns about SSH).

## Why

The client half has a complete extension surface — `registerTab`, `registerFileViewer`, feature negotiation, declarative settings. The host half has none: it resolves files, Git and terminals against *this* process (`node:fs`, a spawned `git`, a local `node-pty`).

So any session whose workspace lives elsewhere can only be served by forking the plugin:

- SSH-attached machines (#238, `dsh-remote`)
- containers / cloud sandboxes
- multi-node deployments where another node owns the session

All three are one shape: *the bytes for this session should not come from this process.*

## What

Two optional host services, symmetric to the client half:

| Service | Role |
|---|---|
| `ctx.sidebarSessionBackends` | A plugin claims session ids and serves the session-scoped API for them |
| `ctx.sidebarHostApi` | The owner half: the sidebar's real implementations behind an owner-strict cwd resolver |

```ts
// ingress: claim what you own
ctx.sidebarSessionBackends.register({
  id: 'my-transport',
  claimSession: id => id.startsWith('remote:'),
  invoke: (method, sessionId, payload) => /* your transport */,
  invokeBinary: (method, sessionId, payload) => /* your transport */,
  attachTerminal: (ws, sessionId, tab, { reconnectGraceMs }) => /* your channel */,
})

// owner: borrow the sidebar's own workspace implementation
const api = ctx.sidebarHostApi.createSessionApi()
await api.invoke('fs.tree', sessionId, payload)
```

Routing covers `/sidebar/api`, `/sidebar/file`, `/sidebar/html` and the terminal WS upgrade.

Terminals also gain pull-shaped routes (`terminal.open/read/input/resize/terminate/detach`), because pty events cannot cross a transport. `PtyManager` tracks a monotonic output offset next to its bounded transcript so a reader can page output by offset — both fields are inert on the local path (two additions per data event).

## Guarantees

- **No backend installed → byte-for-byte the previous behaviour.** An unclaimed session costs one predicate call, no network hop, no changed semantics.
- **Allow list, not deny list**: a newly added API method is not routable until named. Global settings, ingress-local browser probes, this process's pty status and uuid-addressed agent terminals stay local by construction.
- **Routing owns `sessionId`** and strips any caller-supplied `cwd` before forwarding — even one hidden inside an ordinary payload field.
- **Owner-strict resolution never falls back to `process.cwd()`**: an unknown session is a 404, not an unrelated directory. Owner binary reads keep the existing `requireAbsolute` + `isWithin` fence.
- **A throwing `claimSession` does not claim** — one bad backend cannot take the sidebar down with it.
- The seam types are structural (no `ws` import), so the client-reachable declaration graph stays node-free.

## Verification

- 24 new tests in `tests/session-backend.spec.ts`: claim order and fall-through, disposal, payload fencing, owner-strict cwd (missing / blank / relative), the allow list, the local-path regression, and terminal offset semantics
- Full suite green, `pnpm typecheck`, `scripts/check-consumer-types.sh`, market manifest guard
- Running against a real multi-node deployment as a second consumer, which is what convinced me the interface is not shaped around one use case

Design doc: `docs/plans/2026-08-25-session-backend-seam-design.md`

Happy to adjust the interface shape — the naming, the allow-list boundary and whether the owner half belongs in this PR or a follow-up are all open questions from my side.
