### PR TITLE
fix(client): align collapsed toggle cluster with DSH session header / 折叠态开关组对齐 DSH 会话标题行

### DIFF
--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -489,6 +489,25 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   padding-top: var(--dsh-title-bar-strip, 40px);
 }
 
+/* ── Collapsed cluster alignment with the DSH web session header ───────── */
+
+/* While the right panel is open, the cluster rides the panel's 34px tab
+   strip (28px buttons at top: 3). Collapsed, it floats over DSH's own
+   session header instead — whose controls (title, "Session log" capsule)
+   are vertically centered at 28px on both desktop and narrow viewports.
+   top: 3 then strands the cluster ~11px above that row; re-center the
+   28px buttons at 14px. The attribute disappears while the panel is open,
+   so the tab-strip alignment above is untouched. With position
+   compatibility active the DSH header sits below the caption strip, hence
+   strip + 14. */
+:global(body[data-dsh-sidebar-collapsed]) .toggleCluster {
+  top: calc(14px + env(safe-area-inset-top));
+}
+
+:global(body[data-dsh-sidebar-collapsed][data-dsh-title-bar-compat]) .toggleCluster {
+  top: calc(var(--dsh-title-bar-strip, 40px) + 14px);
+}
+
 /* The shared corner (both panels open): the intersection of the right
    panel's left edge and the bottom panel's top edge. Horizontal drags
    resize the width, vertical drags the height — the two panels drag


### PR DESCRIPTION
## Problem

Collapsed, the top-right toggle cluster (`top: 3px`) floats over DSH's native session header, whose controls (title, "Session log" capsule) are vertically centered at 28px on desktop and narrow viewports alike — the 28px buttons sit ~11px too high and read as misaligned. The open state is already correct: the cluster rides the panel's 34px tab strip (28px buttons at top: 3, centered at 17px).

## Change

- `body[data-dsh-sidebar-collapsed] .toggleCluster { top: calc(14px + env(safe-area-inset-top)) }` — re-centers the cluster only while the right panel is collapsed; the attribute is removed when the panel opens, so the tab-strip alignment is untouched.
- Position-compatibility composition: `body[data-dsh-sidebar-collapsed][data-dsh-title-bar-compat]` uses `strip + 14px`, since the DSH header sits below the caption strip.

## Verification

- Real `dsh web` (DSH 0.1.1-rc.2 behind an nginx reverse proxy), headless Chromium at 1280×720 and 390×844:
  - collapsed: cluster center at 28px, flush with the native header controls on both viewports;
  - open: center stays at 17px inside the tab strip, no regression.
- `pnpm typecheck` clean; `pnpm test` 92 files green (912 passed / 5 skipped).

---

## 问题

折叠态下，右上角开关组（`top: 3px`）悬浮在 DSH 原生会话标题栏上，而标题行控件（标题、"Session log" 胶囊）垂直中心在 28px（桌面与窄视口一致），28px 按钮因此偏高约 11px，视觉上违和。展开态开关组嵌在面板 34px tab 条内（中心 17px），本就正确。

## 修改

- `body[data-dsh-sidebar-collapsed] .toggleCluster { top: calc(14px + env(safe-area-inset-top)) }`：仅折叠态下移居中；属性在展开时移除，tab 条对齐不受影响。
- 位置兼容模式叠加：`body[data-dsh-sidebar-collapsed][data-dsh-title-bar-compat]` 用 `strip + 14px`（DSH 标题行位于 caption strip 之下）。

## 验证

- DSH 0.1.1-rc.2（`dsh web` 经 nginx 反代）headless Chromium 实测：1280×720 与 390×844 折叠态开关组中心 28px，与原生标题行控件齐平；展开态中心仍 17px，无回归。
- `pnpm typecheck` 通过；`pnpm test` 92 文件全过（912 passed / 5 skipped）。
