### PR TITLE
feat(git): render commit history graph

### DIFF
--- a/src/client/GitView.tsx
+++ b/src/client/GitView.tsx
@@ -9,7 +9,7 @@
  * focus. While visible it polls lightweight porcelain state so model-authored
  * file changes appear without a manual refresh.
  */
-import { useCallback, useEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react'
 import {
   Button, IconBranchOutline16, IconCodeOutline16, IconCopyOutline16, IconRefreshOutline16,
   IconTrashOutline16, Input, Menu, Modal, writeClipboard,
@@ -17,6 +17,7 @@ import {
 import type { GitLogEntry, GitStatusEntry, GitStatusResult, GitWorktree, SessionScope } from './api.ts'
 import { api } from './api.ts'
 import { isWithinWorkspace, relativeTo } from './paths.ts'
+import { layoutGitGraph } from './git-graph.ts'
 import { resolveSidebarPath } from './produced-files.ts'
 import { relativeTime, t } from './locales.ts'
 import type { SidebarTab } from './state.ts'
@@ -104,6 +105,11 @@ export function GitView(props: {
   /** Whether the history was fully paged (a batch shorter than LOG_BATCH). */
   const [logEnded, setLogEnded] = useState(false)
   const [logLoadingMore, setLogLoadingMore] = useState(false)
+  const graphRows = useMemo(() => layoutGitGraph(logEntries), [logEntries])
+  const graphLanes = graphRows.reduce(
+    (max, row) => Math.max(max, row.lanes, row.lane + 1),
+    1,
+  )
 
   /** The open file-row context menu (cursor position for the portaled Menu). */
   const [fileMenu, setFileMenu] = useState<{ entry: GitStatusEntry; staged: boolean; x: number; y: number } | null>(null)
@@ -520,34 +526,77 @@ export function GitView(props: {
 
           <div className={css.gitSection}>
             <div className={css.gitSectionHeader}><span>{t('history')}</span></div>
-            {logEntries.map(entry => (
-              <div
-                key={entry.hashFull}
-                role="button"
-                tabIndex={0}
-                className={css.gitLogRow}
-                title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
-                onClick={() => { openCommitDiff(entry) }}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault()
-                    openCommitDiff(entry)
-                  }
-                }}
-                onContextMenu={(event) => { openHistoryMenu(event, entry) }}
-              >
-                <span className={css.gitLogLine1}>
-                  <span className={css.gitLogHash}>{entry.hash}</span>
-                  <span className={css.gitLogSubject}>{entry.subject}</span>
-                </span>
-                <span className={css.gitLogLine2}>
-                  {refNames(entry.refs).map(ref => (
-                    <span key={ref} className={css.gitLogRef}>{ref}</span>
-                  ))}
-                  <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
-                </span>
-              </div>
-            ))}
+            {logEntries.map((entry, index) => {
+              const graph = graphRows[index]!
+              const graphWidth = Math.max(24, Math.min(52, graphLanes * 9 + 6))
+              const laneX = (lane: number): number => graphLanes === 1
+                ? graphWidth / 2
+                : 5 + lane * ((graphWidth - 10) / (graphLanes - 1))
+              return (
+                <div
+                  key={entry.hashFull}
+                  role="button"
+                  tabIndex={0}
+                  className={css.gitLogRow}
+                  title={`${entry.author} · ${entry.date}\n${entry.hashFull}`}
+                  onClick={() => { openCommitDiff(entry) }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      openCommitDiff(entry)
+                    }
+                  }}
+                  onContextMenu={(event) => { openHistoryMenu(event, entry) }}
+                >
+                  <span className={css.gitGraphCell} style={{ width: graphWidth }}>
+                    <svg
+                      className={css.gitGraphSvg}
+                      viewBox={`0 0 ${graphWidth} 1`}
+                      preserveAspectRatio="none"
+                      aria-hidden="true"
+                    >
+                      {graph.edges.map((edge, edgeIndex) => {
+                        const from = laneX(edge.from)
+                        const to = laneX(edge.to)
+                        const d = edge.from === edge.to
+                          ? `M ${from} 0 L ${from} 1`
+                          : `M ${from} 0 C ${from} 0.45, ${to} 0.55, ${to} 1`
+                        return (
+                          <path
+                            key={edgeIndex}
+                            d={d}
+                            fill="none"
+                            stroke={`var(--git-graph-${edge.color % 6})`}
+                            strokeWidth={2}
+                            vectorEffect="non-scaling-stroke"
+                            strokeLinecap="round"
+                          />
+                        )
+                      })}
+                    </svg>
+                    <span
+                      className={css.gitGraphNode}
+                      style={{
+                        left: laneX(graph.lane),
+                        background: `var(--git-graph-${graph.color % 6})`,
+                      }}
+                    />
+                  </span>
+                  <span className={css.gitLogText}>
+                    <span className={css.gitLogLine1}>
+                      <span className={css.gitLogHash}>{entry.hash}</span>
+                      <span className={css.gitLogSubject}>{entry.subject}</span>
+                    </span>
+                    <span className={css.gitLogLine2}>
+                      {refNames(entry.refs).map(ref => (
+                        <span key={ref} className={css.gitLogRef}>{ref}</span>
+                      ))}
+                      <span className={css.gitLogMeta}>{entry.author} · {relativeTime(entry.date)}</span>
+                    </span>
+                  </span>
+                </div>
+              )
+            })}
             {!logEnded && (
               <button
                 type="button"

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -68,6 +68,8 @@ export interface GitLogEntry {
   date: string
   /** Ref decorations (--decorate=short), e.g. `HEAD -> main, origin/main`; '' when none. */
   refs: string
+  /** Parent full hashes, first parent first; empty for a root commit. */
+  parents: string[]
 }
 
 /** Text read result. */

--- a/src/client/git-graph.ts
+++ b/src/client/git-graph.ts
@@ -1,0 +1,88 @@
+/**
+ * Lane layout for the source-control history graph. The input is the same
+ * newest-first list used by the history rows; each row receives the edges
+ * needed to render one slice of the branch graph.
+ */
+import type { GitLogEntry } from './api.ts'
+
+export interface GitGraphEdge {
+  /** Horizontal lane at the top of the row slice. */
+  from: number
+  /** Horizontal lane at the bottom of the row slice. */
+  to: number
+  /** Stable lane color index; edges joining a lane use that lane's color. */
+  color: number
+}
+
+export interface GitGraphRow {
+  /** The commit's lane at the middle of its row slice. */
+  lane: number
+  /** The commit's stable branch color. */
+  color: number
+  /** Number of lanes that exist after this row has been placed. */
+  lanes: number
+  edges: GitGraphEdge[]
+}
+
+interface GraphLane {
+  hash: string
+  color: number
+}
+
+/** Lay out commits into left-to-right lanes. Unknown parents get a lane so
+ *  page boundaries do not make an otherwise continuous branch disappear. */
+export function layoutGitGraph(entries: readonly GitLogEntry[]): GitGraphRow[] {
+  const rows: GitGraphRow[] = []
+  let active: GraphLane[] = []
+  let nextColor = 0
+
+  for (const entry of entries) {
+    let lane = active.findIndex(item => item.hash === entry.hashFull)
+    if (lane === -1) {
+      active.push({ hash: entry.hashFull, color: nextColor++ })
+      lane = active.length - 1
+    }
+
+    const nodeColor = active[lane]!.color
+    const remaining = active.filter((_, index) => index !== lane)
+    const targetOf = (hash: string): number => remaining.findIndex(item => item.hash === hash)
+    const parentTargets: number[] = []
+
+    entry.parents.forEach((parent, parentIndex) => {
+      let target = targetOf(parent)
+      if (target !== -1) {
+        parentTargets.push(target)
+        return
+      }
+      // The first parent continues the commit's branch in its original
+      // position; side parents open new lanes to the right.
+      const insertedLane: GraphLane = {
+        hash: parent,
+        color: parentIndex === 0 ? nodeColor : nextColor++,
+      }
+      if (parentIndex === 0) remaining.splice(Math.min(lane, remaining.length), 0, insertedLane)
+      else remaining.push(insertedLane)
+      parentTargets.push(remaining.length - 1)
+    })
+
+    const edges: GitGraphEdge[] = []
+    active.forEach((item, index) => {
+      if (index === lane) return
+      const to = remaining.findIndex(candidate => candidate.hash === item.hash)
+      if (to !== -1) edges.push({ from: index, to, color: item.color })
+    })
+    parentTargets.forEach((to, parentIndex) => {
+      // A first-parent edge stays on the commit's branch; side branches keep
+      // their own color while curving into an existing lane.
+      edges.push({
+        from: lane,
+        to,
+        color: parentIndex === 0 ? nodeColor : remaining[to]!.color,
+      })
+    })
+    rows.push({ lane, color: nodeColor, lanes: remaining.length, edges })
+    active = remaining
+  }
+
+  return rows
+}

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2507,11 +2507,51 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
    (badges live on the second line so they never crowd the subject). */
 .gitLogRow {
   display: flex;
-  flex-direction: column;
+  align-items: stretch;
   gap: 2px;
   padding: 5px 12px;
   cursor: pointer;
   border-radius: 8px;
+}
+
+.gitGraphCell {
+  --git-graph-0: #2563eb;
+  --git-graph-1: #16a34a;
+  --git-graph-2: #f59e0b;
+  --git-graph-3: #9333ea;
+  --git-graph-4: #db2777;
+  --git-graph-5: #0891b2;
+
+  position: relative;
+  flex: none;
+  min-width: 24px;
+}
+
+.gitGraphSvg {
+  position: absolute;
+  inset: -5px 0;
+  width: 100%;
+  height: calc(100% + 10px);
+  overflow: visible;
+}
+
+.gitGraphNode {
+  position: absolute;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--dsw-alias-bg-layer-1);
+  border-radius: 999px;
+  transform: translate(-50%, -50%);
+  box-sizing: content-box;
+}
+
+.gitLogText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
 }
 
 .gitLogRow:hover {

--- a/src/git.ts
+++ b/src/git.ts
@@ -55,6 +55,8 @@ export interface GitLogEntry {
   date: string
   /** Ref decorations (`%D` with --decorate=short), e.g. `HEAD -> main, origin/main`; '' when none. */
   refs: string
+  /** Parent full hashes, first parent first; empty for a root commit. */
+  parents: string[]
 }
 
 /** One git failure (stderr text as the message). */
@@ -133,12 +135,12 @@ export function parseWorktreeList(output: string): GitWorktreeRecord[] {
   return rows
 }
 
-/** Parse `git log --pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D` rows. */
+/** Parse `git log --pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%P%x1f%D` rows. */
 export function parseLogLines(output: string): GitLogEntry[] {
   const rows: GitLogEntry[] = []
   for (const line of output.split('\n')) {
     if (line === '') continue
-    const [hash, subject, author, date, hashFull, refs] = line.split('\x1f')
+    const [hash, subject, author, date, hashFull, parents, refs] = line.split('\x1f')
     if (hash === undefined || subject === undefined) continue
     rows.push({
       hash,
@@ -146,6 +148,7 @@ export function parseLogLines(output: string): GitLogEntry[] {
       author: author ?? '',
       date: date ?? '',
       hashFull: hashFull ?? hash,
+      parents: (parents ?? '').split(' ').filter(parent => parent !== ''),
       refs: refs ?? '',
     })
   }
@@ -346,7 +349,7 @@ export async function checkout(cwd: string, branch: string, selected?: string): 
 export async function log(cwd: string, count = 30, skip = 0, selected?: string): Promise<GitLogEntry[]> {
   const raw = await runGit(await repoRoot(cwd, selected), [
     'log', '-n', String(count), '--skip', String(skip), '--decorate=short',
-    '--pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%D',
+    '--pretty=format:%h%x1f%s%x1f%an%x1f%ai%x1f%H%x1f%P%x1f%D',
   ])
   return parseLogLines(raw)
 }

--- a/tests/git-graph.spec.ts
+++ b/tests/git-graph.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { layoutGitGraph } from '../src/client/git-graph.ts'
+import type { GitLogEntry } from '../src/client/api.ts'
+
+function commit(hash: string, parents: string[] = []): GitLogEntry {
+  return {
+    hash: hash.slice(0, 7),
+    hashFull: hash,
+    subject: hash,
+    author: 'Test',
+    date: '2026-08-24 00:00:00 +0800',
+    parents,
+    refs: '',
+  }
+}
+
+describe('git history graph layout', () => {
+  it('keeps linear history in one lane', () => {
+    const rows = layoutGitGraph([
+      commit('ccccccc', ['bbbbbbb']),
+      commit('bbbbbbb', ['aaaaaaa']),
+      commit('aaaaaaa'),
+    ])
+    expect(rows.map(row => row.lane)).toEqual([0, 0, 0])
+    expect(rows[0]).toMatchObject({ lanes: 1, edges: [{ from: 0, to: 0, color: 0 }] })
+    expect(rows[2]!.edges).toEqual([])
+  })
+
+  it('puts a side branch in a second lane and merges it back', () => {
+    const rows = layoutGitGraph([
+      commit('mmmmmmm', ['nnnnnnn', 'sssssss']),
+      commit('sssssss', ['nnnnnnn']),
+      commit('nnnnnnn'),
+    ])
+    expect(rows[0]).toMatchObject({ lane: 0, lanes: 2 })
+    expect(rows[0]!.edges).toEqual([
+      { from: 0, to: 0, color: 0 },
+      { from: 0, to: 1, color: 1 },
+    ])
+    expect(rows[1]!.lane).toBe(1)
+    expect(rows[1]!.edges).toContainEqual({ from: 1, to: 0, color: 1 })
+  })
+})

--- a/tests/git-view-worktree.spec.tsx
+++ b/tests/git-view-worktree.spec.tsx
@@ -38,6 +38,7 @@ function logFor(target?: string, index = 0): GitLogEntry[] {
     subject: agent ? `Agent checkout commit ${index}` : `Main checkout commit ${index}`,
     author: 'Test',
     date: '2026-08-20 00:00:00 +0800',
+    parents: index === 0 ? [] : [`${digit.repeat(32)}${(index - 1).toString(16).padStart(8, '0')}`],
     refs: agent ? 'HEAD -> agent' : 'HEAD -> main',
   }]
 }

--- a/tests/git.spec.ts
+++ b/tests/git.spec.ts
@@ -80,8 +80,8 @@ describe('git parsing', () => {
 
   it('parses log rows with unit separators (full hash + refs)', () => {
     const rows = parseLogLines(
-      'abc1234\x1fFirst subject\x1fAlice\x1f2024-01-01 10:00:00 +0800\x1fabc1234def5678abc1234def5678abc1234def5678\x1fHEAD -> main, origin/main\n'
-      + 'def5678\x1fSecond subject\x1fBob\x1f2024-01-02 10:00:00 +0800\x1fdef5678abc1234def5678abc1234def5678abc1234\x1f\n',
+      'abc1234\x1fFirst subject\x1fAlice\x1f2024-01-01 10:00:00 +0800\x1fabc1234def5678abc1234def5678abc1234def5678\x1fdef5678abc1234def5678abc1234def5678abc1234\x1fHEAD -> main, origin/main\n'
+      + 'def5678\x1fSecond subject\x1fBob\x1f2024-01-02 10:00:00 +0800\x1fdef5678abc1234def5678abc1234def5678abc1234\x1f\x1f\n',
     )
     expect(rows).toEqual([
       {
@@ -90,6 +90,7 @@ describe('git parsing', () => {
         author: 'Alice',
         date: '2024-01-01 10:00:00 +0800',
         hashFull: 'abc1234def5678abc1234def5678abc1234def5678',
+        parents: ['def5678abc1234def5678abc1234def5678abc1234'],
         refs: 'HEAD -> main, origin/main',
       },
       {
@@ -98,6 +99,7 @@ describe('git parsing', () => {
         author: 'Bob',
         date: '2024-01-02 10:00:00 +0800',
         hashFull: 'def5678abc1234def5678abc1234def5678abc1234',
+        parents: [],
         refs: '',
       },
     ])


### PR DESCRIPTION
## Summary
- add parent hashes to Git log entries
- lay out source-control history into colored branch lanes
- render merge/fork curves and commit nodes in the Git history list
- cover linear history, branch forks, merges, and log parsing

## Validation
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run tests/git-graph.spec.ts tests/git-view-worktree.spec.tsx`

Relevant log parsing is covered by `tests/git.spec.ts`; graph layout is covered by the new `tests/git-graph.spec.ts`.