### PR TITLE
test: realpath temp workspaces in git specs (macOS)

### DIFF
--- a/tests/git-worktree.spec.ts
+++ b/tests/git-worktree.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {realpathSync,  mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { parseWorktreeList, resolveWorktree, status, worktrees } from '../src/git.ts'
@@ -56,7 +56,7 @@ describe('linked Git worktrees', () => {
   })
 
   it('discovers dirty linked checkouts and fences selected targets', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'dsh-sidebar-worktrees-'))
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'dsh-sidebar-worktrees-')))
     const main = join(root, 'main')
     const agent = join(root, 'agent worktree')
     try {

--- a/tests/git.spec.ts
+++ b/tests/git.spec.ts
@@ -1,6 +1,6 @@
 import { execFile, execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import {realpath,  mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
@@ -13,7 +13,7 @@ const normalizePath = (path: string): string => path.replaceAll('\\', '/')
 
 describe('git parsing', () => {
   it('discovers and selects direct child repositories under a workspace directory', async () => {
-    const workspace = await mkdtemp(join(tmpdir(), 'dsh-better-sidebar-git-'))
+    const workspace = await realpath(await mkdtemp(join(tmpdir(), 'dsh-better-sidebar-git-')))
     const first = join(workspace, 'first-repo')
     const second = join(workspace, 'second-repo')
     try {


### PR DESCRIPTION
macOS 把 /var 软链到 /private/var：os.tmpdir() 返回软链拼写，而 git 内部/子进程报告规范路径，tests/git.spec.ts 与 tests/git-worktree.spec.ts 的相等断言在原版 macOS 上直接失败。对 mkdtemp 结果做一次 realpath，让断言锚定物理路径，其他平台行为不变。独立验证：两个 spec 串行 12/12 通过，全套 912/917 串行通过（5 个 skip、0 真失败）。