### PR TITLE
feat(filetree): add open-in-explorer hover button

### DIFF
--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -297,24 +297,49 @@ export function FileTree(props: {
     })
   }, [])
 
-  /** The row's trailing actions: the @-reference button, or the copied label. */
+  /** Open `path` in the OS file manager through the host route: directories
+   *  open directly, files open with the parent folder and the file focused. */
+  const openInExplorer = (path: string, isDir: boolean): void => {
+    void api.openExternal(isDir
+      ? { action: 'open', path }
+      : { action: 'reveal', path },
+    ).catch((error: unknown) => {
+      console.error('open in explorer failed', error)
+    })
+  }
+
+  /** The row's trailing actions: the @-reference button plus the open-in-explorer button, or the copied label. */
   const rowActions = (entry: FsEntry): ReactNode => {
     if (copiedPath === entry.path) {
       return <span className={css.explorerCopied}>{t('copied')}</span>
     }
     return (
-      <button
-        type="button"
-        className={css.explorerRef}
-        aria-label={t('referenceFile')}
-        title={t('referenceFile')}
-        onClick={(event) => {
-          event.stopPropagation()
-          onReferenceFile(entry.path)
-        }}
-      >
-        {t('referenceFile')}
-      </button>
+      <>
+        <button
+          type="button"
+          className={css.explorerRef}
+          aria-label={t('referenceFile')}
+          title={t('referenceFile')}
+          onClick={(event) => {
+            event.stopPropagation()
+            onReferenceFile(entry.path)
+          }}
+        >
+          {t('referenceFile')}
+        </button>
+        <button
+          type="button"
+          className={css.explorerRef}
+          aria-label={t('openWithExplorer')}
+          title={t('openWithExplorer')}
+          onClick={(event) => {
+            event.stopPropagation()
+            openInExplorer(entry.path, entry.isDir)
+          }}
+        >
+          {t('openWithExplorer')}
+        </button>
+      </>
     )
   }
 
@@ -525,18 +550,32 @@ export function FileTree(props: {
             {copiedPath === root
               ? <span className={css.explorerCopied}>{t('copied')}</span>
               : (
-                <button
-                  type="button"
-                  className={css.explorerRef}
-                  aria-label={t('referenceFile')}
-                  title={t('referenceFile')}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onReferenceFile(root)
-                  }}
-                >
-                  {t('referenceFile')}
-                </button>
+                <>
+                  <button
+                    type="button"
+                    className={css.explorerRef}
+                    aria-label={t('referenceFile')}
+                    title={t('referenceFile')}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onReferenceFile(root)
+                    }}
+                  >
+                    {t('referenceFile')}
+                  </button>
+                  <button
+                    type="button"
+                    className={css.explorerRef}
+                    aria-label={t('openWithExplorer')}
+                    title={t('openWithExplorer')}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      openInExplorer(root, true)
+                    }}
+                  >
+                    {t('openWithExplorer')}
+                  </button>
+                </>
               )}
           </div>
           {data[root] !== undefined && renderLevel(root, 1)}

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -318,7 +318,7 @@ export const api = {
    *  the OS file manager, or hand a custom-scheme URL (vscode://, cursor://,
    *  zed://, custom editors) to its registered handler. The host launches
    *  the platform opener (argv, no shell). */
-  openExternal: (payload: { action: 'reveal'; path: string } | { action: 'url'; url: string }) =>
+  openExternal: (payload: { action: 'open'; path: string } | { action: 'reveal'; path: string } | { action: 'url'; url: string }) =>
     call<{ started: boolean }>('open.external', payload),
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -584,8 +584,9 @@ function buildApi(
       const record = payload as { action?: unknown } | null
       const action = record?.action
       if (action === 'reveal') return launchExternal('reveal', requireString(payload, 'path'))
+      if (action === 'open') return launchExternal('open', requireString(payload, 'path'))
       if (action === 'url') return launchExternal('url', requireString(payload, 'url'))
-      throw new SidebarError('bad-request', 'action must be "reveal" or "url"')
+      throw new SidebarError('bad-request', 'action must be "open", "reveal" or "url"')
     },
     // Side Chat: create a side-thread child seeded with the parent's full
     // log up to now, deliver follow-ups (cold-resuming when the thread's

--- a/src/open-external.ts
+++ b/src/open-external.ts
@@ -14,12 +14,29 @@ import { parentOf, requireAbsolute } from './fs-tree.ts'
 import { SidebarError } from './wire.ts'
 
 /** The two external open actions the route accepts. */
-export type OpenExternalAction = 'reveal' | 'url'
+export type OpenExternalAction = 'open' | 'reveal' | 'url'
 
 /** One platform opener invocation (argv array — never a shell string). */
 export interface ExternalCommand {
   command: string
   args: string[]
+}
+
+/** Open a path in the OS file manager: directories open directly, files open
+ *  in their containing folder (Explorer/Finder enter the folder for a
+ *  directory argument; a file argument lands the manager on its parent with
+ *  the file focused). */
+export function openCommand(path: string, platform: NodeJS.Platform = process.platform): ExternalCommand {
+  switch (platform) {
+    case 'darwin':
+      return { command: 'open', args: [path] }
+    case 'win32':
+      // No `/select,` here — a bare directory path makes Explorer ENTER the
+      // folder (a file path still lands on its parent with the file focused).
+      return { command: 'explorer.exe', args: [path] }
+    default:
+      return { command: 'xdg-open', args: [path] }
+  }
 }
 
 /** Reveal/select a path in the OS file manager. On Linux there is no common
@@ -82,7 +99,9 @@ export function launchExternal(action: OpenExternalAction, value: string): { sta
   const platform = process.platform
   const spec = action === 'reveal'
     ? revealCommand(requireAbsolute(value), platform)
-    : urlCommand(validateExternalUrl(value), platform)
+    : action === 'open'
+      ? openCommand(requireAbsolute(value), platform)
+      : urlCommand(validateExternalUrl(value), platform)
   const child = spawn(spec.command, spec.args, { detached: true, stdio: 'ignore' })
   child.on('error', () => { /* opener missing/denied: handled by the OS */ })
   child.unref()

--- a/tests/open-external.spec.ts
+++ b/tests/open-external.spec.ts
@@ -5,8 +5,22 @@
  * OS outcome is not testable here.
  */
 import { describe, expect, it } from 'vitest'
-import { launchExternal, revealCommand, urlCommand, validateExternalUrl } from '../src/open-external.ts'
+import { openCommand, launchExternal, revealCommand, urlCommand, validateExternalUrl } from '../src/open-external.ts'
 import { SidebarError } from '../src/wire.ts'
+
+describe('openCommand', () => {
+  it('darwin: `open <path>` opens the folder in Finder', () => {
+    expect(openCommand('/a/b', 'darwin')).toEqual({ command: 'open', args: ['/a/b'] })
+  })
+
+  it('win32: a bare `explorer <path>` enters the folder (no /select,)', () => {
+    expect(openCommand('C:\\a\\b', 'win32')).toEqual({ command: 'explorer.exe', args: ['C:\\a\\b'] })
+  })
+
+  it('linux: `xdg-open <path>` opens the folder', () => {
+    expect(openCommand('/a/b', 'linux')).toEqual({ command: 'xdg-open', args: ['/a/b'] })
+  })
+})
 
 describe('revealCommand', () => {
   it('darwin: `open -R <path>` selects the file in Finder', () => {


### PR DESCRIPTION
﻿Add a hover button to each file tree row that opens the file/folder in the OS file manager (Explorer/Finder/xdg-open).

- **File rows**: reveals the file in its parent folder with the item selected
- **Directory rows**: opens the folder directly
- The button sits to the right of the existing @-reference button, reusing the same `.explorerRef` CSS class
- Reuses the existing `openWithExplorer` locale key (资源管理器 / File Manager), no new i18n required
- Adds a new `open` action to the external-open system (in addition to existing `reveal` and `url`), for opening a directory directly rather than selecting it in its parent
- Root row (workspace root) also gets the button

Implementation details:
- `src/open-external.ts`: adds `openCommand` (win32: `explorer.exe <path>`, darwin: `open <path>`, linux: `xdg-open <path>`) and extends `launchExternal` to handle the `open` action
- `src/index.ts`: adds `open` action handling to the `open.external` route
- `src/client/api.ts`: extends the `openExternal` call type
- `src/client/FileTree.tsx`: adds `openInExplorer` function and the hover button to both `rowActions` and the root row
- `tests/open-external.spec.ts`: adds tests for `openCommand`
