### PR TITLE
[Bug] Free Window 在会话恢复后可能生成重复的 float ID

### DIFF
--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -149,7 +149,7 @@ export function mintTabId(): string {
 
 /**
  * The largest numeric suffix across a raw persisted state's counter ids
- * (`pane:N` / `tab:N` / `split:N`). The uid counter is module-global and
+ * (`pane:N` / `tab:N` / `split:N` / `float:N`). The uid counter is module-global and
  * resets on every reload, so a split minted AFTER a reload would collide
  * with the persisted ids (a fresh "pane:1" beside the persisted "pane:1");
  * mapLeaf would then visit BOTH leaves and every open would land in both
@@ -160,7 +160,7 @@ function maxCounterId(parsed: unknown): number {
   let max = 0
   const consider = (id: unknown): void => {
     if (typeof id !== 'string') return
-    const match = /^(?:pane|tab|split):(\d+)$/.exec(id)
+    const match = /^(?:pane|tab|split|float):(\d+)$/.exec(id)
     if (match !== null) max = Math.max(max, Number(match[1]))
   }
   const walk = (node: unknown): void => {

--- a/tests/free-window-restored-id.spec.ts
+++ b/tests/free-window-restored-id.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createSidebarStore, floatTab } from '../src/client/state.ts'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('restored free-window ids', () => {
+  it('seeds the shared uid counter past persisted float ids before minting another window', () => {
+    localStorage.setItem('dsh-sidebar:v1:s1', JSON.stringify({
+      panelOpen: true,
+      width: 400,
+      activePane: 'pane:1',
+      nextTerminal: 1,
+      nextBrowser: 1,
+      expanded: [],
+      splits: {
+        kind: 'leaf',
+        id: 'pane:1',
+        active: 'tab:2',
+        tabs: [{ id: 'tab:2', type: 'browser', title: 'Docked' }],
+      },
+      bottomOpen: false,
+      bottomHeight: 220,
+      bottomOpenedOnce: false,
+      bottomSplits: {
+        kind: 'leaf',
+        id: 'pane:3',
+        active: null,
+        tabs: [],
+      },
+      floats: [{
+        id: 'float:5',
+        tab: { id: 'tab:4', type: 'browser', title: 'Existing float' },
+        x: 0,
+        y: 0,
+        w: 390,
+        h: 500,
+      }],
+    }))
+
+    const store = createSidebarStore()
+    store.setSession('s1')
+    store.reduce(state => floatTab(state, 'tab:2', 400, 300))
+
+    const ids = store.getSnapshot().state!.floats.map(float => float.id)
+    expect(ids).toEqual(['float:5', 'float:6'])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})


### PR DESCRIPTION
## 问题描述

Free Window 与 pane / tab / split 共用同一个模块级 `uid()` 计数器来生成 ID，例如 `float:5`。

但当前会话恢复逻辑在计算持久化状态中的最大计数值时，只识别 `pane:N`、`tab:N` 和 `split:N`，没有把 `float:N` 纳入统计。

这会导致一种边界情况：如果刷新前最大的 ID 恰好属于 Free Window，刷新恢复后全局计数器会被恢复到一个偏小的值。此时再次将某个 tab 浮动为 Free Window，就可能重新生成一个已经存在的 `float:N` ID。

重复的 float ID 会影响所有按 window id 定位的操作，例如移动、缩放、置顶和重新 dock，可能出现操作一个窗口却同时影响另一个窗口，或者命中错误窗口的情况。

## 复现步骤

可以用下面这个确定性的状态来复现：

1. 当前会话中存在以下 ID：
   - `pane:1`
   - `tab:2`
   - `pane:3`
   - `tab:4`
   - 一个已经打开的 Free Window：`float:5`
2. 刷新 / 重启侧边栏，使上述状态从持久化数据中恢复。
3. 恢复时，当前 `maxCounterId()` 只统计 pane / tab / split，因此最大值会被识别为 `4`，而不是 `5`。
4. 再把一个普通 tab 浮动为新的 Free Window。
5. `uid('float')` 会从计数器 `4` 继续递增，并再次生成 `float:5`。

## 实际结果

同一会话中出现两个 ID 都为 `float:5` 的 Free Window。

后续执行 move / resize / raise / dock 等基于 float ID 的操作时，可能匹配到多个窗口或错误窗口。

## 预期结果

恢复持久化状态时，`float:N` 应与 `pane:N`、`tab:N`、`split:N` 一样参与全局 UID 最大值计算。

如果恢复状态中已经存在 `float:5`，刷新后新创建的 Free Window 应至少生成 `float:6`，并保证 ID 唯一。

## 原因定位

当前最大 ID 的匹配逻辑类似：

```ts
/^(?:pane|tab|split):(\d+)$/
```

但 Free Window 实际也通过共享计数器生成：

```ts
uid('float')
```

因此这里存在恢复逻辑与 ID 生成逻辑不一致的问题。

## 建议修复

将 `float` 纳入恢复阶段的 ID 匹配范围，并增加一个回归测试：恢复已有 `float:5` 的状态后，再创建一个 Free Window，应得到 `float:6` 且所有 float ID 唯一。

已有对应修复 PR：#385