### PR TITLE
fix(files): make folder rows reliable toggles

### DIFF
--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -139,6 +139,8 @@ export function FileTree(props: {
   const { sessionId, cwd, expanded, revealed, onToggle, onOpenFile, onOpenFileNewTab, onOpenFileSide, openWithTargets, openWithPinned, openWithSsh, onOpenWith, onToggleOpenWithPin, onReferenceFile, refreshTick, onUploadRequest, busy } = props
   const [data, setData] = useState<Record<string, LevelData>>({})
   const dataRef = useRef(data)
+  /** The workspace root is a visible tree node too; it starts open per cwd. */
+  const [rootOpen, setRootOpen] = useState(true)
   /** The row whose path was just copied ("copied" label replaces its button). */
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
   /** Open context menu: the row path (and whether it is a directory) plus the cursor position. */
@@ -275,6 +277,17 @@ export function FileTree(props: {
     loadDir(root)
     for (const dir of expanded) loadDir(dir)
   }, [cwd, expanded, refreshTick, loadDir])
+
+  useEffect(() => {
+    setRootOpen(true)
+  }, [cwd])
+
+  // "Show in folder" must remain able to surface its target even when the
+  // user previously collapsed the workspace root. A later manual collapse
+  // stays respected until a new reveal payload arrives.
+  useEffect(() => {
+    if (revealed.length > 0) setRootOpen(true)
+  }, [revealed])
 
   // Bring a "Show in folder" reveal into view: the ancestors expand above
   // (revealPaths), but the row may not be scrolled into sight — a reveal on
@@ -438,8 +451,6 @@ export function FileTree(props: {
         return (
           <div key={entry.path}>
             <div
-              role="button"
-              tabIndex={0}
               className={clsx(
                 css.explorerRow, css.explorerDir, entry.hidden && css.explorerHidden,
                 dropTarget === entry.path && css.explorerRowDropTarget,
@@ -447,20 +458,20 @@ export function FileTree(props: {
               )}
               data-dsh-revealed={revealed.includes(entry.path) ? 'true' : undefined}
               style={{ paddingLeft: depth * 22 + 6 }}
-              onClick={() => { onToggle(entry.path) }}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault()
-                  onToggle(entry.path)
-                }
-              }}
               onDragOver={(event) => { handleRowDragOver(event, entry.path) }}
               onDrop={(event) => { handleDirDrop(event, entry.path) }}
               onContextMenu={(event) => { openRowMenu(event, entry.path, true) }}
             >
-              {isOpen ? <VscFolderOpened size={14} /> : <VscFolder size={14} />}
-              <span className={css.explorerName}>{entry.name}</span>
-              {entry.isSymlink && <IconLinkOutline16 size={12} className={css.explorerSymlink} />}
+              <button
+                type="button"
+                className={css.explorerDirToggle}
+                aria-expanded={isOpen}
+                onClick={() => { onToggle(entry.path) }}
+              >
+                {isOpen ? <VscFolderOpened size={14} /> : <VscFolder size={14} />}
+                <span className={css.explorerName}>{entry.name}</span>
+                {entry.isSymlink && <IconLinkOutline16 size={12} className={css.explorerSymlink} />}
+              </button>
               {rowActions(entry)}
             </div>
             {isOpen && renderLevel(entry.path, depth + 1)}
@@ -520,8 +531,15 @@ export function FileTree(props: {
             onDrop={(event) => { handleDirDrop(event, root) }}
             onContextMenu={(event) => { openRowMenu(event, root, true) }}
           >
-            <VscFolderOpened size={14} />
-            <span className={css.explorerName}>{baseName(root)}</span>
+            <button
+              type="button"
+              className={css.explorerDirToggle}
+              aria-expanded={rootOpen}
+              onClick={() => { setRootOpen(open => !open) }}
+            >
+              {rootOpen ? <VscFolderOpened size={14} /> : <VscFolder size={14} />}
+              <span className={css.explorerName}>{baseName(root)}</span>
+            </button>
             {copiedPath === root
               ? <span className={css.explorerCopied}>{t('copied')}</span>
               : (
@@ -539,7 +557,7 @@ export function FileTree(props: {
                 </button>
               )}
           </div>
-          {data[root] !== undefined && renderLevel(root, 1)}
+          {rootOpen && data[root] !== undefined && renderLevel(root, 1)}
         </>
       )}
       {dropOver && dropRect !== null && createPortal(

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -943,6 +943,30 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   font: var(--dsw-font-s-strong-14);
 }
 
+/* Keep the directory toggle and the hover-only @ action as sibling controls.
+   A role=button row containing a real button creates overlapping interactive
+   targets. The native button owns the remaining row width and exposes
+   aria-expanded; clicking it a second time always collapses the directory. */
+.explorerDirToggle {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.explorerDirToggle .explorerName {
+  flex: 1;
+}
+
 .explorerHidden {
   opacity: 0.45;
 }
@@ -2652,6 +2676,7 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 .tabBarPlus:focus-visible,
 .paneCard:focus-visible,
 .explorerRow:focus-visible,
+.explorerDirToggle:focus-visible,
 .explorerRef:focus-visible,
 .gitRowMain:focus-visible,
 .gitLink:focus-visible,

--- a/tests/file-tree-drop.spec.tsx
+++ b/tests/file-tree-drop.spec.tsx
@@ -97,9 +97,9 @@ function fire(target: Element, type: string, dataTypes?: string[]): Event {
 
 const dropZone = (): HTMLElement | null => document.body.querySelector<HTMLElement>('[class*="uploadDropZone"]')
 
-/** The row whose label text matches (rows are role="button" divs). */
+/** The visual row whose label text matches (folder toggles are child buttons). */
 function rowByName(container: HTMLElement, name: string): HTMLElement {
-  const row = [...container.querySelectorAll<HTMLElement>('[role="button"]')]
+  const row = [...container.querySelectorAll<HTMLElement>('[class*="explorerRow"]')]
     .find(el => el.querySelector('[class*="explorerName"]')?.textContent === name)
   if (row === undefined) throw new Error(`row not found: ${name}`)
   return row

--- a/tests/file-tree-toggle.spec.tsx
+++ b/tests/file-tree-toggle.spec.tsx
@@ -1,0 +1,145 @@
+/** FileTree folder controls, including the workspace root. */
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createElement, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { FileTree } from '../src/client/FileTree.tsx'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+beforeAll(() => {
+  Object.defineProperty(window.navigator, 'language', { value: 'en-US', configurable: true })
+})
+
+vi.mock('../src/client/api.ts', () => ({
+  api: {
+    fsTree: async (_scope: unknown, dir: string) => ({
+      entries: dir === '/tmp'
+        ? [{ name: 'src', path: '/tmp/src', isDir: true }]
+        : dir === '/tmp/src'
+          ? [
+              { name: 'client', path: '/tmp/src/client', isDir: true },
+              { name: 'index.ts', path: '/tmp/src/index.ts', isDir: false },
+            ]
+          : [{ name: 'view.tsx', path: '/tmp/src/client/view.tsx', isDir: false }],
+    }),
+  },
+  downloadUrl: () => '/sidebar/file',
+}))
+
+interface Harness {
+  container: HTMLDivElement
+  references: string[]
+  unmount: () => void
+}
+
+async function mountTree(): Promise<Harness> {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root: Root = createRoot(container)
+  const references: string[] = []
+
+  function ControlledTree() {
+    const [expanded, setExpanded] = useState<string[]>([])
+    return createElement(FileTree, {
+      sessionId: 's1',
+      cwd: '/tmp',
+      expanded,
+      revealed: [],
+      onToggle: (path: string) => {
+        setExpanded(current => current.includes(path)
+          ? current.filter(item => item !== path)
+          : [...current, path])
+      },
+      onOpenFile: () => {},
+      onReferenceFile: (path: string) => { references.push(path) },
+      refreshTick: 0,
+      onUploadRequest: () => {},
+      busy: false,
+    })
+  }
+
+  await act(async () => { root.render(createElement(ControlledTree)) })
+  return {
+    container,
+    references,
+    unmount: () => { act(() => { root.unmount() }) },
+  }
+}
+
+function folderButton(container: HTMLElement, name: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]')]
+    .find(item => item.textContent === name)
+  if (button === undefined) throw new Error(`folder button not found: ${name}`)
+  return button
+}
+
+function click(target: Element): void {
+  act(() => { target.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+}
+
+describe('FileTree directory toggles', () => {
+  let harness: Harness | undefined
+  afterEach(() => {
+    harness?.unmount()
+    harness = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('collapses and restores the workspace root while preserving nested state', async () => {
+    harness = await mountTree()
+    const root = folderButton(harness.container, 'tmp')
+    click(folderButton(harness.container, 'src'))
+    await act(async () => {})
+    click(folderButton(harness.container, 'client'))
+    await act(async () => {})
+    expect(harness.container.textContent).toContain('view.tsx')
+
+    click(root)
+    expect(root.getAttribute('aria-expanded')).toBe('false')
+    expect(harness.container.textContent).not.toContain('src')
+
+    click(root)
+    expect(root.getAttribute('aria-expanded')).toBe('true')
+    expect(folderButton(harness.container, 'src').getAttribute('aria-expanded')).toBe('true')
+    expect(folderButton(harness.container, 'client').getAttribute('aria-expanded')).toBe('true')
+    expect(harness.container.textContent).toContain('view.tsx')
+  })
+
+  it('expands and collapses the same folder button on consecutive clicks', async () => {
+    harness = await mountTree()
+    const src = folderButton(harness.container, 'src')
+    expect(src.getAttribute('aria-expanded')).toBe('false')
+    click(src)
+    await act(async () => {})
+    expect(src.getAttribute('aria-expanded')).toBe('true')
+    expect(harness.container.textContent).toContain('index.ts')
+    click(src)
+    expect(src.getAttribute('aria-expanded')).toBe('false')
+    expect(harness.container.textContent).not.toContain('index.ts')
+  })
+
+  it('lets a nested folder toggle independently', async () => {
+    harness = await mountTree()
+    click(folderButton(harness.container, 'src'))
+    await act(async () => {})
+    const client = folderButton(harness.container, 'client')
+    click(client)
+    await act(async () => {})
+    expect(harness.container.textContent).toContain('view.tsx')
+    click(client)
+    expect(harness.container.textContent).not.toContain('view.tsx')
+    expect(folderButton(harness.container, 'src').getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('keeps the @ reference action separate from the directory toggle', async () => {
+    harness = await mountTree()
+    const src = folderButton(harness.container, 'src')
+    const reference = src.parentElement?.querySelector<HTMLButtonElement>('button:not([aria-expanded])')
+    expect(reference).not.toBeNull()
+    click(reference!)
+    expect(harness.references).toEqual(['/tmp/src'])
+    expect(src.getAttribute('aria-expanded')).toBe('false')
+  })
+})


### PR DESCRIPTION
## Summary
- replace nested interactive folder rows with a native folder toggle and a sibling @ reference action
- make the workspace root collapsible while preserving nested expansion state
- expose aria-expanded and keep Show in folder able to reopen a collapsed root

## Validation
- pnpm run typecheck
- pnpm run build
- pnpm vitest run tests/file-tree-toggle.spec.tsx tests/file-tree-drop.spec.tsx (12/12)
- full Windows run: 1005 passed, 12 skipped; 4 pre-existing platform failures (CRLF assertions and symlink privilege)
- isolated DSH Canary on 127.0.0.1:3084 verified root and nested click sequences