### PR TITLE
feat: support pane-scoped panel mounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ better-sidebar 从 v0.4.0 起暴露 `ctx.betterSidebar` 服务（Cordis context 
 
 > ⚠️ **host 半不发布此服务**：`ctx.betterSidebar` 只在 client 侧存在。如果你的插件 host 半需要读 better-sidebar 状态，走 better-sidebar 自己的 HTTP/WS 路由（`/sidebar/api/*`），不走服务。
 
+### 1.1 Workbench Pane 挂载
+
+`ctx.betterSidebar.panes` 是可选的浏览器端多实例能力，`protocol === 1` 时可由布局兼容插件调用 `mountPane(target)`。每个挂载拥有独立 `SidebarStore` 和 React Root，Session 状态继续写入原有 `dsh-sidebar:v1:<sessionId>` 文档；右侧和底部宿主分别由 `target.rightHost`、`target.bottomHost` 占位，因此一个 Pane 的尺寸不会推挤兄弟 Pane。Pane 模式把 `--dsh-sidebar-width/height` 写在自身 `[data-dsh-pane-host]`，只供面板内部几何继承，禁止写到 Pane 根并再次触发 viewport 模式的 Conversation margin。Focus 更新只路由命令，不改变任何 Pane 的展开状态。
+
+第一个 Pane 挂载会暂停全局 viewport Root，最后一个 Pane 释放后恢复它。Scoped `openTab`、`updateTab`、`activateTab` 和 `closeTab` 路由到对应 Pane Store；未提供 `panes` 或协议不匹配的消费者必须保持 stock 全局布局，不能搬运 DOM 或访问私有 Store。
+
 ---
 
 ## 2. 消费插件的最小骨架

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - **🪟 双工作台**：右侧栏 + 底部面板；拖 Tab 拆分 / 合并分栏（可跨面板），移动端自动合并全宽抽屉
 - **🪟 自由窗口**：把标签栏的任一 tab 拖到主会话区域——成为可移动 / 缩放 / 置顶的悬浮窗口（默认 390×780），拖回侧边栏 pane 即停靠，随会话持久化；`features` 含 `'floatWindows'`，插件 tab 无差别支持
 - **🔁 会话隔离**：布局 / Tab / 面板按会话持久化，陈旧状态自动净化
+- **🪟 Workbench Pane 适配**：可选 `ctx.betterSidebar.panes` protocol 1 为每个 Session Pane 挂载独立 React Root 与 Store；两个 Pane 可同时保留自己的右侧和底部面板，焦点切换只路由命令
 - **⚙️ 声明式设置**：设置页「侧边卡片」逐项独立开关，二级设置经齿轮弹窗
 - **⚡ 按需加载**：启动只拉 ~325KB 核心，终端 / 编辑器 / Mermaid 图表等重依赖用到才按需拉取（[设计文档](docs/plans/2026-08-12-lazy-chunks-design.md)）
 - **🌏 多语言**：界面文案跟随 DSH 语言（zh / en）实时切换；安装 `@huanlin/dsh-plugin-better-locale` 后支持日语（ja）等第三语言覆盖（见下方「🌏 第三语言覆盖」）

--- a/README_EN.md
+++ b/README_EN.md
@@ -50,6 +50,7 @@
 - **🪟 Dual Workbench**: right sidebar + bottom panel; drag tabs to split / merge panes (cross-panel), mobile auto-merges into a full-width drawer
 - **🪟 Free Windows**: drag any tab onto the main conversation area to turn it into a movable / resizable / raiseable floating window (default 390×780); drag it back onto a pane to dock; persisted per session. `features` includes `'floatWindows'` and plugin tabs are supported identically
 - **🔁 Session Isolation**: layout / tabs / panels persisted per session, stale state auto-purged
+- **🪟 Workbench Pane integration**: optional `ctx.betterSidebar.panes` protocol 1 mounts an independent React root and store for each Session Pane; both Panes may keep right and bottom panels open while focus only routes commands
 - **⚙️ Declarative Settings**: per-item toggles in the "Side Cards" settings section, secondary settings via the gear dialog
 - **⚡ On-demand Loading**: only ~325KB core at startup; heavy deps (terminal / editor / mermaid diagrams) load on demand ([design](docs/plans/2026-08-12-lazy-chunks-design.md))
 - **🌏 i18n**: UI text follows DSH's language (zh / en) with live switching; with the optional `@huanlin/dsh-plugin-better-locale` peer, 19 third-language overlays (ja / de / fr / …) are available

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -59,11 +59,20 @@ import { detectNewDirectSubagent } from './subagent-detect.ts'
 import { detectNewJob } from './subagent-jobs.ts'
 import { t } from './locales.ts'
 import { api, type SessionScope } from './api.ts'
+import type { BetterSidebarPaneTarget } from './service.ts'
 import css from './sidebar.module.css'
 
 /** How many consecutive reconnect failures stop the agent-terminals push loop
  * (mirror of the terminal view's own cap; the loop restarts on session switch). */
 const FAILURE_LIMIT = 3
+const PANE_PANEL_MIN = 220
+const PANE_CONTENT_MIN = 260
+
+/** Preserve a usable conversation column when a saved global width enters a Pane. */
+function panePanelWidth(width: number, viewportWidth: number): number {
+  const maximum = Math.max(PANE_PANEL_MIN, viewportWidth - PANE_CONTENT_MIN)
+  return Math.min(Math.max(PANE_PANEL_MIN, Math.round(width)), maximum)
+}
 
 /**
  * Subagent auto-open debounce (ms). The host delivers a new child's origin
@@ -178,8 +187,9 @@ function buildNewTabOptions(state: SidebarState, ctx: Context, scope: SessionSco
     }))
 }
 
-export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
-  const { ctx, store } = props
+export function Sidebar(props: { ctx: Context; store: SidebarStore; paneTarget?: BetterSidebarPaneTarget }) {
+  const { ctx, store, paneTarget } = props
+  const paneMode = paneTarget !== undefined
 
   // Copy freshness: re-render the whole tree when the DSH locale switches.
   // The module-level t() reads the active locale at call time, so a root
@@ -244,8 +254,8 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // — the merged display is the right sidebar alone, the bottom tabs thrown
   // into its strips. Widening never rewrites the migrated state: the tabs
   // keep living in the right tree.
-  const viewport = useViewportSize()
-  const narrow = isNarrowWidth(viewport.width)
+  const viewport = useViewportSize(paneTarget?.pane)
+  const narrow = paneMode ? false : isNarrowWidth(viewport.width)
 
   // On-screen keyboard / visual-viewport inset (mobile, split-screen, …):
   // when the visual viewport shrinks below the layout viewport, bottom-
@@ -260,6 +270,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   const [keyboardInset, setKeyboardInset] = useState(0)
   const [visualViewportHeight, setVisualViewportHeight] = useState<number | null>(null)
   useEffect(() => {
+    if (paneMode) return
     const vv = window.visualViewport
     if (vv === null || vv === undefined) return
     let frame: number | null = null
@@ -278,7 +289,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       vv.removeEventListener('scroll', onResize)
       if (frame !== null) cancelAnimationFrame(frame)
     }
-  }, [])
+  }, [paneMode])
   // The bottom panel is offset above the on-screen keyboard. Cap its height
   // against that same visible area, not the taller layout viewport, so the
   // conversation keeps PANEL_MIN even on wide touch devices.
@@ -289,7 +300,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     useMemo(() => (callback: () => void) => ctx.sessions.list.subscribe(callback), [ctx]),
     useCallback(() => ctx.sessions.list.getSnapshot(), [ctx]),
   )
-  const current = sessionList.current
+  const current = paneTarget?.sessionId ?? sessionList.current
 
   // Per-session sidebar state.
   const snapshot = useSyncExternalStore(
@@ -318,10 +329,11 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // it — an open panel already squeezes `#root` left, moving the header clear.
   const collapsed = state === undefined || !state.panelOpen
   useEffect(() => {
+    if (paneMode) return
     if (collapsed) document.body.setAttribute('data-dsh-sidebar-collapsed', '')
     else document.body.removeAttribute('data-dsh-sidebar-collapsed')
     return () => { document.body.removeAttribute('data-dsh-sidebar-collapsed') }
-  }, [collapsed])
+  }, [collapsed, paneMode])
 
   // Title-bar / shell compatibility (the "位置兼容模式" scheme):
   //   auto    — CONSERVATIVE: only the standard Window Controls Overlay
@@ -349,6 +361,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   )
   const titleBarCompat = titleBarStrip > 0
   useEffect(() => {
+    if (paneMode) return
     const root = document.documentElement
     if (titleBarCompat) {
       document.body.setAttribute('data-dsh-title-bar-compat', '')
@@ -361,7 +374,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       document.body.removeAttribute('data-dsh-title-bar-compat')
       root.style.removeProperty('--dsh-title-bar-strip')
     }
-  }, [titleBarCompat, titleBarStrip])
+  }, [titleBarCompat, titleBarStrip, paneMode])
 
   // User-space CSS injection (the escape hatch): preset CSS (scheme
   // `preset`) and free-form custom CSS (scheme `custom`) are appended AFTER
@@ -373,11 +386,12 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   const presetCss = scheme === 'preset' ? preset?.css ?? '' : ''
   const customCss = scheme === 'custom' ? snapshot.prefs.customCss : ''
   useEffect(() => {
+    if (paneMode) return
     const tags: HTMLStyleElement[] = []
     if (presetCss !== '') tags.push(injectUserCss('data-dsh-preset-css', preset?.id ?? '', presetCss))
     if (customCss !== '') tags.push(injectUserCss('data-dsh-custom-css', 'custom', customCss))
     return () => { for (const tag of tags) tag.remove() }
-  }, [presetCss, customCss, preset?.id])
+  }, [presetCss, customCss, preset?.id, paneMode])
 
   /**
    * Bottom-panel merge on narrow viewports: whenever a session is current
@@ -666,19 +680,22 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       return
     }
     const rect = col.getBoundingClientRect()
+    const localRight = paneMode
+      ? Math.max(0, rect.width - (state?.panelOpen === true ? panePanelWidth(state.width, rect.width) : 0))
+      : rect.right
     // Ref + direct DOM write (see the centerRectRef comment): the bottom
     // panel keeps tracking the center column per frame during the right
     // panel's open/close animation without re-rendering the shell. The
     // one-shot measured flip renders the panel visible once (a stale
     // {0,0} fallback would flash full-width).
-    centerRectRef.current = { left: rect.left, right: rect.right }
+    centerRectRef.current = { left: paneMode ? 0 : rect.left, right: localRight }
     const bottom = bottomRef.current
     if (bottom !== null) {
-      bottom.style.setProperty('left', `${rect.left}px`)
-      bottom.style.setProperty('right', `${window.innerWidth - rect.right}px`)
+      bottom.style.setProperty('left', `${paneMode ? 0 : rect.left}px`)
+      bottom.style.setProperty('right', `${paneMode ? Math.max(0, rect.width - localRight) : window.innerWidth - rect.right}px`)
     }
     setCenterMeasured(prev => (prev ? prev : true))
-  }, [])
+  }, [paneMode, state?.panelOpen, state?.width])
   useEffect(() => {
     let disposed = false
     let observer: ResizeObserver | undefined
@@ -694,7 +711,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // (observed: a 1px sliver at the viewport's left edge).
     const locate = (): void => {
       if (disposed) return
-      const col = document.querySelector('#root [data-slot="conversation"]')
+      const col = paneTarget?.pane ?? document.querySelector('#root [data-slot="conversation"]')
         ?.parentElement as HTMLElement | undefined
       if (col === undefined || !col.isConnected) {
         if (centerColRef.current !== null) {
@@ -737,7 +754,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       })
     }
     const watcher = new MutationObserver(scheduleLocate)
-    const root = document.getElementById('root')
+    const root = paneTarget?.pane ?? document.getElementById('root')
     if (root !== null) watcher.observe(root, { childList: true, subtree: true })
     // The layout push writes --dsh-sidebar-* on <html>. A HMR re-activation
     // clears those variables on teardown and re-writes them on setup — and
@@ -748,7 +765,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // rewrite re-locates and re-measures, so the bottom panel recovers
     // instead of staying hidden on a stale {0,0} center rect.
     const htmlStyleWatcher = new MutationObserver(scheduleLocate)
-    htmlStyleWatcher.observe(document.documentElement, { attributes: true, attributeFilter: ['style'] })
+    if (!paneMode) htmlStyleWatcher.observe(document.documentElement, { attributes: true, attributeFilter: ['style'] })
     // Last-resort safety net (issue #248): no watcher is guaranteed to fire
     // for every HMR teardown/setup interleaving (e.g. the style attribute
     // may end up byte-identical, and the col may be swapped before the
@@ -770,7 +787,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // panel opened before the center column was ever found must not stay
     // invisible forever (the HMR recovery path depends on the observers
     // above, this is the belt-and-braces retry for the open moment itself).
-  }, [measureCenter, state?.bottomOpen])
+  }, [measureCenter, state?.bottomOpen, paneMode, paneTarget?.pane])
 
   /**
    * Free windows — drag-out detection. The tab strips already drive HTML5
@@ -888,6 +905,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // a store reduce re-renders both workbenches (terminals, editors…) per
   // move, which is the visible drag lag. The store is committed once on
   // pointer up (clamping + persistence).
+  const panelHostRef = useRef<HTMLDivElement | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const widthDrag = useRef({ startX: 0, startWidth: 0 })
@@ -910,17 +928,24 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // Clamp mirrors of setWidth/setBottomHeight for mid-drag values (the store
   // re-clamps on commit; these keep the panels from overshooting mid-drag).
   const clampWidth = (width: number): number =>
-    Math.min(Math.max(PANEL_MIN, Math.round(width)), Math.max(PANEL_MIN, window.innerWidth))
+    paneMode
+      ? panePanelWidth(width, viewport.width)
+      : Math.min(Math.max(PANEL_MIN, Math.round(width)), Math.max(PANEL_MIN, viewport.width))
   const clampHeight = (height: number): number =>
-    Math.min(Math.max(BOTTOM_MIN, Math.round(height)), Math.max(BOTTOM_MIN, window.innerHeight - PANEL_MIN))
+    Math.min(Math.max(BOTTOM_MIN, Math.round(height)), Math.max(BOTTOM_MIN, viewport.height - PANEL_MIN))
 
   /** Single writer for the layout-push variables: the app shell gives up
    *  the panel's width/height while open (0 while collapsed) through
    *  layout.css's margins. Every size change — drag frames and committed
    *  state — flows through here so the push never forks between paths. */
   const writeGeometry = (width: number, height: number): void => {
-    document.documentElement.style.setProperty('--dsh-sidebar-width', `${width}px`)
-    document.documentElement.style.setProperty('--dsh-sidebar-height', `${height}px`)
+    const geometryRoot = paneMode ? panelHostRef.current : document.documentElement
+    geometryRoot?.style.setProperty('--dsh-sidebar-width', `${width}px`)
+    geometryRoot?.style.setProperty('--dsh-sidebar-height', `${height}px`)
+    if (paneTarget !== undefined) {
+      paneTarget.rightHost.style.width = `${width}px`
+      paneTarget.bottomHost.style.height = `${height}px`
+    }
     // The corner handle positions itself relative to the panel (CSS
     // `bottom: calc(var(--dsh-sidebar-height) + 6px)`), so these two layout
     // variables are all it needs — no viewport coordinates written here
@@ -947,7 +972,9 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // width (innerWidth - state.width - detailsWidth), so this equals
     // `width + detailsWidth` — derived from the measured column, keeping the
     // drag write-only (no React re-render mid-drag).
-    bottomRef.current?.style.setProperty('right', `${(window.innerWidth - centerRectRef.current.right) + (width - (state?.width ?? 0))}px`)
+    bottomRef.current?.style.setProperty('right', paneMode
+      ? `${width}px`
+      : `${(window.innerWidth - centerRectRef.current.right) + (width - (state?.width ?? 0))}px`)
     const bottomPush = !narrow && state?.bottomOpen === true ? height + keyboardInset : 0
     writeGeometry(width, bottomPush)
   }
@@ -1048,7 +1075,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
         width = clampWidth(widthDrag.current.startWidth + (widthDrag.current.startX - event.clientX))
         height = pushedBottomHeight(state?.bottomOpen === true, state?.bottomHeight ?? 0)
       } else if (draggingBottom) {
-        width = Math.min(state?.width ?? 0, window.innerWidth)
+        width = Math.min(state?.width ?? 0, viewport.width)
         height = pushedBottomHeight(true, clampHeight(bottomDrag.current.startHeight + (bottomDrag.current.startY - event.clientY)))
       } else if (draggingCorner) {
         width = clampWidth(cornerDrag.current.startWidth + (cornerDrag.current.startX - event.clientX))
@@ -1105,7 +1132,9 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       narrow,
       panelOpen: snapshot.state?.panelOpen === true,
       bottomOpen: snapshot.state?.bottomOpen === true,
-      width: snapshot.state?.width ?? 0,
+      width: paneMode
+        ? panePanelWidth(snapshot.state?.width ?? PANE_PANEL_MIN, viewport.width)
+        : snapshot.state?.width ?? 0,
       bottomHeight: snapshot.state?.bottomHeight ?? 0,
       viewportWidth: viewport.width,
       viewportHeight: layoutViewportHeight,
@@ -1114,7 +1143,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       ? height + keyboardInset
       : 0
     writeGeometry(width, bottomPush)
-  }, [narrow, snapshot.state?.panelOpen, snapshot.state?.width, snapshot.state?.bottomOpen, snapshot.state?.bottomHeight, viewport.width, layoutViewportHeight, keyboardInset])
+  }, [narrow, paneMode, snapshot.state?.panelOpen, snapshot.state?.width, snapshot.state?.bottomOpen, snapshot.state?.bottomHeight, viewport.width, layoutViewportHeight, keyboardInset])
   // Unmount must release the push (issue #31): when the boundary swaps the
   // whole sidebar after a render crash (or the plugin fiber is disposed /
   // HMR), the CSS variables would otherwise stay on <html> and layout.css
@@ -1129,14 +1158,22 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   // mounted makes the push invisible to mid-flush style recals.
   useEffect(() => {
     return () => {
-      document.documentElement.style.removeProperty('--dsh-sidebar-width')
-      document.documentElement.style.removeProperty('--dsh-sidebar-height')
+      const geometryRoot = paneMode ? panelHostRef.current : document.documentElement
+      geometryRoot?.style.removeProperty('--dsh-sidebar-width')
+      geometryRoot?.style.removeProperty('--dsh-sidebar-height')
+      if (paneTarget !== undefined) {
+        paneTarget.rightHost.style.removeProperty('width')
+        paneTarget.bottomHost.style.removeProperty('height')
+      }
     }
-  }, [])
+  }, [paneMode, paneTarget])
   useEffect(() => {
-    if (anyDragging) document.body.setAttribute('data-dsh-sidebar-dragging', '')
-    else document.body.removeAttribute('data-dsh-sidebar-dragging')
-  }, [anyDragging])
+    const target = paneTarget?.pane ?? document.body
+    const attribute = paneMode ? 'data-dsh-pane-sidebar-dragging' : 'data-dsh-sidebar-dragging'
+    if (anyDragging) target.setAttribute(attribute, '')
+    else target.removeAttribute(attribute)
+    return () => { target.removeAttribute(attribute) }
+  }, [anyDragging, paneMode, paneTarget?.pane])
 
 
   const actions: WorkbenchActions = useMemo(() => ({
@@ -1223,7 +1260,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // Keep the unavailable controls focusable: touch users have no hover, so
     // focus is the only way the existing Tooltip can explain what is missing.
     return (
-      <div data-dsh-panel-host {...osFileDragShield}>
+      <div ref={panelHostRef} data-dsh-panel-host data-dsh-pane-host={paneMode ? '' : undefined} {...osFileDragShield}>
         <div className={css.toggleCluster} data-dsh-toggle-cluster>
           {!narrow && (
             <Tooltip label={t('noSession')} side="bottom" delayMs={500}>
@@ -1337,7 +1374,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
   )
 
   return (
-    <div data-dsh-panel-host {...osFileDragShield}>
+    <div ref={panelHostRef} data-dsh-panel-host data-dsh-pane-host={paneMode ? '' : undefined} {...osFileDragShield}>
       {/*
         The persistent toggle cluster at the top-right corner: the bottom
         panel's button (bottom glyph) LEFT of the right panel's (side glyph).
@@ -1388,7 +1425,9 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
         className={clsx(css.panel, !state.panelOpen && css.panelHidden)}
         data-dsh-panel
         style={{
-          width: narrow ? '100vw' : Math.min(state.width, window.innerWidth),
+          width: narrow
+            ? '100vw'
+            : paneMode ? panePanelWidth(state.width, viewport.width) : Math.min(state.width, window.innerWidth),
           // Narrow drawer: keep the bottom-anchored sheet above the on-screen
           // keyboard (visualViewport inset); desktop panels are full-height
           // and unaffected.
@@ -1405,7 +1444,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
                 event.preventDefault()
                 event.currentTarget.setPointerCapture(event.pointerId)
                 dragCommitted.current = false
-                widthDrag.current = { startX: event.clientX, startWidth: state.width }
+                widthDrag.current = { startX: event.clientX, startWidth: clampWidth(state.width) }
                 setDraggingWidth(true)
               }}
               onPointerMove={(event) => {
@@ -1467,7 +1506,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
               cornerDrag.current = {
                 startX: event.clientX,
                 startY: event.clientY,
-                startWidth: state.width,
+                startWidth: clampWidth(state.width),
                 startHeight: state.bottomHeight,
               }
               setDraggingCorner(true)
@@ -1521,7 +1560,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
         data-dsh-bottom-panel
         style={{
           height: bottomPanelHeight,
-          left: centerRectRef.current.left,
+          left: paneMode ? 0 : centerRectRef.current.left,
           // Keep the panel above the on-screen keyboard when the visual
           // viewport shrinks (see the keyboardInset effect).
           bottom: keyboardInset > 0 ? `${keyboardInset}px` : undefined,
@@ -1530,7 +1569,9 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
           // details column's left edge (the details column sits between the
           // center and the right panel, and the right panel's margin-right
           // push is already baked into centerRect.right).
-          right: window.innerWidth - centerRectRef.current.right,
+          right: paneMode
+            ? (state.panelOpen ? panePanelWidth(state.width, viewport.width) : 0)
+            : window.innerWidth - centerRectRef.current.right,
           // The seam against the open right panel needs its own hairline
           // (the right panel's border-left alone is covered by this panel's
           // fill — without it the corner looks cut off).

--- a/src/client/breakpoints.ts
+++ b/src/client/breakpoints.ts
@@ -32,27 +32,37 @@ export interface ViewportSize {
  * resize listener is equally exact for a breakpoint that never changes
  * while the page is open.
  */
-export function useViewportSize(): ViewportSize {
+export function useViewportSize(target?: HTMLElement): ViewportSize {
   const [size, setSize] = useState<ViewportSize>(() => ({
-    width: typeof window === 'undefined' ? 0 : window.innerWidth,
-    height: typeof window === 'undefined' ? 0 : window.innerHeight,
+    width: target?.getBoundingClientRect().width ?? (typeof window === 'undefined' ? 0 : window.innerWidth),
+    height: target?.getBoundingClientRect().height ?? (typeof window === 'undefined' ? 0 : window.innerHeight),
   }))
   useEffect(() => {
     if (typeof window === 'undefined') return
+    const element = target
     let frame: number | null = null
     const measure = (): void => {
       frame = null
-      setSize({ width: window.innerWidth, height: window.innerHeight })
+      if (element === undefined) {
+        setSize({ width: window.innerWidth, height: window.innerHeight })
+      } else {
+        const rect = element.getBoundingClientRect()
+        setSize({ width: rect.width, height: rect.height })
+      }
     }
     const onResize = (): void => {
       if (frame === null) frame = requestAnimationFrame(measure)
     }
-    window.addEventListener('resize', onResize)
+    if (element === undefined) window.addEventListener('resize', onResize)
+    const observer = element === undefined ? undefined : new ResizeObserver(onResize)
+    if (element !== undefined) observer?.observe(element)
+    measure()
     return () => {
-      window.removeEventListener('resize', onResize)
+      if (element === undefined) window.removeEventListener('resize', onResize)
+      observer?.disconnect()
       if (frame !== null) cancelAnimationFrame(frame)
     }
-  }, [])
+  }, [target])
   return size
 }
 

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -23,6 +23,7 @@ import { registerImeGuard } from './ime-guard.ts'
 import { registerSettingsNavIcon } from './settings-nav-icon.ts'
 import { loadExternalDisable, loadPrefs } from './prefs.ts'
 import { SideCardSection } from './SideCardSection.tsx'
+import { createPaneCapability } from './pane-mount.tsx'
 import { api } from './api.ts'
 import { LOCALE_NS, attachLocale, attachBetterLocale, t, zh, en,
   ja, de, fr, pt, ko, ar, hi, id, tr, vi, th, ru, it, nl, sv, pl,
@@ -121,7 +122,11 @@ export function apply(ctx: Context): void {
   // Published before the panel mounts so consumers injecting 'betterSidebar'
   // are ready by the time the sidebar renders.
   const service = createBetterSidebarService(sidebarStore)
+  let reconcileGlobalMount = (): void => {}
+  const paneCapability = createPaneCapability(ctx, sidebarStore, service, () => { reconcileGlobalMount() })
+  service.panes = paneCapability
   ctx.provide('betterSidebar', service)
+  ctx.effect(() => () => { paneCapability.dispose() }, 'dsh-better-sidebar: Pane mounts')
   // Terminal tab titles use the host's effective shell name (e.g. bash/zsh)
   // instead of "Terminal 1". Start with a safe fallback and replace it as
   // soon as the host shell info resolves. Tabs created before the response
@@ -181,6 +186,7 @@ export function apply(ctx: Context): void {
       let root: Root | undefined
       let host: HTMLDivElement | undefined
       let mounted = false
+      let suspended = false
       let bodyObserver: MutationObserver | undefined
       let hostCheckFrame: number | null = null
       const unmount = (): void => {
@@ -271,6 +277,11 @@ export function apply(ctx: Context): void {
           fail('mount', error)
         }
       }
+      const reconcile = (): void => {
+        if (suspended || paneCapability.activeCount > 0) unmount()
+        else mount()
+      }
+      reconcileGlobalMount = reconcile
       const sync = async (): Promise<void> => {
         if (disposed) return
         // Resolve the user's side card prefs BEFORE the first session seeds,
@@ -287,11 +298,10 @@ export function apply(ctx: Context): void {
         // Mutual exclusion with the dsh-web-ui family right panel: while the
         // aionui-panel provider is selected, the sidebar must not mount at
         // all. Re-evaluated on every settings-document update (live switch).
-        const suspended = await loadExternalDisable(api)
+        suspended = await loadExternalDisable(api)
         if (disposed) return
         sidebarStore.setSuspended(suspended)
-        if (suspended) unmount()
-        else mount()
+        reconcile()
       }
       void sync()
       // Live re-evaluation: the runtime broadcasts settings-document updates
@@ -302,6 +312,7 @@ export function apply(ctx: Context): void {
       const offRemote = remote?.$on?.('settings/document-updated', () => { void sync() })
       return () => {
         disposed = true
+        reconcileGlobalMount = () => {}
         offRemote?.()
         unmount()
       }

--- a/src/client/pane-mount.tsx
+++ b/src/client/pane-mount.tsx
@@ -13,7 +13,7 @@ import type {
 } from './service.ts'
 
 interface PaneMount {
-  readonly target: BetterSidebarPaneTarget
+  target: BetterSidebarPaneTarget
   readonly root: Root
   readonly host: HTMLElement
   readonly detachStore: () => void
@@ -31,9 +31,15 @@ export function createPaneCapability(
 ): BetterSidebarPaneCapability & { dispose(): void } {
   const mounts = new Map<string, PaneMount>()
 
+  const syncFocusedSession = (): void => {
+    const focused = [...mounts.values()].find(mount => mount.target.focused)?.target.sessionId
+    primaryStore.setSession(focused ?? ctx.sessions.list.getSnapshot().current)
+  }
+
   const disposeMount = (sessionId: string, mount: PaneMount): void => {
     if (mounts.get(sessionId) !== mount) return
     mounts.delete(sessionId)
+    syncFocusedSession()
     mount.disposePrefs()
     mount.detachStore()
     mount.root.unmount()
@@ -88,16 +94,17 @@ export function createPaneCapability(
         bottomReservation,
       }
       mounts.set(target.sessionId, mount)
+      syncFocusedSession()
       onActiveChange()
-      let current = target
       return {
         update(next): void {
-          if (next.sessionId !== current.sessionId) {
+          if (next.sessionId !== mount.target.sessionId) {
             throw new Error('[dsh-better-sidebar] Pane attachment cannot change Session identity')
           }
-          current = next
+          mount.target = next
           if (next.focused) host.setAttribute('data-focused', '')
           else host.removeAttribute('data-focused')
+          syncFocusedSession()
         },
         dispose(): void { disposeMount(target.sessionId, mount) },
       }

--- a/src/client/pane-mount.tsx
+++ b/src/client/pane-mount.tsx
@@ -1,0 +1,169 @@
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import type { Context } from '../context-types.ts'
+import { Sidebar } from './Sidebar.tsx'
+import { createSidebarStore, type SidebarStore } from './state.ts'
+import type {
+  BetterSidebarPaneAttachment,
+  BetterSidebarPaneCapability,
+  BetterSidebarPaneTarget,
+  BetterSidebarService,
+  OpenTabSeed,
+  SessionScope,
+} from './service.ts'
+
+interface PaneMount {
+  readonly target: BetterSidebarPaneTarget
+  readonly root: Root
+  readonly host: HTMLElement
+  readonly detachStore: () => void
+  readonly disposePrefs: () => void
+  readonly rightReservation: HTMLElement
+  readonly bottomReservation: HTMLElement
+}
+
+/** Create the versioned multi-Pane mounting capability for one client activation. */
+export function createPaneCapability(
+  ctx: Context,
+  primaryStore: SidebarStore,
+  service: BetterSidebarService,
+  onActiveChange: () => void,
+): BetterSidebarPaneCapability & { dispose(): void } {
+  const mounts = new Map<string, PaneMount>()
+
+  const disposeMount = (sessionId: string, mount: PaneMount): void => {
+    if (mounts.get(sessionId) !== mount) return
+    mounts.delete(sessionId)
+    mount.disposePrefs()
+    mount.detachStore()
+    mount.root.unmount()
+    mount.host.remove()
+    mount.rightReservation.remove()
+    mount.bottomReservation.remove()
+    onActiveChange()
+  }
+
+  const capability: BetterSidebarPaneCapability & { dispose(): void } = {
+    protocol: 1,
+    get activeCount() { return mounts.size },
+    mountPane(target): BetterSidebarPaneAttachment {
+      if (mounts.has(target.sessionId)) {
+        throw new Error(`[dsh-better-sidebar] Pane "${target.sessionId}" is already mounted`)
+      }
+      const store = createSidebarStore()
+      store.setPrefs(primaryStore.getPrefs())
+      store.setSession(target.sessionId)
+      const detachStore = service.attachPaneStore(target.sessionId, store)
+      let prefsFingerprint = JSON.stringify(primaryStore.getPrefs())
+      const disposePrefs = primaryStore.subscribe(() => {
+        const prefs = primaryStore.getPrefs()
+        const fingerprint = JSON.stringify(prefs)
+        if (fingerprint === prefsFingerprint) return
+        prefsFingerprint = fingerprint
+        store.setPrefs(prefs)
+      })
+      const host = document.createElement('div')
+      host.setAttribute('data-dsh-better-sidebar', '')
+      host.setAttribute('data-dsh-better-sidebar-pane', target.sessionId)
+      if (target.focused) host.setAttribute('data-focused', '')
+      target.pane.appendChild(host)
+      const rightReservation = document.createElement('span')
+      rightReservation.hidden = true
+      rightReservation.setAttribute('data-dsh-pane-panel-reservation', 'right')
+      target.rightHost.appendChild(rightReservation)
+      const bottomReservation = document.createElement('span')
+      bottomReservation.hidden = true
+      bottomReservation.setAttribute('data-dsh-pane-panel-reservation', 'bottom')
+      target.bottomHost.appendChild(bottomReservation)
+      const root = createRoot(host)
+      const paneCtx = scopedContext(ctx, service, store, target.sessionId)
+      root.render(createElement(Sidebar, { ctx: paneCtx, store, paneTarget: target }))
+      const mount: PaneMount = {
+        target,
+        root,
+        host,
+        detachStore,
+        disposePrefs,
+        rightReservation,
+        bottomReservation,
+      }
+      mounts.set(target.sessionId, mount)
+      onActiveChange()
+      let current = target
+      return {
+        update(next): void {
+          if (next.sessionId !== current.sessionId) {
+            throw new Error('[dsh-better-sidebar] Pane attachment cannot change Session identity')
+          }
+          current = next
+          if (next.focused) host.setAttribute('data-focused', '')
+          else host.removeAttribute('data-focused')
+        },
+        dispose(): void { disposeMount(target.sessionId, mount) },
+      }
+    },
+    dispose(): void {
+      for (const [sessionId, mount] of [...mounts]) disposeMount(sessionId, mount)
+    },
+  }
+  return capability
+}
+
+/** Scope current-session reads and unscoped service calls to one Pane store. */
+function scopedContext(
+  ctx: Context,
+  service: BetterSidebarService,
+  store: SidebarStore,
+  sessionId: string,
+): Context {
+  const scope: SessionScope = { sessionId }
+  const paneService = new Proxy(service, {
+    get(target, property) {
+      if (property === 'openTab') return (seed: OpenTabSeed, requested?: SessionScope) => target.openTab(seed, requested ?? scope)
+      if (property === 'closeTab') return (tabId: string, requested?: SessionScope) => target.closeTab(tabId, requested ?? scope)
+      if (property === 'activateTab') return (tabId: string, requested?: SessionScope) => target.activateTab(tabId, requested ?? scope)
+      if (property === 'updateTab') {
+        return (tabId: string, patch: { title?: string; path?: string; meta?: unknown }, requested?: SessionScope) =>
+          target.updateTab(tabId, patch, requested ?? scope)
+      }
+      if (property === 'getSnapshot') return () => store.getSnapshot()
+      if (property === 'subscribeState') return (listener: () => void) => store.subscribe(listener)
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  let sourceListSnapshot = ctx.sessions.list.getSnapshot()
+  let scopedListSnapshot = { ...sourceListSnapshot, current: sessionId }
+  const getListSnapshot = (): typeof sourceListSnapshot => {
+    const next = ctx.sessions.list.getSnapshot()
+    if (next !== sourceListSnapshot) {
+      sourceListSnapshot = next
+      scopedListSnapshot = { ...next, current: sessionId }
+    }
+    return scopedListSnapshot
+  }
+  const list = new Proxy(ctx.sessions.list, {
+    get(target, property) {
+      if (property === 'getSnapshot') return getListSnapshot
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  const sessions = new Proxy(ctx.sessions, {
+    get(target, property) {
+      if (property === 'list') return list
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  return new Proxy(ctx, {
+    get(target, property) {
+      if (property === 'sessions') return sessions
+      if (property === 'get') {
+        return (name: string) => name === 'betterSidebar' ? paneService : target.get(name as never)
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -416,7 +416,7 @@ export interface BetterSidebarService {
   /** Subscribe to snapshot changes (session switch, state changes, prefs changes). Returns the disposer. */
   subscribeState(listener: () => void): () => void
   /** Update an open tab's display fields (title / path / meta); a missing tab id is a no-op. */
-  updateTab(tabId: string, patch: { title?: string; path?: string; meta?: unknown }): void
+  updateTab(tabId: string, patch: { title?: string; path?: string; meta?: unknown }, scope?: SessionScope): void
   /**
    * Activate an open tab (the tab-bar activation path; fires
    * descriptor.onActivate). An unknown tab id is a strict no-op. `scope`
@@ -425,6 +425,32 @@ export interface BetterSidebarService {
   activateTab(tabId: string, scope?: SessionScope): void
   /** Open a file in the sidebar editor of `scope`'s session (title defaults to the file name). */
   openFile(scope: SessionScope, path: string, title?: string): void
+  /** Register a live Pane store so scoped service calls reach its mounted UI. */
+  attachPaneStore(sessionId: string, store: SidebarStore): () => void
+  /** Optional multi-Pane mounting capability supplied by the browser plugin. */
+  panes?: BetterSidebarPaneCapability
+}
+
+/** DOM hosts owned by one visible Workbench Session Pane. */
+export interface BetterSidebarPaneTarget {
+  readonly sessionId: string
+  readonly pane: HTMLElement
+  readonly rightHost: HTMLElement
+  readonly bottomHost: HTMLElement
+  readonly focused: boolean
+}
+
+/** One live Better Sidebar attachment for a Workbench Pane. */
+export interface BetterSidebarPaneAttachment {
+  update(target: BetterSidebarPaneTarget): void
+  dispose(): void
+}
+
+/** Versioned capability consumed by Workbench panel compatibility packages. */
+export interface BetterSidebarPaneCapability {
+  readonly protocol: 1
+  readonly activeCount: number
+  mountPane(target: BetterSidebarPaneTarget): BetterSidebarPaneAttachment
 }
 
 /** Extract the lowercase extension without leading dot from a path. */
@@ -503,6 +529,7 @@ export const SIDEBAR_FEATURES = [
   'urlTarget',
   'settingSelect',
   'floatWindows',
+  'paneMount',
 ] as const
 
 /** Run one plugin callback; a throw is logged and never breaks the caller. */
@@ -523,6 +550,23 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
   const tabs = new Map<string, TabDescriptor>()
   const viewers = new Map<string, FileViewerDescriptor>()
   const listeners = new Set<() => void>()
+  const paneStores = new Map<string, SidebarStore>()
+
+  const storeFor = (scope?: SessionScope): SidebarStore => {
+    const sessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+    return sessionId === undefined ? store : paneStores.get(sessionId) ?? store
+  }
+
+  const attachPaneStore = (sessionId: string, paneStore: SidebarStore): (() => void) => {
+    const occupied = paneStores.get(sessionId)
+    if (occupied !== undefined && occupied !== paneStore) {
+      throw new Error(`[dsh-better-sidebar] Pane store for session "${sessionId}" is already attached`)
+    }
+    paneStores.set(sessionId, paneStore)
+    return () => {
+      if (paneStores.get(sessionId) === paneStore) paneStores.delete(sessionId)
+    }
+  }
 
   const notify = (): void => {
     for (const fn of [...listeners]) fn()
@@ -612,14 +656,17 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
     if (descriptor === undefined) return
     // A scope targets another session: the open lands in THAT session's
     // state (loaded on demand) without switching the UI's active session.
-    const targetSessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+    const targetStore = storeFor(scope)
+    const targetSessionId = scope?.sessionId ?? targetStore.getSnapshot().sessionId
     if (targetSessionId === undefined) return
     const callbackScope: SessionScope = scope ?? { sessionId: targetSessionId }
     // Whether this open targets a session that is NOT the one on screen: a
     // targeted open must not auto-expand panels the user cannot see (the
     // expansion is about landing "in sight" for the CURRENT viewer).
     const activeSessionId = store.getSnapshot().sessionId
-    const targetsInactiveSession = scope !== undefined && scope.sessionId !== activeSessionId
+    const targetsInactiveSession = scope !== undefined
+      && scope.sessionId !== activeSessionId
+      && !paneStores.has(scope.sessionId)
     // Lifecycle capture: `created` when the open minted a NEW tab (a
     // dedupe/id-safety-net focus is an ACTIVATION, not an open).
     let created: SidebarTab | undefined
@@ -735,7 +782,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
     if (targetsInactiveSession) {
       store.reduceFor(scope.sessionId, reducer)
     } else {
-      store.reduce(reducer)
+      targetStore.reduce(reducer)
     }
     if (created !== undefined) safeCall(() => descriptor.onOpen?.(created!, callbackScope))
     else if (activated !== undefined) safeCall(() => descriptor.onActivate?.(activated!, callbackScope))
@@ -743,7 +790,8 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
 
   const closeTab = (tabId: string, scope?: SessionScope): void => {
     let closed: SidebarTab | undefined
-    store.reduce((state) => {
+    const targetStore = storeFor(scope)
+    targetStore.reduce((state) => {
       // Unknown tab ids are a strict no-op: no state churn, no notify, no
       // pointless localStorage rewrite (mirrors updateTab's short-circuit).
       if (!tabOpenIn(state, tabId)) return state
@@ -759,7 +807,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
       return closeTabReducer(state, paneId, tabId)
     })
     if (closed !== undefined) {
-      const sessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+      const sessionId = scope?.sessionId ?? targetStore.getSnapshot().sessionId
       if (sessionId !== undefined) {
         const descriptor = tabs.get(closed.type)
         // An explicit scope (with its optional cwd) rides to the callback.
@@ -775,8 +823,8 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
   const subscribeState = (listener: () => void): (() => void) => store.subscribe(listener)
 
   /** Patch an open tab's display fields (a missing tab id is a no-op). */
-  const updateTab = (tabId: string, patch: { title?: string; path?: string; meta?: unknown }): void => {
-    store.reduce((state) => patchTab(state, tabId, {
+  const updateTab = (tabId: string, patch: { title?: string; path?: string; meta?: unknown }, scope?: SessionScope): void => {
+    storeFor(scope).reduce((state) => patchTab(state, tabId, {
       ...(patch.title !== undefined ? { title: patch.title } : {}),
       ...(patch.path !== undefined ? { path: patch.path } : {}),
       ...(patch.meta !== undefined ? { meta: patch.meta } : {}),
@@ -786,7 +834,8 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
   /** Activate an open tab (the tab-bar activation path; fires onActivate). */
   const activateTab = (tabId: string, scope?: SessionScope): void => {
     let activated: SidebarTab | undefined
-    store.reduce((state) => {
+    const targetStore = storeFor(scope)
+    targetStore.reduce((state) => {
       // Unknown tab ids are a strict no-op (no state churn / notify).
       if (!tabOpenIn(state, tabId)) return state
       // A floating tab "activates" by raising its window — no pane switch.
@@ -801,7 +850,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
       return activateTabReducer(state, paneId, tabId)
     })
     if (activated !== undefined) {
-      const sessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+      const sessionId = scope?.sessionId ?? targetStore.getSnapshot().sessionId
       if (sessionId !== undefined) {
         const descriptor = tabs.get(activated.type)
         // An explicit scope (with its optional cwd) rides to the callback.
@@ -836,6 +885,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
     updateTab,
     activateTab,
     openFile,
+    attachPaneStore,
   }
 }
 

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -48,6 +48,19 @@
   overflow: hidden;
 }
 
+:global([data-dsh-panel-host][data-dsh-pane-host]) {
+  position: absolute;
+  top: 32px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+}
+
+:global([data-dsh-panel-host][data-dsh-pane-host]) .toggleCluster {
+  top: 15px;
+}
+
 :global([data-dsh-panel-host][data-dsh-panel-host-degraded]) {
   position: absolute;
   top: 0;
@@ -249,7 +262,9 @@
 }
 
 body[data-dsh-sidebar-dragging] .panel,
-body[data-dsh-sidebar-dragging] .bottomPanel {
+body[data-dsh-sidebar-dragging] .bottomPanel,
+:global([data-dsh-pane-sidebar-dragging]) .panel,
+:global([data-dsh-pane-sidebar-dragging]) .bottomPanel {
   will-change: transform;
 }
 

--- a/tests/api-surface.spec.ts
+++ b/tests/api-surface.spec.ts
@@ -61,7 +61,7 @@ describe('public API surface (v0.12.0)', () => {
     // Full releases are bare x.y.z; pre-releases (beta) carry -<tag>.<n>.
     expect(SIDEBAR_SERVICE_VERSION).toMatch(/^\d+\.\d+\.\d+(-[a-z0-9.]+)?$/)
     expect(SIDEBAR_FEATURES.length).toBeGreaterThanOrEqual(8)
-    for (const feature of ['badge', 'tabLifecycle', 'updateTab', 'openFile', 'targetedOpen', 'stateSubscription', 'tabMeta', 'pluginSettings']) {
+    for (const feature of ['badge', 'tabLifecycle', 'updateTab', 'openFile', 'targetedOpen', 'stateSubscription', 'tabMeta', 'pluginSettings', 'paneMount']) {
       expect(SIDEBAR_FEATURES).toContain(feature)
     }
   })

--- a/tests/bottom-auto-terminal.spec.tsx
+++ b/tests/bottom-auto-terminal.spec.tsx
@@ -40,6 +40,11 @@ interface MountedSidebar {
   container: HTMLDivElement
   store: SidebarStore
   service: BetterSidebarService
+  paneTarget?: {
+    pane: HTMLElement
+    rightHost: HTMLElement
+    bottomHost: HTMLElement
+  }
   unmount: () => void
 }
 
@@ -47,10 +52,9 @@ interface MountedSidebar {
 /** Unique per-test session ids (see the comment inside). */
 let sessionSeq = 0
 
-function mountSidebar(): MountedSidebar {
+function mountSidebar(paneMode = false): MountedSidebar {
   vi.stubGlobal('WebSocket', FakeWebSocket)
   const container = document.createElement('div')
-  document.body.append(container)
   const store = createSidebarStore()
   const service = createBetterSidebarService(store)
   // Fresh-session seed: the right panel starts OPEN, the bottom panel closed
@@ -74,15 +78,46 @@ function mountSidebar(): MountedSidebar {
     betterSidebar: service,
     get: (name: string) => name === 'betterSidebar' ? service : undefined,
   }
+  let paneTarget: MountedSidebar['paneTarget']
+  if (paneMode) {
+    vi.stubGlobal('ResizeObserver', class {
+      observe(): void {}
+      disconnect(): void {}
+    })
+    const pane = document.createElement('section')
+    Object.defineProperty(pane, 'getBoundingClientRect', {
+      value: () => ({
+        x: 0, y: 0, top: 0, left: 0, right: 884, bottom: 1180,
+        width: 884, height: 1180, toJSON: () => ({}),
+      }),
+    })
+    const rightHost = document.createElement('aside')
+    const bottomHost = document.createElement('aside')
+    pane.append(rightHost, bottomHost, container)
+    document.body.append(pane)
+    paneTarget = { pane, rightHost, bottomHost }
+  } else {
+    document.body.append(container)
+  }
   const root: Root = createRoot(container)
-  act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, store })) })
+  act(() => {
+    root.render(createElement(Sidebar, {
+      ctx: ctx as never,
+      store,
+      ...(paneTarget === undefined
+        ? {}
+        : { paneTarget: { sessionId, focused: true, ...paneTarget } }),
+    }))
+  })
   return {
     container,
     store,
     service,
+    ...(paneTarget === undefined ? {} : { paneTarget }),
     unmount: () => {
       act(() => { root.unmount() })
-      container.remove()
+      if (paneTarget === undefined) container.remove()
+      else paneTarget.pane.remove()
     },
   }
 }
@@ -115,6 +150,20 @@ function registerStubTerminal(service: BetterSidebarService, renders: { count: n
 }
 
 describe('bottom-panel first-expand auto terminal (issue #42 trigger chain)', () => {
+  it('Pane mode reserves the bottom row once and keeps legacy layout variables inside the panel host', () => {
+    const { container, store, service, paneTarget } = mountSidebar(true)
+    registerStubTerminal(service, { count: 0 })
+
+    act(() => { store.reduce(toggleBottomPanel) })
+
+    const height = `${store.getSnapshot().state!.bottomHeight}px`
+    const panelHost = container.querySelector<HTMLElement>('[data-dsh-pane-host]')!
+    expect(panelHost.style.getPropertyValue('--dsh-sidebar-height')).toBe(height)
+    expect(paneTarget!.bottomHost.style.height).toBe(height)
+    expect(paneTarget!.pane.style.getPropertyValue('--dsh-sidebar-height')).toBe('')
+    expect(document.documentElement.style.getPropertyValue('--dsh-sidebar-height')).toBe('')
+  })
+
   it('auto-opens exactly one terminal tab in the bottom workbench on the FIRST expansion', () => {
     const { container, store, service } = mountSidebar()
     const renders = { count: 0 }

--- a/tests/consumer-types.ts
+++ b/tests/consumer-types.ts
@@ -17,6 +17,9 @@ import {
 } from '../src/client/service.ts'
 import type {
   BetterSidebarService,
+  BetterSidebarPaneAttachment,
+  BetterSidebarPaneCapability,
+  BetterSidebarPaneTarget,
   FileFetchStrategy,
   FileViewerDescriptor,
   FileViewerProps,
@@ -122,8 +125,20 @@ const snapshot: SidebarSnapshot | undefined = service.getSnapshot()
 void snapshot
 service.subscribeState(() => {})
 service.updateTab('tab:1', { title: 'T', path: '/p', meta: 1 })
+service.updateTab('tab:1', { title: 'Scoped' }, { sessionId: 's1' })
 service.activateTab('tab:1')
 service.openFile({ sessionId: 's1', cwd: '/p' }, '/p/a.csv', 'Data')
+const paneTarget: BetterSidebarPaneTarget = {
+  sessionId: 's1',
+  pane: document.createElement('section'),
+  rightHost: document.createElement('aside'),
+  bottomHost: document.createElement('aside'),
+  focused: true,
+}
+const paneCapability: BetterSidebarPaneCapability | undefined = service.panes
+const paneAttachment: BetterSidebarPaneAttachment | undefined = paneCapability?.mountPane(paneTarget)
+paneAttachment?.update({ ...paneTarget, focused: false })
+paneAttachment?.dispose()
 
 /** Named state vocabulary stays importable (the pre-0.12 gap). */
 const diff: SidebarDiffRef = { kind: 'worktree', path: '/p/a.ts', staged: false }

--- a/tests/pane-mount.spec.tsx
+++ b/tests/pane-mount.spec.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { createElement } from 'react'
+import { act } from 'react-dom/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/client/Sidebar.tsx', () => ({
+  Sidebar: ({ ctx, store }: {
+    ctx: { sessions: { list: { getSnapshot(): unknown } } }
+    store: { getSnapshot(): { sessionId?: string } }
+  }) => {
+    const first = ctx.sessions.list.getSnapshot()
+    const second = ctx.sessions.list.getSnapshot()
+    return createElement('div', {
+      'data-test-pane-sidebar': store.getSnapshot().sessionId,
+      'data-test-list-snapshot-stable': String(first === second),
+    })
+  },
+}))
+
+import type { Context } from '../src/context-types.ts'
+import { createPaneCapability } from '../src/client/pane-mount.tsx'
+import { createBetterSidebarService } from '../src/client/service.ts'
+import { createSidebarStore } from '../src/client/state.ts'
+
+function target(sessionId: string, focused = false) {
+  const pane = document.createElement('section')
+  const rightHost = document.createElement('aside')
+  const bottomHost = document.createElement('aside')
+  pane.append(rightHost, bottomHost)
+  document.body.appendChild(pane)
+  return { sessionId, pane, rightHost, bottomHost, focused }
+}
+
+function context(): Context {
+  const snapshot = {
+    ids: ['s1', 's2'],
+    byId: { s1: { id: 's1' }, s2: { id: 's2' } },
+    current: 's1',
+    presentation: { visible: ['s1', 's2'], focused: 's1', capacity: 2 },
+  }
+  const list = { getSnapshot: () => snapshot, subscribe: () => () => {} }
+  const ctx = {
+    sessions: { list },
+    get: () => undefined,
+  }
+  return ctx as unknown as Context
+}
+
+describe('Better Sidebar Pane capability', () => {
+  beforeEach(() => { document.body.replaceChildren() })
+
+  it('mounts one scoped React root per Session and releases it independently', async () => {
+    const primary = createSidebarStore()
+    primary.setSession('s1')
+    const service = createBetterSidebarService(primary)
+    const changed = vi.fn()
+    const panes = createPaneCapability(context(), primary, service, changed)
+    const paneTarget = target('s2')
+
+    let attachment: ReturnType<typeof panes.mountPane>
+    await act(async () => { attachment = panes.mountPane(paneTarget) })
+    expect(panes.activeCount).toBe(1)
+    expect(paneTarget.pane.querySelector('[data-dsh-better-sidebar-pane="s2"]')).not.toBeNull()
+    expect(paneTarget.pane.querySelector('[data-test-pane-sidebar="s2"]')).not.toBeNull()
+    expect(paneTarget.pane.querySelector('[data-test-list-snapshot-stable="true"]')).not.toBeNull()
+
+    attachment!.update({ ...paneTarget, focused: true })
+    expect(paneTarget.pane.querySelector('[data-dsh-better-sidebar-pane="s2"]')?.hasAttribute('data-focused')).toBe(true)
+
+    await act(async () => { attachment!.dispose() })
+    expect(panes.activeCount).toBe(0)
+    expect(paneTarget.pane.querySelector('[data-dsh-better-sidebar-pane]')).toBeNull()
+    expect(changed).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/pane-mount.spec.tsx
+++ b/tests/pane-mount.spec.tsx
@@ -72,4 +72,34 @@ describe('Better Sidebar Pane capability', () => {
     expect(paneTarget.pane.querySelector('[data-dsh-better-sidebar-pane]')).toBeNull()
     expect(changed).toHaveBeenCalledTimes(2)
   })
+
+  it('routes unscoped service opens to the focused Pane store', async () => {
+    const primary = createSidebarStore()
+    primary.setSession('s1')
+    const service = createBetterSidebarService(primary)
+    const onOpen = vi.fn()
+    service.registerTab({ id: 'probe', title: 'Probe', component: () => null, onOpen })
+    const panes = createPaneCapability(context(), primary, service, () => {})
+    const first = target('s1', true)
+    const second = target('s2')
+    let firstAttachment: ReturnType<typeof panes.mountPane>
+    let secondAttachment: ReturnType<typeof panes.mountPane>
+    await act(async () => {
+      firstAttachment = panes.mountPane(first)
+      secondAttachment = panes.mountPane(second)
+    })
+
+    service.openTab({ type: 'probe' })
+    expect(onOpen).toHaveBeenLastCalledWith(expect.anything(), { sessionId: 's1' })
+
+    firstAttachment!.update({ ...first, focused: false })
+    secondAttachment!.update({ ...second, focused: true })
+    service.openTab({ type: 'probe' })
+    expect(onOpen).toHaveBeenLastCalledWith(expect.anything(), { sessionId: 's2' })
+
+    await act(async () => {
+      firstAttachment!.dispose()
+      secondAttachment!.dispose()
+    })
+  })
 })

--- a/tests/service.spec.ts
+++ b/tests/service.spec.ts
@@ -693,6 +693,38 @@ describe('state subscription (v0.12.0)', () => {
   })
 })
 
+describe('Pane store routing', () => {
+  it('routes scoped open, update and close calls to the attached Pane store', () => {
+    const primary = createSidebarStore()
+    const pane = createSidebarStore()
+    primary.setSession('s1')
+    pane.setSession('s2')
+    const service = createBetterSidebarService(primary)
+    service.registerTab({ id: 'doc', title: 'Doc', component: () => null })
+    const detach = service.attachPaneStore('s2', pane)
+
+    service.openTab({ type: 'doc', id: 'doc:2', title: 'Two' }, { sessionId: 's2' })
+    expect(allLeaves(primary.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs).filter(tab => tab.type === 'doc')).toHaveLength(0)
+    expect(allLeaves(pane.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs).filter(tab => tab.type === 'doc').map(tab => tab.id)).toEqual(['doc:2'])
+
+    service.updateTab('doc:2', { title: 'Updated' }, { sessionId: 's2' })
+    expect(allLeaves(pane.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs).find(tab => tab.id === 'doc:2')?.title).toBe('Updated')
+    service.closeTab('doc:2', { sessionId: 's2' })
+    expect(allLeaves(pane.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs).filter(tab => tab.type === 'doc')).toHaveLength(0)
+    detach()
+  })
+
+  it('rejects two live stores for the same Session and allows replacement after disposal', () => {
+    const service = createBetterSidebarService(createSidebarStore())
+    const first = createSidebarStore()
+    const second = createSidebarStore()
+    const detach = service.attachPaneStore('s', first)
+    expect(() => service.attachPaneStore('s', second)).toThrow(/already attached/)
+    detach()
+    expect(() => service.attachPaneStore('s', second)).not.toThrow()
+  })
+})
+
 describe('updateTab (v0.12.0)', () => {
   it('patches title / path / meta of an open tab', () => {
     const store = createSidebarStore()


### PR DESCRIPTION
## Summary
- add a pane-mount capability so compatible hosts can render independent right and bottom panels inside each session pane
- keep the existing global sidebar behavior unchanged when no pane host is present
- preserve each pane's own visibility, size, active tab, and lifecycle state
- route unscoped service actions to the currently focused pane store
- document and test the optional capability on the current v0.16.1 baseline

## Compatibility
The capability is opt-in. Existing DeepSeek Harness installations and users without a pane host continue to use the current global mount path.

## Verification
- `pnpm typecheck`
- `pnpm vitest run tests/api-surface.spec.ts tests/service.spec.ts tests/pane-mount.spec.tsx tests/bottom-auto-terminal.spec.tsx` (83 tests)
- `pnpm build`

This replaces the automatically closed #396 after its fork branch was renamed to follow this repository's `feat/*` convention.