### PR TITLE
fix: keep TOC button above the DSH code block's sticky banner

### DIFF
--- a/docs/plans/2026-08-24-markdown-html-toc-design.md
+++ b/docs/plans/2026-08-24-markdown-html-toc-design.md
@@ -33,6 +33,7 @@ DSH 宿主的 `MarkdownText` 出于聊天安全把 raw HTML 按字面文本渲�
 - 标题从**渲染后的 DOM** 收集（h1–h6，含 HTML 段内标题），MutationObserver 重扫（签名比对防重渲染循环）。
 - 跳转：展开 `closest('details:not([open])')` → `scrollIntoView({behavior:'smooth'})` → CSS 动画高亮 1.2s。
 - **⚠️ 关键实现陷阱（本次踩坑）**：MdToc **不能**通过传入父容器 ref 定位——React 的 layout 阶段子先于父，子组件的 `useLayoutEffect` 执行时父 div 的 ref **尚未挂上**（实测 `containerRef.current === null`，且依赖数组恒定导致 effect 永不重跑，按钮永不出现；jsdom 单测传预填 ref 对象会掩盖此 bug，只有真实挂载 e2e 能抓到）。修复：MdToc 用**自身 bar div 的 ref**（自身 effect 前必然已挂）取 `parentElement` 作为容器——挂载契约「渲染为目标滚动容器的直接子元素」写入组件文档；bar 常驻渲染（零高度无副作用）以保证 ref 恒在。
+- **层叠层级（2026-08-26 修复记录）**：TOC bar `z-index: 8`，**必须高于 DSH `CodeBlock` 的 sticky 头部**（宿主 `CodeBlock.module.css` 的 `.bannerWrap` 是 `position: sticky; top: 0; z-index: 6`）。文档以代码围栏开头或滚动到代码块时，banner 会钉在预览滚动区顶部、正好压在右上角 TOC 按钮下——若 TOC bar 层级更低，图标被不透明 banner 完全遮住（实测 `z-index: 3` 时按钮被挡、点击落在 banner 上）。取舍：TOC chrome 是预览滚动区内的最顶层；banner 钉顶期间 TOC 按钮会盖住 banner 右端的复制按钮一角（两者同钉顶、角落必然交叠，二选一）。配套 hover 表现：按钮浮在 banner 上时 hover 用**边框强化的 border 表现**（`border-l1 → border-l2`）而非半透明 `interactive-bg-hover` 填充，避免透出背后的复制按钮。回归守卫：e2e 在 `readme-style.md` 种子顶部加了代码围栏，`tocButton` 的 topmost 断言 + 点击即证明不被遮挡。
 
 ### 2.4 依赖与产物
 

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2832,7 +2832,12 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 .tocBar {
   position: sticky;
   top: 0;
-  z-index: 3;
+  /* Above the DSH CodeBlock banner: the host's CodeBlock.module.css gives
+     .bannerWrap `position: sticky; top: 0; z-index: 6`, so a code fence at
+     the top of the scrollport pins its opaque header right under the TOC
+     button and would otherwise paint over it. The TOC chrome is the
+     topmost layer inside the preview scrollport. */
+  z-index: 8;
   display: flex;
   justify-content: flex-end;
   height: 0;
@@ -2856,7 +2861,10 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 }
 
 .tocButton:hover {
-  background: var(--dsw-alias-interactive-bg-hover);
+  /* Border-based hover, not a fill: the button floats over the DSH code
+     banner's copy button, and the translucent interactive-bg-hover fill
+     let the copy button show through. */
+  border-color: var(--dsw-alias-border-l2);
   color: var(--dsw-alias-label-primary);
 }
 

--- a/tests/e2e/mount.e2e.ts
+++ b/tests/e2e/mount.e2e.ts
@@ -91,7 +91,16 @@ async function seedSession(): Promise<void> {
   // The README-style probe file: raw-HTML runs (badge wall div with an
   // embedded script, a <details> nesting a fence + heading) plus inline tags
   // inside a table cell. The script must be sanitized away in the preview.
+  // The document OPENS with a code fence: its sticky banner pins at the top
+  // of the preview scrollport, exactly under the pinned TOC button — the
+  // TOC probe below proves the button stays the topmost element there
+  // (regression: the DSH CodeBlock banner's sticky header used to paint
+  // over the TOC bar because its z-index 6 beat the bar's 3).
   writeFileSync(join(WORKSPACE_PATH, SEEDED_README_FILE), [
+    '```ts',
+    'export const tocStaysOnTop = true',
+    '```',
+    '',
     '# Readme Style',
     '',
     '<div align="center">',
@@ -500,13 +509,27 @@ test('plugin mounts into the DSH shell and survives a built-in tab sweep', async
     sidebar.locator('a[href="https://example.com/def"]'),
     'reference links must resolve across lifted HTML runs',
   ).toHaveCount(1, { timeout: 30_000 })
-  // TOC: the outline button appears (4 headings), opens the panel, and
-  // jumping into the collapsed details expands it.
+  // TOC: the outline button appears (4 headings), must stay the topmost
+  // element over the leading code fence's sticky banner, opens the panel,
+  // and jumping into the collapsed details expands it.
   const tocButton = sidebar.locator('[data-dsh-md-toc]')
   await expect(
     tocButton,
     'the TOC button must appear once the document has enough headings',
   ).toHaveCount(1, { timeout: 30_000 })
+  // The seed document opens with a code fence, so its sticky header is
+  // pinned under the TOC button right from the top of the preview. The
+  // button's center must hit-test back to the button (regression: the DSH
+  // banner's sticky z-index 6 used to paint over the TOC bar's 3).
+  await expect
+    .poll(async () => tocButton.evaluate((el) => {
+      const rect = el.getBoundingClientRect()
+      const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
+      return hit === el || (hit !== null && el.contains(hit))
+    }), {
+      message: 'the TOC button must be the topmost element at its center (not covered by the code banner)',
+    })
+    .toBe(true)
   await tocButton.click()
   const tocPanel = sidebar.locator('[data-dsh-md-toc-panel]')
   await expect(tocPanel, 'the TOC panel must open').toHaveCount(1)


### PR DESCRIPTION
## Problem

In the markdown preview, the TOC outline button (`md-toc.tsx:113`, `.tocBar`) is pinned top-right of the scroll container at `z-index: 3`. The host DSH `CodeBlock` banner (`CodeBlock.module.css` `.bannerWrap`) is `position: sticky; top: 0; z-index: 6` — so whenever a document starts with a code fence (or you scroll into one), the opaque banner pins exactly under the TOC button and painted over it: the icon was hidden and clicks landed on the banner.

## Fix

- `src/client/sidebar.module.css`: raise `.tocBar` to `z-index: 8` — the TOC chrome stays the topmost layer inside the preview scrollport (documented in the CSS + design doc).
- Hover treatment switched from the translucent `interactive-bg-hover` fill (which let the banner's copy button show through) to a border-based hover (`border-l1` → `border-l2`).

## Regression guard

`tests/e2e/mount.e2e.ts`: the `readme-style.md` seed now opens with a code fence, and the sweep asserts the TOC button hit-tests back to itself at its center (topmost) before clicking it — this fails with the old `z-index: 3`.

## Verification

- `pnpm typecheck` clean; unit suite green (only pre-existing PTY-spawn tests fail under the local sandbox, unrelated — verified identical without this change).
- `pnpm test:mount` mount lane: 5/5 mount specs pass, including the built-in tab sweep with the new TOC probe.

docs: design doc records the layering decision (2026-08-24-markdown-html-toc-design.md).