### PR TITLE
feat: terminal per-command blocks with hover add-to-conversation

### DIFF
--- a/docs/plans/2026-08-27-terminal-blocks-design.md
+++ b/docs/plans/2026-08-27-terminal-blocks-design.md
@@ -1,6 +1,6 @@
 # 终端块框架（Terminal Blocks）设计
 
-> 2026-08-27 · 状态：已实施（feat/terminal-blocks）
+> 2026-08-27 · 状态：已实施（feat/terminal-blocks，v2 含 hover block 层）
 > 需求：优化 term 框架，把终端里不同 CLI 执行拆成独立的 block；参考文件/代码 viewer 里「添加到对话框」（selection popup → `appendToDraft`）的能力，复用到 xterm 中——选中即浮出按钮、以及把「最后一次执行」作为一个整体插入对话草稿。
 
 ## 0. 决策记录（已确认）
@@ -13,7 +13,8 @@
 | 「添加到对话框」两种形态 | ① **选中**：TextEditor 同款浮钮（`.xterm-selection` 首段 DOM rect 锚定 + `createPortal` 到 body）；② **block**：终端右上角内置小药丸（每次命令提交后出现），点击把当前 block（命令 + 当前输出）整块插入 |
 | 输出上限 | `TERMINAL_INSERT_LIMIT = 4000` 字符，超出**截断 + `\n…` 标记**（不丢弃——终端 block 的价值就是输出本身，与文件选择的「超限只留 header」不同） |
 | 纯逻辑位置 | `src/client/terminal-blocks.ts`（零依赖，结构类型对齐 xterm `IBuffer`/`IBufferLine`），随 TerminalView 打进懒加载 chunk，不进核心 bundle |
-| 视觉分隔线 | **不做**（v1）：xterm 无稳定非 propose API 画行分隔（`registerMarker` 叠加层需渲染器内省，且 decoration 是 proposed API）；block 的可见形态 = 右上角药丸 + 选中 popup |
+| 锚点健壮性 | 每个 block 提交时由视图 `term.registerMarker(0)`（cursor 行 = echo 行）钉住锚点——marker 随 scrollback trim 平移、随 reflow 平移、滚出 buffer 自动 dispose；`blockStartLine` 优先 marker.line，disposed marker 解析为 **+Infinity**（行已消失 = 整体不可见），无 marker 时退回索引 |
+| 视觉 block 化与 hover | **已实施**（v2）：`TerminalBlockOverlay.tsx` 以每次 CLI 执行的 echo 行为界画 hairline 分隔线；鼠标悬停某个 block → 该 block 行区间淡色高亮 + 悬停行右侧浮出「添加到对话」药丸，点击整块插入草稿（选中模式 popup 优先）；矩形几何 = `.xterm-screen` rect + `(row - viewportY) × cellH`，不依赖 renderer 内部行元素 |
 
 ## 1. 现状关键事实（实施依据）
 

--- a/docs/plans/2026-08-27-terminal-blocks-design.md
+++ b/docs/plans/2026-08-27-terminal-blocks-design.md
@@ -1,0 +1,106 @@
+# 终端块框架（Terminal Blocks）设计
+
+> 2026-08-27 · 状态：已实施（feat/terminal-blocks）
+> 需求：优化 term 框架，把终端里不同 CLI 执行拆成独立的 block；参考文件/代码 viewer 里「添加到对话框」（selection popup → `appendToDraft`）的能力，复用到 xterm 中——选中即浮出按钮、以及把「最后一次执行」作为一个整体插入对话草稿。
+
+## 0. 决策记录（已确认）
+
+| 决策点 | 结论 |
+|---|---|
+| block 边界来源 | **用户输入流**（onData 里的 Enter），不做 prompt 嗅探——shell 提示符千变万化（zsh 右提示符、git 分支、颜色），嗅探不可靠且不可测 |
+| block 锚点 | Enter 时刻 `buffer.length - 1`（shell echo 行 = 提示符 + 命令所在行）；**不含 marker**——xterm marker 无法在测试中 mock，且滚动回收在 4000 行 scrollback 下几乎不影响尾部锚点（可接受偏差：paste 竞态少一行） |
+| echo 行处理 | 提取输出时**跳过 echo 行**，命令由 payload 的 fence info 行（`$ <command>`）携带，不重复 |
+| 「添加到对话框」两种形态 | ① **选中**：TextEditor 同款浮钮（`.xterm-selection` 首段 DOM rect 锚定 + `createPortal` 到 body）；② **block**：终端右上角内置小药丸（每次命令提交后出现），点击把当前 block（命令 + 当前输出）整块插入 |
+| 输出上限 | `TERMINAL_INSERT_LIMIT = 4000` 字符，超出**截断 + `\n…` 标记**（不丢弃——终端 block 的价值就是输出本身，与文件选择的「超限只留 header」不同） |
+| 纯逻辑位置 | `src/client/terminal-blocks.ts`（零依赖，结构类型对齐 xterm `IBuffer`/`IBufferLine`），随 TerminalView 打进懒加载 chunk，不进核心 bundle |
+| 视觉分隔线 | **不做**（v1）：xterm 无稳定非 propose API 画行分隔（`registerMarker` 叠加层需渲染器内省，且 decoration 是 proposed API）；block 的可见形态 = 右上角药丸 + 选中 popup |
+
+## 1. 现状关键事实（实施依据）
+
+- **「添加到对话框」现有链路**（`src/client/TextEditor.tsx`）：非空选区 → 浮钮（`css.selectionPopup`，`createPortal` 到 body，`position:fixed`，锚在选区头部上方）→ 点击 `appendToDraft(ctx, scope.sessionId, insert)`（`src/client/conversation-draft.ts`：`ctx.sessions.scope(sessionId)` + `ctx.get('conversation').input.setDraft`）。payload 由 `selection-payload.ts` 纯函数构建（fence + `相对路径:行号` info 行）。滚动/失焦/选区坍缩即隐藏。
+- **TerminalView**（`src/client/TerminalView.tsx`）：props `{ scope, tabId, store }`，主 effect 创建 xterm（`@xterm/xterm` 5.5.0，**DOM renderer 为默认**，`DomRenderer` 把选区画成 `.xterm-selection` 容器下的绝对定位 div——锚定 rect 的直接来源）；`term.onData` 已存在（转发 socket）；卸载三分支（close/park/drop）不变。**没有 ctx prop**——需要补。
+- **懒加载**（`chunks/terminal.tsx` → `lib/client-terminal.js`）：TerminalView 经 `lazyChunkComponent` 包装；`terminal-blocks.ts` / `conversation-draft.ts` 都是零重依赖模块，随 chunk 走。
+- **descriptor**（`src/client/builtins/tabs.tsx`）：终端 descriptor 的 component 收 `TabComponentProps`（含 `ctx`），显式映射 `tab.id → tabId`（`tests/lazy-chunk.spec.tsx` 回归钉住）。
+
+## 2. 数据模型与状态机
+
+```ts
+// terminal-blocks.ts
+interface TerminalBlock {
+  id: number          // 单调递增
+  command: string     // 清洗后的命令（trim，永不为空）
+  startRow: number    // Enter 时刻 buffer.length - 1（echo 行）
+  endRow: number | null  // 下一条命令的 echo 行；null = 仍开（尾部 = buffer 当前末尾）
+  finished: boolean
+}
+
+class TerminalBlockTracker {
+  blocks: readonly TerminalBlock[]   // 最旧在前，上限 BLOCK_KEEP = 32
+  current: TerminalBlock | null      // 最后一次提交的命令（仍在生长的 block）
+  pending: string                    // 自上次提交以来清洗后的输入（下一条命令）
+  onData(data: string, bufferLength: number): void
+}
+```
+
+- **输入清洗**（跨 chunk 的状态机，逐字符）：ESC 起 CSI（`[`…0x40–0x7e）/ OSC（`]`…BEL 或 ST）、bracketed-paste 标记、`\x7f`/`\b` 退格弹末字符、其余 C0（tab/bell）丢弃、可打印累积。
+- **提交**：`\r`/`\n` → `command = pending.trim()`；空命令（裸 Enter）**不产生 block**（shell 只多盖一行新提示符，留在前一个 block 的区间里，提取时尾部空行被剥掉）；非空 → 关闭上一个 block（`endRow = 新 startRow`）、新 block `startRow = max(0, bufferLength - 1)`。
+- **多行 paste**（`echo a\recho b\r` 一个 chunk）：逐字符处理 → 每行一个 block。
+
+## 3. 提取与 payload
+
+```ts
+blockOutputText(buffer, block, pending = '') → string
+```
+- 区间 `[startRow+1, end)`（echo 行跳过；finished block 用 `endRow` 闭合，开 block 用 `buffer.length`）。
+- 行拼接：`isWrapped` 行不插 `\n`（还原折行）；`translateToString(true)` 去行尾空白。
+- **剥离尾巴**：最后一行若以 `pending.trim()` 结尾（shell 正在回显下一条命令）→ 剥掉该行（单行场景整段为空）；尾部空行 `trimEnd()`。
+- 防御：`startRow` 越界（alt buffer 切换）→ clamp 到 `[0, length]`，`end <= from` 返回 ''。
+- best-effort 偏差（文档化）：paste 竞态（Enter 先于 echo 落屏）锚点偏一行；进度条 `\r` 原地重写只影响最终快照。
+
+```ts
+buildTerminalInsert(command, body, { limit = 4000, ellipsis = '\n…' }) → string
+// ```$ npm test
+// ✓ 3 passed
+// ```
+```
+- fence info 行 = `$ <command>`（命令未知/空时为裸 fence）；body 超限截断 + 标记（与文件选择的「超限只留 header」刻意不同）。
+- `blockForSelection(blocks, row0)`：倒序找 `startRow <= row0 < endRow` 的 block（选中开始行归属的 block 的命令作为 header；开 block 的 `endRow === null` 视为无穷）。
+
+## 4. TerminalView 接线
+
+```tsx
+// props 增加 ctx；effect 内：
+const tracker = new TerminalBlockTracker()
+termRef.current = term; trackerRef.current = tracker
+
+term.onData((data) => {
+  tracker.onData(data, term.buffer.active.length)
+  if (tracker.current !== null) setBlockReady(true)   // 幂等，首次提交后常亮
+  socket.send(data)
+})
+
+term.onSelectionChange(() => { ...  // 选区非空 → rAF 后读 .xterm-selection 首段 rect
+  // command = blockForSelection(tracker.blocks, range.start.y - 1)?.command
+  showSelectionPopup(buildTerminalInsert(command, selected), ...) })
+term.onScroll(() => hideSelectionPopup())             // 与编辑器同规则
+```
+
+- **选中 popup**：`createPortal` 到 body 的 `css.selectionPopup`（TextEditor 同款），`onMouseDown.preventDefault` 保选区，点击 `appendToDraft(ctx, scope.sessionId, insert)`。
+- **block 药丸**：`blockReady && connected && 无致命` 时渲染 `css.selectionPopup + css.terminalAddBlock`（absolute 右上角）；点击时**现取** `tracker.current` + `blockOutputText(term.buffer.active, ...)` 构建 payload（无过期状态）；有选中时隐藏（选中优先）。
+- **清理**：`selectionSub`/`scrollSub` dispose、rAF cancel、`termRef/trackerRef` 置空、`hideSelectionPopup()`；effect 开头 `setBlockReady(false)`（重挂载不残留旧会话状态）。
+- 卸载三分支（close/park/drop）、重连、字体/主题订阅全部不动。
+
+## 5. 风险与取舍
+
+| 项 | 说明 |
+|---|---|
+| DOM renderer 依赖 | 选区 rect 来自 `.xterm-selection > div`（当前默认且唯一 renderer）；若未来换 renderer，选中 popup 静默隐藏，block 药丸不受影响 |
+| 半条命令泄漏 | 剥尾巴只处理「最后一行以完整 pending 结尾」；折行的 pending 可能剥不干净（best-effort，文档化） |
+| 误剥 | 输出最后一行恰好以 pending 文本结尾会被误剥（概率低，可接受） |
+| 重连后 | 转录回放无输入历史 → 从零开始跟踪；用户再敲命令即恢复 |
+| 核心 bundle | terminal-blocks.ts 只被 TerminalView 引用 → 打进 `client-terminal.js` chunk，不动启动路径（`tests` 直接 import 该模块不受 bundle 影响） |
+
+## 6. 测试
+
+- `tests/terminal-blocks.spec.ts`（21 例，零挂载）：清洗状态机（CSI/OSC/粘贴标记/跨 chunk ESC/退格）、提交语义（锚点/闭合/裸 Enter/多行 paste/上限裁剪）、`blockOutputText`（echo 跳过/折行/闭合区间/尾部空行/pending 剥离/越界防御）、`blockForSelection`、`buildTerminalInsert`（fence 形状/截断/默认上限）。
+- 既有回归：`lazy-chunk.spec.tsx`（descriptor props 契约）、`builtins.spec.ts`、`terminal-deps-banner.spec.tsx` 全绿；typecheck 通过；`pnpm build` 出 chunk。

--- a/src/client/TerminalBlockOverlay.tsx
+++ b/src/client/TerminalBlockOverlay.tsx
@@ -1,0 +1,196 @@
+/**
+ * The visual "block" layer of the terminal: hairline dividers at every
+ * block boundary (each CLI execution is a UI unit) and, on hover, a span
+ * highlight of the block under the mouse plus a floating "add to
+ * conversation" pill at the hovered row — the per-block face of the same
+ * action the text viewers expose through their selection popup.
+ *
+ * Geometry: the terminal is DOM-rendered with one viewport row per buffer
+ * row, so `cellHeight = .xterm-screen.height / term.rows` and
+ * `pixelY = screenOriginY + (bufferRow - viewportY) * cellHeight` — no
+ * dependence on renderer-internal row elements. The layer renders inside
+ * the terminal host (`.terminal` gained `position: relative`), is
+ * pointer-transparent, and only the pill itself receives clicks.
+ *
+ * Refresh model: nothing here is reactive to React state — the layer
+ * redraws itself on a rAF-coalesced tick driven by the terminal's own
+ * events (scroll / write-parsed / resize) plus a ResizeObserver on the
+ * host; mousemove/mouseleave on the host drive the hover highlight. Blocks
+ * come from the tracker; each block's echo row is pinned by an xterm
+ * marker (see terminal-blocks.ts), so boundaries stay correct while the
+ * scrollback trims or the buffer reflows.
+ */
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import type { Terminal } from '@xterm/xterm'
+import { blockForSelection, blockSpanLines, type TerminalBlock, type TerminalBlockTracker } from './terminal-blocks.ts'
+import { t } from './locales.ts'
+import css from './sidebar.module.css'
+
+/** The overlay's props. `hostRef` points at the terminal host div (the ref
+ *  is read inside effects, so the first render may see a null host — the
+ *  layer then renders nothing until the host is attached and ticks). */
+export interface TerminalBlockOverlayProps {
+  hostRef: RefObject<HTMLDivElement | null>
+  term: Terminal
+  tracker: TerminalBlockTracker
+  /** Banners/errors hide the layer (no blocks to hover while degraded). */
+  visible: boolean
+  onAddBlock: (block: TerminalBlock) => void
+}
+
+/** Hover state: the block under the mouse (by id — the tracker's list
+ *  rotates, identity lookup keeps it honest) and the hovered buffer row. */
+interface Hover {
+  blockId: number
+  row: number
+}
+
+export function TerminalBlockOverlay(props: TerminalBlockOverlayProps) {
+  const { hostRef, term, tracker, visible, onAddBlock } = props
+  /** rAF-coalesced redraw tick (scroll/write/resize/host-size). */
+  const [, setTick] = useState(0)
+  const [hover, setHover] = useState<Hover | null>(null)
+  const frameRef = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (host === null) return
+    const schedule = (): void => {
+      if (frameRef.current !== undefined) return
+      frameRef.current = window.requestAnimationFrame(() => {
+        frameRef.current = undefined
+        setTick(value => value + 1)
+      })
+    }
+    schedule() // First paint once the host (and its size) exists.
+    const scrollSub = term.onScroll(schedule)
+    const writeSub = term.onWriteParsed(schedule)
+    const resizeSub = term.onResize(schedule)
+    const observer = new ResizeObserver(schedule)
+    observer.observe(host)
+    // Hover → highlight + pill. The row under the mouse resolves to a block
+    // through the tracker; leaving the terminal clears it.
+    const onMove = (event: MouseEvent): void => {
+      const screen = host.querySelector<HTMLElement>('.xterm-screen')
+      if (screen === null || term.rows === 0) return
+      const rect = screen.getBoundingClientRect()
+      if (rect.height === 0) return
+      const cellHeight = rect.height / term.rows
+      const buffer = term.buffer.active
+      const row = buffer.viewportY + Math.floor((event.clientY - rect.top) / cellHeight)
+      const block = blockForSelection(tracker.blocks, row)
+      setHover(block === null ? null : { blockId: block.id, row })
+    }
+    const onLeave = (): void => { setHover(null) }
+    host.addEventListener('mousemove', onMove)
+    host.addEventListener('mouseleave', onLeave)
+    return () => {
+      window.cancelAnimationFrame(frameRef.current ?? 0)
+      frameRef.current = undefined
+      scrollSub.dispose()
+      writeSub.dispose()
+      resizeSub.dispose()
+      observer.disconnect()
+      host.removeEventListener('mousemove', onMove)
+      host.removeEventListener('mouseleave', onLeave)
+    }
+    // `visible` only gates the render; the subscriptions are mount-scoped.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hostRef, term, tracker])
+
+  const host = hostRef.current
+  if (host === null || !visible) return null
+  const screen = host.querySelector<HTMLElement>('.xterm-screen')
+  if (screen === null) return null
+  const hostRect = host.getBoundingClientRect()
+  const screenRect = screen.getBoundingClientRect()
+  if (screenRect.width === 0 || screenRect.height === 0 || term.rows === 0) return null
+  const buffer = term.buffer.active
+  // The alt buffer (full-screen TUIs) scrolls/reflows its rows in place —
+  // block boundaries do not mean anything there; the layer yields.
+  if (buffer.type !== 'normal') return null
+  const cellHeight = screenRect.height / term.rows
+  const viewportY = buffer.viewportY
+  const viewportBottom = viewportY + term.rows
+  // The screen's origin inside the host (the host carries the padding; the
+  // layer coordinates are relative to the host's border box).
+  const originX = screenRect.left - hostRect.left
+  const originY = screenRect.top - hostRect.top
+  const scrollbarGap = hostRect.width - (originX + screenRect.width)
+
+  const blocks = tracker.blocks
+  const bufferLength = buffer.length
+  const entries: {
+    block: TerminalBlock
+    dividerY: number // the echo row's pixel Y (block boundary line)
+    spanY: number // clipped visible span: top
+    spanH: number // clipped visible span: height
+  }[] = []
+  for (const block of blocks) {
+    const span = blockSpanLines(blocks, block, bufferLength)
+    const clipStart = Math.max(span.start, viewportY)
+    const clipEnd = Math.min(span.end, viewportBottom)
+    if (clipEnd <= clipStart) continue
+    entries.push({
+      block,
+      dividerY: (span.start - viewportY) * cellHeight,
+      spanY: (clipStart - viewportY) * cellHeight,
+      spanH: (clipEnd - clipStart) * cellHeight - 1,
+    })
+  }
+
+  const hovered = hover !== null
+    ? entries.find(entry => entry.block.id === hover.blockId) ?? null
+    : null
+  // The pill sits at the hovered row — revalidated against the block's
+  // CURRENT span (scrolls shift the buffer under a stale hover). A live
+  // text selection suppresses it: the selection popup is the action of
+  // record then.
+  let pill: { block: TerminalBlock; top: number } | null = null
+  if (hovered !== null && hover !== null && !term.hasSelection()) {
+    const span = blockSpanLines(blocks, hovered.block, bufferLength)
+    if (hover.row >= span.start && hover.row < span.end) {
+      pill = {
+        block: hovered.block,
+        top: originY + (hover.row - viewportY) * cellHeight + (cellHeight - 28) / 2,
+      }
+    }
+  }
+
+  return (
+    <div className={css.terminalBlockLayer}>
+      {entries.map(({ block, dividerY }) => {
+        // A block that started above the viewport has its boundary off-screen
+        // — only draw the hairline inside the host.
+        if (dividerY < 0 || dividerY > hostRect.height - 1) return null
+        return (
+          <div
+            key={block.id}
+            className={css.terminalBlockDivider}
+            style={{ top: originY + dividerY, left: originX + 6, right: scrollbarGap + 6 }}
+          />
+        )
+      })}
+      {hovered !== null && (
+        <div
+          className={css.terminalBlockHover}
+          style={{ top: originY + hovered.spanY, height: hovered.spanH, left: originX, width: screenRect.width }}
+        />
+      )}
+      {pill !== null && (
+        <button
+          type="button"
+          className={css.terminalBlockPill}
+          style={{
+            top: Math.max(0, Math.min(pill.top, hostRect.height - 28)),
+            right: scrollbarGap + 8,
+          }}
+          title={pill.block.command}
+          onClick={() => { onAddBlock(pill.block) }}
+        >
+          {t('addToConversation')}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -33,7 +33,6 @@
  */
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import clsx from 'clsx'
 import { Terminal, type ITheme } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
@@ -49,8 +48,11 @@ import {
   TerminalBlockTracker,
   blockForSelection,
   blockOutputText,
+  blockSpanLines,
   buildTerminalInsert,
+  type TerminalBlock,
 } from './terminal-blocks.ts'
+import { TerminalBlockOverlay } from './TerminalBlockOverlay.tsx'
 import type { Context } from '../context-types.ts'
 import css from './sidebar.module.css'
 
@@ -115,11 +117,18 @@ function xtermTheme(): ITheme {
 
 /** The floating "add to conversation" action: payload + viewport anchor
  *  (the selection-mode port of the text viewers' popup — the block mode is
- *  the pill pinned inside the terminal instead, see {@link TerminalView}). */
+ *  the hover-driven overlay layer, see {@link TerminalBlockOverlay}). */
 interface SelectionPopup {
   insert: string
   left: number
   top: number
+}
+
+/** The live terminal session handed to the block overlay (state, so the
+ *  overlay re-mounts per session instead of chasing refs). */
+interface TerminalSession {
+  term: Terminal
+  tracker: TerminalBlockTracker
 }
 
 export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: string; store: SidebarStore }) {
@@ -134,9 +143,9 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
    *  the popup commits so the payload is always built at click time). */
   const termRef = useRef<Terminal | null>(null)
   const trackerRef = useRef<TerminalBlockTracker | null>(null)
-  /** Whether at least one command was submitted since mount (block mode of
-   *  the "add to conversation" pill). */
-  const [blockReady, setBlockReady] = useState(false)
+  /** The mounted terminal session (null until the mount effect ran); the
+   *  block overlay mounts on it. */
+  const [session, setSession] = useState<TerminalSession | null>(null)
   /** The floating "add to conversation" popup for a selection (null = hidden). */
   const [selectionPopup, setSelectionPopup] = useState<SelectionPopup | null>(null)
   /** Live mirror of the popup state for click-time reads (no re-render race). */
@@ -166,15 +175,16 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
     hideSelectionPopup()
   }
 
-  /** The block pill's click: build the CURRENT block's payload live (the
-   *  command + its output rows so far) and insert it into the draft. */
-  const commitBlockPopup = (): void => {
+  /** The block overlay pill's click: build THE hovered block's payload live
+   *  (command + its output rows, marker-resolved boundaries) and insert it
+   *  into the draft. */
+  const commitBlock = (block: TerminalBlock): void => {
     const tracker = trackerRef.current
     const term = termRef.current
     if (tracker === null || term === null) return
-    const block = tracker.current
-    if (block === null) return
-    const output = blockOutputText(term.buffer.active, block, tracker.pending)
+    const buffer = term.buffer.active
+    const span = blockSpanLines(tracker.blocks, block, buffer.length)
+    const output = blockOutputText(buffer, block, tracker.pending, span.end)
     appendToDraft(ctx, scope.sessionId, buildTerminalInsert(block.command, output))
   }
 
@@ -184,7 +194,6 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
     // A (re)mount starts with a clean block model: the replay/resumed
     // transcript has no input history, and any stale popup from a previous
     // session must not survive.
-    setBlockReady(false)
     hideSelectionPopup()
 
     // The custom font prefs (side card settings, terminal card) resolve at
@@ -201,9 +210,15 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
     })
     // The block model: every Enter in the input stream submits a command and
     // opens a new block anchored at the shell's echo row (terminal-blocks.ts).
-    const tracker = new TerminalBlockTracker()
+    // Each block pins that row with an xterm marker — markers slide with
+    // scrollback trims and reflows, keeping the bloc UI honest over time.
+    const tracker = new TerminalBlockTracker((block) => {
+      const marker = term.registerMarker(0)
+      if (marker !== undefined) block.marker = marker
+    })
     termRef.current = term
     trackerRef.current = tracker
+    setSession({ term, tracker })
     const fit = new FitAddon()
     term.loadAddon(fit)
     // Re-theme in place when the app's scheme flips (tokens + palette).
@@ -304,7 +319,6 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
 
     const inputSub = term.onData((data) => {
       tracker.onData(data, term.buffer.active.length)
-      if (tracker.current !== null) setBlockReady(true)
       if (socket !== null && socket.readyState === WebSocket.OPEN) socket.send(data)
     })
     // Selection → the floating "add to conversation" popup (the shared
@@ -434,6 +448,7 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
       connectRef.current = null
       termRef.current = null
       trackerRef.current = null
+      setSession(null)
       hideSelectionPopup()
     }
   }, [scope.sessionId, scope.cwd, tabId, store])
@@ -457,21 +472,20 @@ export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: 
         </div>
       )}
       {fatal === null && depsFatal === null && !connected && <div className={css.terminalBanner}>{t('disconnected')}</div>}
-      <div ref={hostRef} className={css.terminal} />
-      {/* Block mode of the "add to conversation" action (the terminal analog
-          of the text viewers' selection popup): once a command was submitted
-          this pill offers the current block — the last CLI execution and its
-          output rows so far — pinned to the terminal's top-right corner. The
-          selection popup takes precedence while a selection is active. */}
-      {selectionPopup === null && blockReady && connected && fatal === null && depsFatal === null && (
-        <button
-          type="button"
-          className={clsx(css.selectionPopup, css.terminalAddBlock)}
-          onClick={commitBlockPopup}
-        >
-          {t('addToConversation')}
-        </button>
-      )}
+      <div ref={hostRef} className={css.terminal}>
+        {/* The block layer: hairline dividers at every CLI block boundary;
+            hovering a block highlights its span and raises the per-block
+            "add to conversation" pill (see TerminalBlockOverlay). */}
+        {session !== null && (
+          <TerminalBlockOverlay
+            hostRef={hostRef}
+            term={session.term}
+            tracker={session.tracker}
+            visible={connected && fatal === null && depsFatal === null}
+            onAddBlock={commitBlock}
+          />
+        )}
+      </div>
       {/* Selection mode: portalled to document.body and position:fixed, so
           the terminal's overflow clips cannot crop it (same as TextEditor). */}
       {selectionPopup !== null && createPortal(

--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -32,6 +32,8 @@
  *   bare socket drop gets the host's reconnect grace.
  */
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import clsx from 'clsx'
 import { Terminal, type ITheme } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
@@ -42,6 +44,14 @@ import { api, type SessionScope, type TerminalDepsStatus } from './api.ts'
 import { agentUuidOf, isAgentTabId, type SidebarStore } from './state.ts'
 import { isDarkScheme, subscribeColorScheme, effectiveTokenValue, tokenValue } from './theme.ts'
 import { resolveTerminalFont } from './terminal-font.ts'
+import { appendToDraft } from './conversation-draft.ts'
+import {
+  TerminalBlockTracker,
+  blockForSelection,
+  blockOutputText,
+  buildTerminalInsert,
+} from './terminal-blocks.ts'
+import type { Context } from '../context-types.ts'
 import css from './sidebar.module.css'
 
 /** How many consecutive unreasoned failures before showing the error banner. */
@@ -103,18 +113,80 @@ function xtermTheme(): ITheme {
   }
 }
 
-export function TerminalView(props: { scope: SessionScope; tabId: string; store: SidebarStore }) {
-  const { scope, tabId, store } = props
+/** The floating "add to conversation" action: payload + viewport anchor
+ *  (the selection-mode port of the text viewers' popup — the block mode is
+ *  the pill pinned inside the terminal instead, see {@link TerminalView}). */
+interface SelectionPopup {
+  insert: string
+  left: number
+  top: number
+}
+
+export function TerminalView(props: { ctx: Context; scope: SessionScope; tabId: string; store: SidebarStore }) {
+  const { ctx, scope, tabId, store } = props
   const hostRef = useRef<HTMLDivElement>(null)
   const [connected, setConnected] = useState(false)
   const [fatal, setFatal] = useState<string | null>(null)
   const [depsFatal, setDepsFatal] = useState<TerminalDepsInfo | null>(null)
   const [lastUrl, setLastUrl] = useState<string | null>(null)
   const connectRef = useRef<(() => void) | null>(null)
+  /** Live xterm + block tracker handles (set by the mount effect, read by
+   *  the popup commits so the payload is always built at click time). */
+  const termRef = useRef<Terminal | null>(null)
+  const trackerRef = useRef<TerminalBlockTracker | null>(null)
+  /** Whether at least one command was submitted since mount (block mode of
+   *  the "add to conversation" pill). */
+  const [blockReady, setBlockReady] = useState(false)
+  /** The floating "add to conversation" popup for a selection (null = hidden). */
+  const [selectionPopup, setSelectionPopup] = useState<SelectionPopup | null>(null)
+  /** Live mirror of the popup state for click-time reads (no re-render race). */
+  const selectionPopupRef = useRef<SelectionPopup | null>(null)
+
+  const hideSelectionPopup = (): void => {
+    selectionPopupRef.current = null
+    setSelectionPopup(null)
+  }
+
+  /** Anchor the popup above the selection head; clamp inside the viewport. */
+  const showSelectionPopup = (insert: string, left: number, top: number): void => {
+    const next: SelectionPopup = {
+      insert,
+      left: Math.min(Math.max(left, 80), window.innerWidth - 80),
+      top,
+    }
+    selectionPopupRef.current = next
+    setSelectionPopup(next)
+  }
+
+  /** The selection popup's click: insert the stored payload into the draft. */
+  const commitSelectionPopup = (): void => {
+    const current = selectionPopupRef.current
+    if (current === null) return
+    appendToDraft(ctx, scope.sessionId, current.insert)
+    hideSelectionPopup()
+  }
+
+  /** The block pill's click: build the CURRENT block's payload live (the
+   *  command + its output rows so far) and insert it into the draft. */
+  const commitBlockPopup = (): void => {
+    const tracker = trackerRef.current
+    const term = termRef.current
+    if (tracker === null || term === null) return
+    const block = tracker.current
+    if (block === null) return
+    const output = blockOutputText(term.buffer.active, block, tracker.pending)
+    appendToDraft(ctx, scope.sessionId, buildTerminalInsert(block.command, output))
+  }
 
   useEffect(() => {
     const host = hostRef.current
     if (host === null) return
+    // A (re)mount starts with a clean block model: the replay/resumed
+    // transcript has no input history, and any stale popup from a previous
+    // session must not survive.
+    setBlockReady(false)
+    hideSelectionPopup()
+
     // The custom font prefs (side card settings, terminal card) resolve at
     // mount; store changes re-apply them live below.
     const font = resolveTerminalFont(store.getPrefs(), tokenValue('--ds-font-family-code'))
@@ -127,6 +199,11 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
       scrollback: 4000,
       theme: xtermTheme(),
     })
+    // The block model: every Enter in the input stream submits a command and
+    // opens a new block anchored at the shell's echo row (terminal-blocks.ts).
+    const tracker = new TerminalBlockTracker()
+    termRef.current = term
+    trackerRef.current = tracker
     const fit = new FitAddon()
     term.loadAddon(fit)
     // Re-theme in place when the app's scheme flips (tokens + palette).
@@ -226,8 +303,45 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
     connectRef.current = connect
 
     const inputSub = term.onData((data) => {
+      tracker.onData(data, term.buffer.active.length)
+      if (tracker.current !== null) setBlockReady(true)
       if (socket !== null && socket.readyState === WebSocket.OPEN) socket.send(data)
     })
+    // Selection → the floating "add to conversation" popup (the shared
+    // selectionPopup chrome anchored at the selection head; same contract as
+    // the text viewers' portaled button). The DOM renderer paints the
+    // selection segments when the change lands, so the anchor rects are read
+    // on the next frame. Scrolling hides the popup (same rule as the editors).
+    let selectionFrame: number | undefined
+    const selectionSub = term.onSelectionChange(() => {
+      window.cancelAnimationFrame(selectionFrame ?? 0)
+      const selected = term.getSelection()
+      if (selected === '' || selected.trim() === '') {
+        hideSelectionPopup()
+        return
+      }
+      const range = term.getSelectionPosition()
+      if (range === undefined) {
+        hideSelectionPopup()
+        return
+      }
+      selectionFrame = window.requestAnimationFrame(() => {
+        if (closed) return
+        const firstSegment = host.querySelector('.xterm-selection > div:first-child')
+        if (firstSegment === null) {
+          hideSelectionPopup()
+          return
+        }
+        const rect = firstSegment.getBoundingClientRect()
+        const command = blockForSelection(tracker.blocks, range.start.y - 1)?.command
+        showSelectionPopup(
+          buildTerminalInsert(command, selected),
+          rect.left + rect.width / 2,
+          rect.top,
+        )
+      })
+    })
+    const scrollSub = term.onScroll(() => hideSelectionPopup())
     const observer = new ResizeObserver(() => {
       try {
         fit.fit()
@@ -282,10 +396,13 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
       closed = true
       cancelOpen()
       window.clearTimeout(retry)
+      window.cancelAnimationFrame(selectionFrame ?? 0)
       observer.disconnect()
       fontSub()
       schemeSub()
       inputSub.dispose()
+      selectionSub.dispose()
+      scrollSub.dispose()
       // Three unmount cases, distinguished by the store's tab/open state and
       // the active session id:
       // 1. The tab was closed by the user (NOT in its session's state): send
@@ -315,6 +432,9 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
       socket?.close()
       term.dispose()
       connectRef.current = null
+      termRef.current = null
+      trackerRef.current = null
+      hideSelectionPopup()
     }
   }, [scope.sessionId, scope.cwd, tabId, store])
 
@@ -338,6 +458,35 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
       )}
       {fatal === null && depsFatal === null && !connected && <div className={css.terminalBanner}>{t('disconnected')}</div>}
       <div ref={hostRef} className={css.terminal} />
+      {/* Block mode of the "add to conversation" action (the terminal analog
+          of the text viewers' selection popup): once a command was submitted
+          this pill offers the current block — the last CLI execution and its
+          output rows so far — pinned to the terminal's top-right corner. The
+          selection popup takes precedence while a selection is active. */}
+      {selectionPopup === null && blockReady && connected && fatal === null && depsFatal === null && (
+        <button
+          type="button"
+          className={clsx(css.selectionPopup, css.terminalAddBlock)}
+          onClick={commitBlockPopup}
+        >
+          {t('addToConversation')}
+        </button>
+      )}
+      {/* Selection mode: portalled to document.body and position:fixed, so
+          the terminal's overflow clips cannot crop it (same as TextEditor). */}
+      {selectionPopup !== null && createPortal(
+        <button
+          type="button"
+          className={css.selectionPopup}
+          style={{ left: selectionPopup.left, top: selectionPopup.top }}
+          // Keep the selection alive until the click commits.
+          onMouseDown={(event) => { event.preventDefault() }}
+          onClick={commitSelectionPopup}
+        >
+          {t('addToConversation')}
+        </button>,
+        document.body,
+      )}
     </div>
   )
 }

--- a/src/client/builtins/tabs.tsx
+++ b/src/client/builtins/tabs.tsx
@@ -34,8 +34,8 @@ import type { TabDescriptor } from '../service.ts'
  * wrapper keeps the descriptor contract `(props) => ReactNode` — Sidebar
  * calls it as a plain function.
  *
- * TerminalView's props are { scope, tabId, store } — `tabId` is NOT part of
- * TabComponentProps (it carries `tab: SidebarTab` instead), so the
+ * TerminalView's props are { ctx, scope, tabId, store } — `tabId` is NOT
+ * part of TabComponentProps (it carries `tab: SidebarTab` instead), so the
  * descriptor maps it explicitly; a bare pass-through would leave tabId
  * undefined and TerminalView's isAgentTabId(tabId) would crash on
  * `undefined.startsWith` (regression-pinned in tests/lazy-chunk.spec.tsx).
@@ -47,6 +47,7 @@ const LazyTerminal = lazyChunkComponent<TerminalViewProps>(
 
 /** The terminal view's props (mirror of TerminalView's own signature). */
 interface TerminalViewProps {
+  ctx: Context
   scope: SessionScope
   tabId: string
   store: SidebarStore
@@ -282,7 +283,9 @@ export function builtinTabs(ctx: Context, options: BuiltinTabOptions = {}): read
           patch: { nextTerminal: state.nextTerminal + 1 },
         }
       },
-      component: ({ tab, scope, store }) => <LazyTerminal scope={scope} store={store} tabId={tab.id} />,
+      component: ({ ctx, tab, scope, store }) => (
+        <LazyTerminal ctx={ctx} scope={scope} store={store} tabId={tab.id} />
+      ),
     },
     {
       id: 'browser',

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2015,6 +2015,17 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   height: 100%;
 }
 
+/* Block-mode "add to conversation": the shared selectionPopup chrome, but
+   pinned inside the terminal wrap (top-right) instead of floating at the
+   selection — offers the last CLI execution block as one insertable unit. */
+.terminalAddBlock {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  transform: none;
+  z-index: 6;
+}
+
 .terminalBanner {
   flex: none;
   display: flex;

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -2008,6 +2008,7 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 .terminal {
   flex: 1;
   min-height: 0;
+  position: relative; /* containing block for the block layer overlay */
   padding: 6px 4px 6px 8px;
 }
 
@@ -2015,14 +2016,38 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   height: 100%;
 }
 
-/* Block-mode "add to conversation": the shared selectionPopup chrome, but
-   pinned inside the terminal wrap (top-right) instead of floating at the
-   selection — offers the last CLI execution block as one insertable unit. */
-.terminalAddBlock {
+/* The block layer: absolutely fills the terminal host, pointer-transparent
+   (only the pill inside receives clicks). Dividers/highlight/pill positions
+   are computed per render from the xterm screen's live geometry. */
+.terminalBlockLayer {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+/* One hairline per CLI block boundary (at each block's echo row). */
+.terminalBlockDivider {
+  position: absolute;
+  height: 1px;
+  background: var(--dsw-alias-border-l1);
+  pointer-events: none;
+}
+
+/* The hovered block's span, tinted under the text (text stays readable). */
+.terminalBlockHover {
+  position: absolute;
+  background: var(--dsw-alias-interactive-bg-hover);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+/* The per-block "add to conversation" pill: the shared selectionPopup
+   chrome, anchored at the hovered row instead of a selection. */
+.terminalBlockPill {
+  position: absolute;
   transform: none;
+  pointer-events: auto;
   z-index: 6;
 }
 

--- a/src/client/terminal-blocks.ts
+++ b/src/client/terminal-blocks.ts
@@ -1,0 +1,230 @@
+/**
+ * The terminal "block" framework: one continuous xterm buffer is segmented
+ * into per-command blocks — each CLI execution gets a block carrying the
+ * cleaned command and the buffer rows of its output — and the "add to
+ * conversation" payloads are built from them. This is the terminal analog
+ * of `selection-payload.ts` (the text viewers' selection popup): the same
+ * appendToDraft path, fed with a block instead of a file selection.
+ *
+ * Everything here is pure row/string math over a minimal structural view of
+ * the xterm buffer ({@link TerminalBlockBuffer}); xterm's own
+ * `IBuffer`/`IBufferLine` satisfy the shapes structurally, so the unit
+ * tests drive the whole framework without mounting xterm.
+ *
+ * Block boundaries come from the user's input stream, not from prompt
+ * detection: each Enter (`\r`/`\n`) in the onData feed submits the cleaned
+ * pending command and opens a new block anchored at the shell's echo row
+ * (the last buffer row at submit time — the prompt + command line). Output
+ * extraction therefore SKIPS the echo row; the payload carries the command
+ * in its fence header instead. Rows after a submit (output, and the next
+ * prompt) belong to the open block until the next submit closes it.
+ */
+
+/** Minimal structural view of one buffer row (matches xterm's IBufferLine). */
+export interface TerminalBlockLine {
+  /** Whether this row continues the row above (a wrapped line). */
+  readonly isWrapped: boolean
+  translateToString(trimRight?: boolean, startColumn?: number, endColumn?: number): string
+}
+
+/** Minimal structural view of a terminal buffer (matches xterm's IBuffer).
+ *  xterm's real buffer satisfies this shape, so the tracker/extractors are
+ *  fully testable without mounting xterm. */
+export interface TerminalBlockBuffer {
+  readonly length: number
+  getLine(y: number): TerminalBlockLine | undefined
+}
+
+/** How many finished blocks the tracker keeps (older ones drop off). */
+export const BLOCK_KEEP = 32
+
+/** One CLI execution: the command and the buffer span of its rows. */
+export interface TerminalBlock {
+  /** Monotonic per-tracker id (ordering only). */
+  readonly id: number
+  /** The cleaned command text the user submitted (never empty). */
+  readonly command: string
+  /** Buffer row of the shell echo (prompt + command) at submit time. */
+  readonly startRow: number
+  /** Echo row of the NEXT command; null while this block is still open.
+   *  Finished blocks get a closed span: [startRow+1, endRow). The tracker
+   *  closes the span when the next command submits. */
+  endRow: number | null
+  finished: boolean
+}
+
+/**
+ * Segments the terminal's input stream into blocks. Feed every onData chunk
+ * (with the buffer length at that moment) — submits, pending text and the
+ * block list all derive from it.
+ */
+export class TerminalBlockTracker {
+  private _mode: 0 | 1 | 2 | 3 = 0
+  private _clean = ''
+  private _blocks: TerminalBlock[] = []
+  private _current: TerminalBlock | null = null
+  private _nextId = 1
+
+  /** All tracked blocks, oldest first (capped at {@link BLOCK_KEEP}). */
+  get blocks(): readonly TerminalBlock[] {
+    return this._blocks
+  }
+
+  /** The open block (the last submitted command, still growing). */
+  get current(): TerminalBlock | null {
+    return this._current
+  }
+
+  /** Cleaned text typed since the last submit (the next command so far). */
+  get pending(): string {
+    return this._clean
+  }
+
+  /** Feed one onData chunk. `bufferLength` = `term.buffer.active.length`
+   *  at the time the chunk was produced — it anchors a submit's echo row. */
+  onData(data: string, bufferLength: number): void {
+    for (let i = 0; i < data.length; i++) this._feed(data.charAt(i), bufferLength)
+  }
+
+  private _feed(ch: string, bufferLength: number): void {
+    const code = ch.charCodeAt(0)
+    switch (this._mode) {
+      case 1: // After ESC: '[' starts CSI, ']' starts OSC, anything else
+        // consumed the sequence (e.g. ESC \ closes an OSC string).
+        this._mode = ch === '[' ? 2 : ch === ']' ? 3 : 0
+        return
+      case 2: // CSI: swallows up to the final byte (0x40–0x7e).
+        if (code >= 0x40 && code <= 0x7e) this._mode = 0
+        return
+      case 3: // OSC: swallows until BEL or ST (ESC \).
+        if (ch === '\x07') this._mode = 0
+        else if (ch === '\x1b') this._mode = 1
+        return
+      default: // 0 — printable handling below.
+        break
+    }
+    if (code === 0x1b) { this._mode = 1; return }
+    if (ch === '\r' || ch === '\n') { this._submit(bufferLength); return }
+    if (code === 0x7f || code === 0x08) { this._clean = this._clean.slice(0, -1); return }
+    if (code < 0x20) return // Remaining C0 controls (tab, bell…) — not command text.
+    this._clean += ch
+  }
+
+  private _submit(bufferLength: number): void {
+    const command = this._clean.trim()
+    this._clean = ''
+    // A bare Enter produces no block — the shell just stamps another prompt
+    // line, which stays inside the previous block's span (trailing blank
+    // rows are stripped at extraction anyway).
+    if (command === '') return
+    const startRow = Math.max(0, bufferLength - 1)
+    if (this._current !== null) {
+      this._current.finished = true
+      this._current.endRow = startRow
+    }
+    const block: TerminalBlock = {
+      id: this._nextId++,
+      command,
+      startRow,
+      endRow: null,
+      finished: false,
+    }
+    this._blocks.push(block)
+    if (this._blocks.length > BLOCK_KEEP) {
+      this._blocks.splice(0, this._blocks.length - BLOCK_KEEP)
+    }
+    this._current = block
+  }
+}
+
+/**
+ * The plain-text rows of a block's output: `[startRow+1, end)` where the
+ * echo row (prompt + command) is skipped — the payload's fence header
+ * carries the command instead. Wrapped rows re-join without a newline,
+ * trailing blank rows (prompt stamps, empty lines) are stripped, and a
+ * trailing row that still ends with the *pending* next command (the shell
+ * echoes while the user types) is peeled off so a half-typed command never
+ * leaks into the payload. Best-effort by design: reply races (a pasted
+ * Enter landing before its echo) and prompt redraws shift the anchor a
+ * little, never worse than a misplaced boundary line.
+ */
+export function blockOutputText(
+  buffer: TerminalBlockBuffer,
+  block: TerminalBlock,
+  pending = '',
+): string {
+  const length = buffer.length
+  const from = Math.min(Math.max(block.startRow + 1, 0), length)
+  const end = Math.min(block.endRow ?? length, length)
+  if (end <= from) return ''
+  let text = ''
+  let first = true
+  for (let i = from; i < end; i++) {
+    const line = buffer.getLine(i)
+    if (line === undefined) continue
+    const row = line.translateToString(true)
+    // A wrapped row continues the previous line — no newline before it.
+    text += (line.isWrapped || first ? '' : '\n') + row
+    first = false
+  }
+  const pendingTrimmed = pending.trim()
+  if (pendingTrimmed !== '') {
+    // The shell echoes the NEXT command while the user types it; its row is
+    // the open block's tail and must not leak into the payload.
+    const lastBreak = text.lastIndexOf('\n')
+    const lastRow = lastBreak === -1 ? text : text.slice(lastBreak + 1)
+    if (lastRow.trimEnd().endsWith(pendingTrimmed)) {
+      text = lastBreak === -1 ? '' : text.slice(0, lastBreak)
+    }
+  }
+  return text.trimEnd()
+}
+
+/**
+ * The block containing a buffer row (1-based xterm coordinates become
+ * 0-based here), newest first: returns null when the row predates all
+ * tracked blocks — the header then falls back to a bare fence.
+ */
+export function blockForSelection(
+  blocks: readonly TerminalBlock[],
+  bufferRow: number,
+): TerminalBlock | null {
+  if (bufferRow < 0) return null
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i]
+    if (block === undefined) continue
+    if (block.startRow > bufferRow) continue
+    if (block.endRow === null || bufferRow < block.endRow) return block
+  }
+  return null
+}
+
+/** Max body length of an inserted block/selection (UTF-16 units). */
+export const TERMINAL_INSERT_LIMIT = 4000
+
+/** The ellipsis appended at a truncation point (data marker, locale-free). */
+const TERMINAL_INSERT_ELLIPSIS = '\n…'
+
+/**
+ * The full "add to conversation" payload for a terminal block or selection,
+ * mirroring `buildSelectionInsert`'s shape: a fenced code block whose info
+ * line is the command the content belongs to (`$ <command>`, empty when
+ * unknown) and whose body is the text. Over the limit the body is cut and
+ * marked instead of dropped — unlike a file selection, the output IS the
+ * point of a terminal block.
+ */
+export function buildTerminalInsert(
+  command: string | undefined,
+  body: string,
+  options: { limit?: number; ellipsis?: string } = {},
+): string {
+  const header = command !== undefined && command.trim() !== ''
+    ? `$ ${command.trim()}`
+    : ''
+  const limit = options.limit ?? TERMINAL_INSERT_LIMIT
+  let text = body
+  if (text.length > limit) {
+    text = `${text.slice(0, limit)}${options.ellipsis ?? TERMINAL_INSERT_ELLIPSIS}`
+  }
+  return `\`\`\`${header}\n${text}\n\`\`\``
+}

--- a/src/client/terminal-blocks.ts
+++ b/src/client/terminal-blocks.ts
@@ -35,6 +35,18 @@ export interface TerminalBlockBuffer {
   getLine(y: number): TerminalBlockLine | undefined
 }
 
+/** A row anchor that survives scrollback trimming and reflow (matches
+ *  xterm's IMarker — `registerMarker(0)` anchors the cursor's row). The
+ *  VIEW attaches one to a block right after its submit; the tracker itself
+ *  never creates markers, keeping the framework xterm-free. */
+export interface TerminalBlockMarker {
+  /** The current buffer row of the anchor. */
+  readonly line: number
+  /** True once the anchor's row was trimmed out of the buffer. */
+  readonly isDisposed: boolean
+  dispose(): void
+}
+
 /** How many finished blocks the tracker keeps (older ones drop off). */
 export const BLOCK_KEEP = 32
 
@@ -51,12 +63,18 @@ export interface TerminalBlock {
    *  closes the span when the next command submits. */
   endRow: number | null
   finished: boolean
+  /** The live anchor of the echo row (attached by the view right after the
+   *  submit; {@link blockStartLine} prefers it over the index-based
+   *  `startRow`, which drifts when the scrollback trims). */
+  marker?: TerminalBlockMarker
 }
 
 /**
  * Segments the terminal's input stream into blocks. Feed every onData chunk
  * (with the buffer length at that moment) — submits, pending text and the
- * block list all derive from it.
+ * block list all derive from it. The optional `onSubmit` callback fires
+ * right after a block is created — the view uses it to attach the xterm
+ * marker anchoring the echo row — keeping the framework xterm-free.
  */
 export class TerminalBlockTracker {
   private _mode: 0 | 1 | 2 | 3 = 0
@@ -64,6 +82,11 @@ export class TerminalBlockTracker {
   private _blocks: TerminalBlock[] = []
   private _current: TerminalBlock | null = null
   private _nextId = 1
+  private readonly _onSubmit: ((block: TerminalBlock) => void) | undefined
+
+  constructor(onSubmit?: (block: TerminalBlock) => void) {
+    this._onSubmit = onSubmit
+  }
 
   /** All tracked blocks, oldest first (capped at {@link BLOCK_KEEP}). */
   get blocks(): readonly TerminalBlock[] {
@@ -131,31 +154,84 @@ export class TerminalBlockTracker {
     }
     this._blocks.push(block)
     if (this._blocks.length > BLOCK_KEEP) {
-      this._blocks.splice(0, this._blocks.length - BLOCK_KEEP)
+      const dropped = this._blocks.splice(0, this._blocks.length - BLOCK_KEEP)
+      for (const old of dropped) {
+        if (old.marker !== undefined && !old.marker.isDisposed) old.marker.dispose()
+      }
     }
     this._current = block
+    this._onSubmit?.(block)
   }
 }
 
 /**
- * The plain-text rows of a block's output: `[startRow+1, end)` where the
- * echo row (prompt + command) is skipped — the payload's fence header
- * carries the command instead. Wrapped rows re-join without a newline,
- * trailing blank rows (prompt stamps, empty lines) are stripped, and a
- * trailing row that still ends with the *pending* next command (the shell
- * echoes while the user types) is peeled off so a half-typed command never
- * leaks into the payload. Best-effort by design: reply races (a pasted
- * Enter landing before its echo) and prompt redraws shift the anchor a
- * little, never worse than a misplaced boundary line.
+ * The live buffer row a block's echo row currently sits on: the marker's
+ * line when one was attached (markers slide with scrollback trims and
+ * reflows), the index-based `startRow` when no marker exists (never
+ * attached). A DISPOSED marker means the echo row was trimmed out of the
+ * buffer entirely — the block's rows are gone, so it resolves to
+ * +Infinity, which every consumer treats as "not present".
+ */
+export function blockStartLine(block: TerminalBlock): number {
+  if (block.marker === undefined) return block.startRow
+  return block.marker.isDisposed ? Number.POSITIVE_INFINITY : block.marker.line
+}
+
+/**
+ * The buffer row where a block's span ENDS (exclusive): the next block's
+ * start line, or Infinity for the newest block (its span runs to the live
+ * buffer end).
+ */
+export function blockEndLine(
+  blocks: readonly TerminalBlock[],
+  block: TerminalBlock,
+): number {
+  const index = blocks.indexOf(block)
+  if (index === -1 || index >= blocks.length - 1) return Infinity
+  return blockStartLine(blocks[index + 1]!)
+}
+
+/**
+ * The clipped visible span of a block: `{ start, end }` with end exclusive,
+ * both clamped into `[0, bufferLength]` (rows trimmed away or an alt-buffer
+ * swap shrink the buffer; the span then degrades gracefully to what remains).
+ */
+export function blockSpanLines(
+  blocks: readonly TerminalBlock[],
+  block: TerminalBlock,
+  bufferLength: number,
+): { start: number; end: number } {
+  const endLine = blockEndLine(blocks, block)
+  const end = Math.min(Number.isFinite(endLine) ? endLine : bufferLength, bufferLength)
+  return {
+    start: Math.min(Math.max(blockStartLine(block), 0), bufferLength),
+    end,
+  }
+}
+
+/**
+ * The plain-text rows of a block's output: `[start+1, end)` where the echo
+ * row (prompt + command) is skipped — the payload's fence header carries the
+ * command instead, and the span itself resolves through the block's live
+ * marker when available. Wrapped rows re-join without a newline, trailing
+ * blank rows (prompt stamps, empty lines) are stripped, and a trailing row
+ * that still ends with the *pending* next command (the shell echoes while
+ * the user types) is peeled off so a half-typed command never leaks into
+ * the payload. Best-effort by design: reply races (a pasted Enter landing
+ * before its echo) and prompt redraws shift the anchor a little, never
+ * worse than a misplaced boundary line. `endRow` overrides the closed-span
+ * boundary (callers resolve it marker-aware via {@link blockSpanLines});
+ * the open block always runs to the live buffer end.
  */
 export function blockOutputText(
   buffer: TerminalBlockBuffer,
   block: TerminalBlock,
   pending = '',
+  endRow?: number,
 ): string {
   const length = buffer.length
-  const from = Math.min(Math.max(block.startRow + 1, 0), length)
-  const end = Math.min(block.endRow ?? length, length)
+  const from = Math.min(Math.max(blockStartLine(block) + 1, 0), length)
+  const end = Math.min(endRow ?? block.endRow ?? length, length)
   if (end <= from) return ''
   let text = ''
   let first = true
@@ -182,8 +258,10 @@ export function blockOutputText(
 
 /**
  * The block containing a buffer row (1-based xterm coordinates become
- * 0-based here), newest first: returns null when the row predates all
- * tracked blocks — the header then falls back to a bare fence.
+ * 0-based here), newest first — spans resolve through the blocks' live
+ * markers, so the attribution stays correct after scrollback trims. Returns
+ * null when the row predates all tracked blocks — the header then falls
+ * back to a bare fence.
  */
 export function blockForSelection(
   blocks: readonly TerminalBlock[],
@@ -193,8 +271,16 @@ export function blockForSelection(
   for (let i = blocks.length - 1; i >= 0; i--) {
     const block = blocks[i]
     if (block === undefined) continue
-    if (block.startRow > bufferRow) continue
-    if (block.endRow === null || bufferRow < block.endRow) return block
+    if (blockStartLine(block) > bufferRow) continue
+    if (i < blocks.length - 1) {
+      if (bufferRow >= blockStartLine(blocks[i + 1]!)) continue
+    } else if (block.endRow !== null && bufferRow >= block.endRow) {
+      // Defensive: the tracker only closes a block when a NEXT one exists,
+      // but a synthetic last-and-finished block must not own rows past its
+      // closed span either.
+      continue
+    }
+    return block
   }
   return null
 }

--- a/tests/terminal-block-overlay.spec.tsx
+++ b/tests/terminal-block-overlay.spec.tsx
@@ -1,0 +1,211 @@
+/**
+ * TerminalBlockOverlay tests: the visual block layer must draw one divider
+ * per CLI block, highlight the hovered block's span, raise the per-block
+ * "add to conversation" pill at the hovered row, and commit the RIGHT block
+ * through onAddBlock. Geometry is injected by mocking getBoundingClientRect
+ * on the host/screen elements; rAF is queued and flushed deterministically.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createElement, createRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { TerminalBlockTracker, type TerminalBlockMarker } from '../src/client/terminal-blocks.ts'
+import { TerminalBlockOverlay } from '../src/client/TerminalBlockOverlay.tsx'
+import css from '../src/client/sidebar.module.css'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+/** The viewport: rows 10..29 of a 30-row buffer, cell height 18px. */
+const ROWS = 20
+const VIEWPORT_Y = 10
+const BUFFER_LENGTH = 30
+const CELL_HEIGHT = 18
+const SCREEN_LEFT = 8
+const SCREEN_TOP = 6
+const HOST_WIDTH = 600
+const HOST_HEIGHT = 400
+
+const frames: FrameRequestCallback[] = []
+function installStubs(): void {
+  frames.length = 0
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frames.push(callback)
+    return frames.length
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  vi.stubGlobal('ResizeObserver', class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  })
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.unstubAllGlobals()
+})
+
+/** A real-ish screen plus a rectangle mock on host + screen. */
+async function mountOverlay(
+  tracker: TerminalBlockTracker,
+  onAddBlock = vi.fn(),
+): Promise<{ host: HTMLElement; clickPill: () => void }> {
+  const hostRef = createRef<HTMLDivElement>()
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  const term = {
+    rows: ROWS,
+    onScroll: () => ({ dispose: vi.fn() }),
+    onWriteParsed: () => ({ dispose: vi.fn() }),
+    onResize: () => ({ dispose: vi.fn() }),
+    hasSelection: () => false,
+    buffer: {
+      active: {
+        type: 'normal' as const,
+        viewportY: VIEWPORT_Y,
+        length: BUFFER_LENGTH,
+        getLine: () => undefined,
+      },
+    },
+  }
+  await act(async () => {
+    root.render(createElement('div', { ref: hostRef as never }, createElement(TerminalBlockOverlay, {
+      hostRef: hostRef as never,
+      term: term as never,
+      tracker,
+      visible: true,
+      onAddBlock,
+    } as never)))
+  })
+  const host = hostRef.current!
+  // The terminal's DOM the renderer would have produced.
+  const screen = document.createElement('div')
+  screen.className = 'xterm-screen'
+  host.append(screen)
+  const rectOf = (left: number, top: number, width: number, height: number): DOMRect =>
+    ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top, toJSON: () => ({}) }) as DOMRect
+  vi.spyOn(host, 'getBoundingClientRect').mockReturnValue(rectOf(0, 0, HOST_WIDTH, HOST_HEIGHT))
+  vi.spyOn(screen, 'getBoundingClientRect').mockReturnValue(rectOf(SCREEN_LEFT, SCREEN_TOP, HOST_WIDTH - SCREEN_LEFT, ROWS * CELL_HEIGHT))
+  return {
+    host,
+    clickPill: () => {
+      host.querySelector<HTMLElement>(`.${css.terminalBlockPill}`)?.click()
+    },
+  }
+}
+
+async function flushFrames(): Promise<void> {
+  await act(async () => {
+    while (frames.length > 0) {
+      const callbacks = frames.splice(0)
+      for (const frame of callbacks) frame(0)
+    }
+  })
+}
+
+/** Dispatch a mousemove at the vertical center of a buffer row. */
+async function moveToRow(host: HTMLElement, row: number): Promise<void> {
+  await act(async () => {
+    host.dispatchEvent(new MouseEvent('mousemove', {
+      clientY: SCREEN_TOP + (row - VIEWPORT_Y) * CELL_HEIGHT + CELL_HEIGHT / 2,
+      bubbles: true,
+    }))
+  })
+}
+
+/** Two blocks: `ls` spans rows 12..18, `pwd` spans 18..30 (open tail). */
+function twoBlockTracker(): { tracker: TerminalBlockTracker; markers: TerminalBlockMarker[] } {
+  const markers: TerminalBlockMarker[] = []
+  const tracker = new TerminalBlockTracker((block) => {
+    const marker: TerminalBlockMarker = { line: block.startRow, isDisposed: false, dispose: vi.fn() }
+    markers.push(marker)
+    block.marker = marker
+  })
+  tracker.onData('ls\r', 13) // echo row 12
+  tracker.onData('pwd\r', 19) // echo row 18
+  return { tracker, markers }
+}
+
+describe('TerminalBlockOverlay', () => {
+  it('draws one divider per visible block', async () => {
+    installStubs()
+    const { tracker } = twoBlockTracker()
+    const { host } = await mountOverlay(tracker)
+    await flushFrames()
+    expect(host.querySelectorAll(`.${css.terminalBlockDivider}`)).toHaveLength(2)
+  })
+
+  it('highlights the hovered block and raises the pill; clicking commits THAT block', async () => {
+    installStubs()
+    const { tracker } = twoBlockTracker()
+    const onAddBlock = vi.fn()
+    const { host, clickPill } = await mountOverlay(tracker, onAddBlock)
+    await flushFrames()
+
+    // Row 15 belongs to the FIRST block (`ls` 12..18).
+    await moveToRow(host, 15)
+    await flushFrames()
+    expect(host.querySelector(`.${css.terminalBlockHover}`)).not.toBeNull()
+    expect(host.querySelector(`.${css.terminalBlockPill}`)).not.toBeNull()
+    clickPill()
+    expect(onAddBlock).toHaveBeenCalledTimes(1)
+    expect(onAddBlock.mock.calls[0]![0].command).toBe('ls')
+
+    // A row above both blocks (11 — the pre-block prompt region) shows
+    // neither highlight nor pill.
+    await moveToRow(host, 11)
+    await flushFrames()
+    expect(host.querySelector(`.${css.terminalBlockHover}`)).toBeNull()
+    expect(host.querySelector(`.${css.terminalBlockPill}`)).toBeNull()
+
+    // The second block's row commits the second block.
+    await moveToRow(host, 20)
+    await flushFrames()
+    clickPill()
+    expect(onAddBlock).toHaveBeenCalledTimes(2)
+    expect(onAddBlock.mock.calls[1]![0].command).toBe('pwd')
+  })
+
+  it('mouseleave clears the hover state', async () => {
+    installStubs()
+    const { tracker } = twoBlockTracker()
+    const { host } = await mountOverlay(tracker)
+    await flushFrames()
+    await moveToRow(host, 15)
+    await flushFrames()
+    expect(host.querySelector(`.${css.terminalBlockPill}`)).not.toBeNull()
+    host.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }))
+    await flushFrames()
+    expect(host.querySelector(`.${css.terminalBlockPill}`)).toBeNull()
+  })
+
+  it('renders nothing without a mounted host or while !visible', async () => {
+    installStubs()
+    const { tracker } = twoBlockTracker()
+    const hostRef = createRef<HTMLDivElement>()
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    const term = {
+      rows: ROWS,
+      onScroll: () => ({ dispose: vi.fn() }),
+      onWriteParsed: () => ({ dispose: vi.fn() }),
+      onResize: () => ({ dispose: vi.fn() }),
+      hasSelection: () => false,
+      buffer: { active: { type: 'normal' as const, viewportY: VIEWPORT_Y, length: BUFFER_LENGTH, getLine: () => undefined } },
+    }
+    await act(async () => {
+      root.render(createElement('div', { ref: hostRef as never }, createElement(TerminalBlockOverlay, {
+        hostRef: hostRef as never,
+        term: term as never,
+        tracker,
+        visible: false,
+        onAddBlock: vi.fn(),
+      } as never)))
+    })
+    expect(hostRef.current!.querySelector(`.${css.terminalBlockLayer}`)).toBeNull()
+    await act(async () => { root.unmount() })
+  })
+})

--- a/tests/terminal-blocks.spec.ts
+++ b/tests/terminal-blocks.spec.ts
@@ -3,16 +3,20 @@
  * extraction, selection attribution, insert payloads) — no xterm, the
  * buffer is a fake over the minimal structural contract.
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   BLOCK_KEEP,
   TERMINAL_INSERT_LIMIT,
   TerminalBlockTracker,
+  blockEndLine,
   blockForSelection,
   blockOutputText,
+  blockSpanLines,
+  blockStartLine,
   buildTerminalInsert,
   type TerminalBlock,
   type TerminalBlockBuffer,
+  type TerminalBlockMarker,
 } from '../src/client/terminal-blocks.ts'
 
 /** A fake buffer row honoring the structural contract (trim + wrap flags). */
@@ -234,5 +238,82 @@ describe('buildTerminalInsert', () => {
     expect(insert).not.toContain('y')
     expect(insert).toContain('\n…\n')
     expect(insert.endsWith('```')).toBe(true)
+  })
+})
+describe('markers (blockStartLine / blockEndLine / blockSpanLines)', () => {
+  function marker(line: number, disposed = false): TerminalBlockMarker {
+    return { line, isDisposed: disposed, dispose: vi.fn() }
+  }
+
+  it('prefers the live marker line over the index', () => {
+    const b = block({ startRow: 0, marker: marker(27) })
+    expect(blockStartLine(b)).toBe(27)
+    // Trimmed out (marker disposed): the rows are gone — resolves to
+    // +Infinity so every consumer treats the block as absent.
+    const trimmed = block({ startRow: 0, marker: marker(0, true) })
+    expect(blockStartLine(trimmed)).toBe(Number.POSITIVE_INFINITY)
+    // Never attached: index fallback.
+    expect(blockStartLine(block({ startRow: 9 }))).toBe(9)
+  })
+
+  it('blockEndLine is the next block’s start line, Infinity for the newest', () => {
+    const a = block({ startRow: 0, marker: marker(4) })
+    const b = block({ startRow: 10, marker: marker(16) })
+    const c = block({ startRow: 20 })
+    expect(blockEndLine([a, b, c], a)).toBe(16)
+    expect(blockEndLine([a, b, c], c)).toBe(Number.POSITIVE_INFINITY)
+    expect(blockEndLine([a], b)).toBe(Number.POSITIVE_INFINITY) // unknown block
+  })
+
+  it('blockSpanLines clamps into the live buffer and handles trims', () => {
+    const a = block({ startRow: 0, marker: marker(4) })
+    const b = block({ startRow: 10, marker: marker(16) })
+    expect(blockSpanLines([a, b], a, 50)).toEqual({ start: 4, end: 16 })
+    expect(blockSpanLines([a, b], b, 50)).toEqual({ start: 16, end: 50 })
+    // Buffer shrank (trim overflowed): degraded to what remains.
+    expect(blockSpanLines([a, b], a, 10)).toEqual({ start: 4, end: 10 })
+    // Block fully trimmed out: empty span (start === end).
+    const gone = block({ startRow: 0, marker: marker(0, true) })
+    expect(blockSpanLines([gone], gone, 10)).toEqual({ start: 10, end: 10 })
+  })
+
+  it('blockForSelection resolves spans through markers (trim drift)', () => {
+    const a = block({ startRow: 0, marker: marker(30), endRow: 40, finished: true })
+    const b = block({ startRow: 40, marker: marker(45) })
+    // Row indices drifted (scrollback trimmed), markers still accurate.
+    expect(blockForSelection([a, b], 30)!.id).toBe(a.id)
+    expect(blockForSelection([a, b], 44)!.id).toBe(b.id)
+    expect(blockForSelection([a, b], 45)!.id).toBe(b.id)
+    // A trimmed block is never attributed (its rows are gone).
+    const gone = block({ startRow: 0, marker: marker(0, true) })
+    expect(blockForSelection([gone], 0)).toBeNull()
+    expect(blockForSelection([gone], 5)).toBeNull()
+  })
+
+  it('blockOutputText honors marker-resolved boundaries and endRow', () => {
+    const buf = buffer(['@ ~ old rows', '@ ~ npm test', '✓ 3 passed', '@ ~ git status'])
+    const moved = block({ startRow: 0, marker: marker(1), endRow: 3, finished: true })
+    // The echo row is now line 1 (marker), output starts at 2.
+    expect(blockOutputText(buf, moved)).toBe('✓ 3 passed')
+    // endRow override (marker-resolved closed span).
+    expect(blockOutputText(buf, block({ startRow: 1, endRow: 3 }), '', 3)).toBe('✓ 3 passed')
+  })
+
+  it('the tracker fires onSubmit per block and disposes dropped markers on cap', () => {
+    const submitted: TerminalBlock[] = []
+    const disposes: ReturnType<typeof vi.fn>[] = []
+    const tracker = new TerminalBlockTracker((b) => {
+      const dispose = vi.fn()
+      disposes.push(dispose)
+      b.marker = { line: b.startRow, isDisposed: false, dispose }
+      submitted.push(b)
+    })
+    for (let i = 0; i < BLOCK_KEEP + 3; i++) tracker.onData(`c${i}\r`, i + 1)
+    expect(submitted).toHaveLength(BLOCK_KEEP + 3)
+    expect(submitted.at(-1)!.marker).toBeDefined()
+    // Dropped blocks' markers were disposed (only the survivors stay).
+    expect(disposes).toHaveLength(BLOCK_KEEP + 3)
+    disposes.slice(0, 3).forEach(dispose => expect(dispose).toHaveBeenCalledTimes(1))
+    disposes.slice(3).forEach(dispose => expect(dispose).not.toHaveBeenCalled())
   })
 })

--- a/tests/terminal-blocks.spec.ts
+++ b/tests/terminal-blocks.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * Pure logic tests for the terminal block framework (tracker, row
+ * extraction, selection attribution, insert payloads) — no xterm, the
+ * buffer is a fake over the minimal structural contract.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  BLOCK_KEEP,
+  TERMINAL_INSERT_LIMIT,
+  TerminalBlockTracker,
+  blockForSelection,
+  blockOutputText,
+  buildTerminalInsert,
+  type TerminalBlock,
+  type TerminalBlockBuffer,
+} from '../src/client/terminal-blocks.ts'
+
+/** A fake buffer row honoring the structural contract (trim + wrap flags). */
+function line(text: string, wrapped = false): { isWrapped: boolean; translateToString: () => string } {
+  return {
+    isWrapped: wrapped,
+    translateToString: (trimRight?: boolean) => (trimRight ? text.trimEnd() : text),
+  }
+}
+
+/** A fake buffer: rows array → BlockBuffer (getLine clamps like xterm). */
+function buffer(rows: string[], wraps: boolean[] = []): TerminalBlockBuffer {
+  const lines = rows.map((text, i) => line(text, wraps[i] ?? false))
+  return {
+    get length() {
+      return lines.length
+    },
+    getLine: (y: number) => (y >= 0 && y < lines.length ? lines[y] : undefined),
+  }
+}
+
+function block(partial: Partial<TerminalBlock> = {}): TerminalBlock {
+  return {
+    id: 1,
+    command: 'cmd',
+    startRow: 0,
+    endRow: null,
+    finished: false,
+    ...partial,
+  }
+}
+
+describe('TerminalBlockTracker', () => {
+  it('accumulates pending text and swallows control sequences', () => {
+    const tracker = new TerminalBlockTracker()
+    // Arrow keys (CSI), home, bracketed-paste markers — all stripped.
+    tracker.onData('npm \x1b[A\x1b[B\x1b[H\x1b[200~install\x1b[201~', 0)
+    expect(tracker.pending).toBe('npm install')
+    // OSC title write swallowed (BEL-terminated).
+    tracker.onData('\x1b]0;my title\x07', 0)
+    expect(tracker.pending).toBe('npm install')
+    // ST-terminated OSC (ESC \) and an unknown ESC sequence.
+    tracker.onData('\x1b]2;other\x1b\\', 0)
+    tracker.onData('\x1b7', 0)
+    expect(tracker.pending).toBe('npm install')
+  })
+
+  it('applies backspace/DEL and drops other C0 controls', () => {
+    const tracker = new TerminalBlockTracker()
+    tracker.onData('abc\x7f', 0)
+    expect(tracker.pending).toBe('ab')
+    tracker.onData('\x08', 0)
+    expect(tracker.pending).toBe('a')
+    tracker.onData('\t\x07', 0) // tab + bell
+    expect(tracker.pending).toBe('a')
+  })
+
+  it('keeps escape-mode state across chunks (split sequences)', () => {
+    const tracker = new TerminalBlockTracker()
+    tracker.onData('x\x1b[', 0)
+    tracker.onData('Ay', 0)
+    expect(tracker.pending).toBe('xy')
+    tracker.onData('\x1b', 0)
+    tracker.onData(']', 0)
+    tracker.onData('title', 0)
+    tracker.onData('\x07', 0)
+    expect(tracker.pending).toBe('xy')
+  })
+
+  it('submits on Enter: creates a block anchored at the echo row', () => {
+    const tracker = new TerminalBlockTracker()
+    expect(tracker.current).toBeNull()
+    tracker.onData('npm test\r', 10)
+    expect(tracker.current).not.toBeNull()
+    expect(tracker.current!.command).toBe('npm test')
+    expect(tracker.current!.startRow).toBe(9)
+    expect(tracker.current!.finished).toBe(false)
+    expect(tracker.current!.endRow).toBeNull()
+    expect(tracker.blocks).toHaveLength(1)
+    expect(tracker.pending).toBe('')
+  })
+
+  it('closes the previous block when the next command submits', () => {
+    const tracker = new TerminalBlockTracker()
+    tracker.onData('npm test\r', 10)
+    tracker.onData('git status\r', 15)
+    expect(tracker.blocks).toHaveLength(2)
+    const [first, second] = tracker.blocks
+    expect(first!.command).toBe('npm test')
+    expect(first!.finished).toBe(true)
+    expect(first!.endRow).toBe(14)
+    expect(second!.command).toBe('git status')
+    expect(second!.finished).toBe(false)
+    expect(second!.endRow).toBeNull()
+    expect(second!.startRow).toBe(14)
+  })
+
+  it('ignores bare Enters (no empty blocks, previous block stays open)', () => {
+    const tracker = new TerminalBlockTracker()
+    tracker.onData('npm test\r', 10)
+    tracker.onData('\r', 12)
+    tracker.onData('\n', 13)
+    expect(tracker.blocks).toHaveLength(1)
+    expect(tracker.current!.finished).toBe(false)
+    expect(tracker.current!.command).toBe('npm test')
+  })
+
+  it('splits multi-line pastes into one block per line', () => {
+    const tracker = new TerminalBlockTracker()
+    tracker.onData('echo a\recho b\r', 5)
+    expect(tracker.blocks.map(b => b.command)).toEqual(['echo a', 'echo b'])
+    expect(tracker.blocks[0]!.finished).toBe(true)
+    expect(tracker.blocks[1]!.finished).toBe(false)
+  })
+
+  it('trims command whitespace and caps the block list', () => {
+    const tracker = new TerminalBlockTracker()
+    for (let i = 0; i < BLOCK_KEEP + 5; i++) {
+      tracker.onData(`cmd ${i}\r`, i + 1)
+    }
+    expect(tracker.blocks).toHaveLength(BLOCK_KEEP)
+    expect(tracker.blocks[0]!.command).toBe('cmd 5')
+    expect(tracker.blocks[BLOCK_KEEP - 1]!.command).toBe(`cmd ${BLOCK_KEEP + 4}`)
+  })
+})
+
+describe('blockOutputText', () => {
+  it('returns the rows after the echo row (echo excluded)', () => {
+    const buf = buffer(['~ % npm test', '✓ 3 passed', '✨ done'])
+    const text = blockOutputText(buf, block({ startRow: 0, command: 'npm test' }))
+    expect(text).toBe('✓ 3 passed\n✨ done')
+  })
+
+  it('respects a closed span (finished block)', () => {
+    const buf = buffer(['~ % npm test', '✓ 3 passed', '~ % git status', 'clean'])
+    const text = blockOutputText(buf, block({ startRow: 0, endRow: 2, finished: true }))
+    expect(text).toBe('✓ 3 passed')
+  })
+
+  it('re-joins wrapped rows without a newline', () => {
+    const buf = buffer(['first half of a long line', 'second half', 'next row'], [false, true, false])
+    const text = blockOutputText(buf, block({ startRow: -10 }))
+    expect(text).toBe('first half of a long linesecond half\nnext row')
+  })
+
+  it('strips trailing blank rows and trims the tail', () => {
+    const buf = buffer(['out1', '', '   ', ''])
+    const text = blockOutputText(buf, block({ startRow: -10 }))
+    expect(text).toBe('out1')
+  })
+
+  it('peels a trailing row that ends with the pending next command', () => {
+    const buf = buffer(['~ % npm test', '✓ 3 passed', '~ % git stat'], [false, false, false])
+    const text = blockOutputText(buf, block({ startRow: 0 }), 'git stat')
+    expect(text).toBe('✓ 3 passed')
+  })
+
+  it('keeps the pending row when it does not match (wrapped/mismatched)', () => {
+    const buf = buffer(['~ % npm test', '✓ 3 passed', '~ % git status --long'])
+    const text = blockOutputText(buf, block({ startRow: 0 }), 'git status')
+    // Best-effort: no match → the row stays (documented behavior).
+    expect(text).toBe('✓ 3 passed\n~ % git status --long')
+  })
+
+  it('returns empty for no output, out-of-range anchors, and a pending-only tail', () => {
+    expect(blockOutputText(buffer(['~ % npm test']), block({ startRow: 0 }))).toBe('')
+    expect(blockOutputText(buffer(['a', 'b']), block({ startRow: 100 }))).toBe('')
+    // Only the pending echo row → everything is peeled.
+    const buf2 = buffer(['~ % git stat'])
+    expect(blockOutputText(buf2, block({ startRow: -10 }), 'git stat')).toBe('')
+  })
+})
+
+describe('blockForSelection', () => {
+  const blocks: TerminalBlock[] = [
+    block({ id: 1, startRow: 0, endRow: 5, finished: true }),
+    block({ id: 2, startRow: 5, endRow: 9, finished: true }),
+    block({ id: 3, startRow: 9, endRow: null, finished: false }),
+  ]
+
+  it('attributes a row to its newest block and handles open spans', () => {
+    expect(blockForSelection(blocks, 3)!.id).toBe(1)
+    expect(blockForSelection(blocks, 5)!.id).toBe(2) // boundary: next block owns it
+    expect(blockForSelection(blocks, 8)!.id).toBe(2)
+    expect(blockForSelection(blocks, 9)!.id).toBe(3)
+    expect(blockForSelection(blocks, 42)!.id).toBe(3) // open span extends
+  })
+
+  it('returns null for negative rows and rows above all blocks', () => {
+    expect(blockForSelection(blocks, -1)).toBeNull()
+    expect(blockForSelection(blocks, 0)).not.toBeNull()
+    expect(blockForSelection([], 5)).toBeNull()
+    expect(blockForSelection([block({ startRow: 0, endRow: 2 })], 3)).toBeNull()
+  })
+})
+
+describe('buildTerminalInsert', () => {
+  it('builds a fenced payload with the command as the info line', () => {
+    expect(buildTerminalInsert('npm test', '✓ 3 passed')).toBe(
+      '```$ npm test\n✓ 3 passed\n```',
+    )
+  })
+
+  it('falls back to a bare fence when the command is unknown', () => {
+    expect(buildTerminalInsert(undefined, 'hello')).toBe('```\nhello\n```')
+    expect(buildTerminalInsert('  ', 'hello')).toBe('```\nhello\n```')
+  })
+
+  it('truncates the body over the limit with the ellipsis marker', () => {
+    const insert = buildTerminalInsert('c', 'abcdefghij', { limit: 5 })
+    expect(insert).toBe('```$ c\nabcde\n…\n```')
+    expect(buildTerminalInsert('c', '', { limit: 5 })).toBe('```$ c\n\n```')
+  })
+
+  it('respects TERMINAL_INSERT_LIMIT by default', () => {
+    const body = 'x'.repeat(TERMINAL_INSERT_LIMIT)
+    const insert = buildTerminalInsert('c', body + 'y')
+    expect(insert).toContain('```$ c\n')
+    expect(insert).not.toContain('y')
+    expect(insert).toContain('\n…\n')
+    expect(insert.endsWith('```')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem
终端是一条连续滚动流，无法把「某条命令 + 它的输出」作为一个整体引用。文本/代码 viewer 已有「添加到对话框」能力（TextEditor 选区浮钮 → `appendToDraft`），终端完全缺失同款能力；xterm 自身也没有任何块级语义（无命令边界、无聚合提取、无稳定锚点）。

## Fix
- **`src/client/terminal-blocks.ts`**（纯逻辑，随终端懒加载 chunk 分发，不进核心 bundle）：
  - `TerminalBlockTracker`：以输入流为界切分 block——onData 逐字符状态机清洗（CSI/OSC/粘贴标记/退格，裸回车不产生空块），Enter 提交命令并锚定 shell echo 行；`onSubmit` 回调供视图钉锚点。
  - **marker 化锚点**：视图在每次提交后 `term.registerMarker(0)`（cursor 行 = echo 行）钉住每个 block 的边界——marker 随 scrollback trim / reflow 平移、滚出 buffer 自动 dispose；`blockStartLine / blockEndLine / blockSpanLines` 统一走 marker 解析，disposed marker 解析为 +Infinity（行已消失 = block 整体不可见）。
  - `blockOutputText`：纯文本提取（跳过 echo 行、折行还原、剥尾部空行与半条 pending 命令），marker 解析边界。
  - `buildTerminalInsert` / `blockForSelection`：fence payload（info 行 `$ <command>`、4000 字符截断 + `\n…`）与选区 → block 归属。
- **`src/client/TerminalBlockOverlay.tsx`**：视觉 block 层——每次 CLI 执行以 echo 行为界画 hairline 分隔线；悬停某 block → 行区间淡色高亮 + 悬停行右侧浮出「添加到对话」药丸（有文本选区时让位给选区 popup）；几何 = `.xterm-screen` rect + `(row - viewportY) × cellH`（不依赖渲染器内部行元素），rAF 合并 tick（scroll / write-parsed / resize + ResizeObserver）自驱重绘，alt buffer 时整层让位；点击经 `appendToDraft` 整块插入对话草稿，复用既有 `addToConversation` i18n key（19 语言零新增）。
- **`src/client/TerminalView.tsx` / `builtins/tabs.tsx` / `sidebar.module.css`**：会话 state 驱动 overlay 挂载；提交时 marker 解析边界；替换掉旧的右上角常驻药丸；`.terminal` 增加定位上下文 + 层/分隔线/高亮/药丸样式（全 token 驱动）。

## Regression guard
- `tests/terminal-blocks.spec.ts`（27 例）：清洗状态机、提交/闭合/裸回车/多行粘贴/上限裁剪 + **marker 解析**（trim 漂移归属、disposed → +Infinity 不可见、cap 时 dispose 被丢弃 block 的 marker）、提取、归属、payload 形状。
- `tests/terminal-block-overlay.spec.tsx`（4 例，jsdom + mock rect + 队列化 rAF）：每 block 一条分隔线、hover 高亮 + 药丸点击提交**正确的** block、mouseleave 清除、`!visible` 零渲染。
- 旧代码下必红的断言：marker 漂移后的选区归属（`blockForSelection` 按 `marker.line` 而非起始索引）、disposed marker 不可见（`blockStartLine` 返回 +Infinity）、分割线数量。

## Verification
- `pnpm typecheck` ✅ / `pnpm build` ✅（`lib/client-terminal.js` 545KB，含新代码）/ `check:consumer-types` ✅
- 全量单测 **1054 passed / 9 skipped**（较基线 +10）；仅 `agent-pty`/`smoke` 26 例 `posix_spawnp failed`——沙箱禁止 node-pty 拉起真实 shell，`git stash` 后在干净基线上同样复现（与本次改动无关）
- 挂载冒烟（CI `plugin-mount` job）覆盖终端懒加载 chunk 路径；本机沙箱无法起真实 `dsh web`，未本地跑

## 关联
- 设计文档：`docs/plans/2026-08-27-terminal-blocks-design.md`（决策记录、marker 锚点、hover overlay 设计）
- 分支：`feat/terminal-blocks`（`920549f` + `d976952` 两笔提交）
