### PR TITLE
fix: preserve reverse-proxy base paths

### DIFF
--- a/src/client/MarkdownHtml.tsx
+++ b/src/client/MarkdownHtml.tsx
@@ -40,7 +40,7 @@ export const LazyMermaidMarkdown = lazyChunkComponent<MermaidMarkdownProps>(
 export interface MarkdownHtmlMedia {
   scope: SessionScope
   path: string
-  origin: string
+  baseUrl: string
 }
 
 /** Tag-like text in a rendered text node — the inline pass gate. */
@@ -67,7 +67,7 @@ function postProcessSanitized(root: Element, media: MarkdownHtmlMedia): void {
   for (const element of root.querySelectorAll('img, video, audio, source')) {
     const src = element.getAttribute('src')
     if (src === null) continue
-    element.setAttribute('src', resolveLocalMediaDest(src, media.scope, media.path, media.origin))
+    element.setAttribute('src', resolveLocalMediaDest(src, media.scope, media.path, media.baseUrl))
   }
 }
 

--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -50,6 +50,7 @@ import { layoutPushSize } from './layout-push.ts'
 import { parseDesktopEnv } from './desktop-env.ts'
 import { getWcoSnapshot, subscribeWco } from './wco.ts'
 import { getShellPreset } from './shell-presets.ts'
+import { hostWebSocketUrl } from './host-route-url.ts'
 import { computeTitleBarStrip } from './titlebar-strip.ts'
 import type { NewTabOption } from './TabBar.tsx'
 import { TAB_DRAG_TYPE, parseDrag, type TabDragPayload } from './TabBar.tsx'
@@ -428,8 +429,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     let failures = 0
     const connect = (): void => {
       if (closed) return
-      const url = new URL('/sidebar/ws/agent-terminals', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/agent-terminals')
       url.search = new URLSearchParams({ sessionId }).toString()
       socket = new WebSocket(url.toString())
       socket.onmessage = (event) => {
@@ -485,8 +485,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     let failures = 0
     const connect = (): void => {
       if (closed) return
-      const url = new URL('/sidebar/ws/agent-opens', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/agent-opens')
       url.search = new URLSearchParams({ sessionId }).toString()
       socket = new WebSocket(url.toString())
       socket.onmessage = (event) => {

--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -47,6 +47,7 @@ import {
   shouldActivateTerminalLink,
   openTerminalUrl,
 } from './terminal-links.ts'
+import { hostWebSocketUrl } from './host-route-url.ts'
 import css from './sidebar.module.css'
 
 /** How many consecutive unreasoned failures before showing the error banner. */
@@ -182,8 +183,7 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
     let failures = 0
 
     const wsUrl = (): string => {
-      const url = new URL('/sidebar/ws/terminal', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/terminal')
       // Agent terminals attach by uuid (the host looks them up in the agent
       // pty registry); UI-tab terminals attach by sessionId+tab (the host
       // uses the UI-tab pty manager). Same upgrade endpoint, different query.
@@ -194,9 +194,7 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
         if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
         url.search = params.toString()
       }
-      // Same construction the app's own downlink WebSockets use (new URL
-      // over location.origin + protocol swap): whatever the environment
-      // does to the app's websockets applies identically here.
+      // The injected document base keeps the socket under the same reverse-proxy prefix as the page.
       return url.toString()
     }
 

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -277,7 +277,7 @@ export function TextEditor(props: FileViewerProps) {
    *  `media` identity, so a fresh object per render would re-sanitize every
    *  keystroke. */
   const htmlMedia = useMemo<MarkdownHtmlMedia>(
-    () => ({ scope, path, origin: window.location.origin }),
+    () => ({ scope, path, baseUrl: document.baseURI }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [scope.sessionId, scope.cwd, path],
   )

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -250,7 +250,7 @@ export function TextEditor(props: FileViewerProps) {
    *  `mdText` stays untouched for selection/line lookup and for mermaid-block
    *  detection, which are unaffected by image syntax. */
   const previewText = markdown
-    ? rewriteLocalImageUrls(mdText, scope, path, window.location.origin)
+    ? rewriteLocalImageUrls(mdText, scope, path, document.baseURI)
     : mdText
   /** md/mermaid block split for the preview (mermaid fences lift out). Split
    *  only in preview mode: edit-mode keystrokes must not re-scan the source. */

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -7,6 +7,7 @@
  * request). Failures surface as {@link SidebarApiError} with the wire code.
  */
 import { encodeHtmlUrl } from '../html-route.ts'
+import { hostRouteUrl } from './host-route-url.ts'
 import type { LastActivity } from '../subagent-activity.ts'
 import type { SidechatThreadInfo } from '../sidechat-core.ts'
 import type { BrowserProbeResult } from './browser.ts'
@@ -115,7 +116,7 @@ export type TerminalDepsStatus =
 async function call<T>(method: string, payload: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
   let response: Response
   try {
-    response = await fetch(`/sidebar/api/${method}`, {
+    response = await fetch(hostRouteUrl(`sidebar/api/${method}`), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),
@@ -153,7 +154,7 @@ async function fetchUpload<T>(
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
   let response: Response
   try {
-    response = await fetch(`/sidebar/upload?${params.toString()}`, {
+    response = await fetch(hostRouteUrl(`sidebar/upload?${params.toString()}`), {
       method: 'POST',
       headers: { 'content-type': 'application/octet-stream' },
       body,
@@ -341,7 +342,7 @@ function fileUrl(scope: SessionScope, path: string, download: boolean): string {
   const params = new URLSearchParams({ sessionId: scope.sessionId, path })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
   if (download) params.set('download', '1')
-  return `/sidebar/file?${params.toString()}`
+  return hostRouteUrl(`sidebar/file?${params.toString()}`).href
 }
 
 /**
@@ -353,5 +354,5 @@ function fileUrl(scope: SessionScope, path: string, download: boolean): string {
  * client-side platform signal is needed.
  */
 export function htmlUrl(scope: SessionScope, path: string): string {
-  return encodeHtmlUrl(scope.sessionId, path)
+  return hostRouteUrl(encodeHtmlUrl(scope.sessionId, path)).href
 }

--- a/src/client/chunk-loader.ts
+++ b/src/client/chunk-loader.ts
@@ -49,6 +49,8 @@
  * client.js); an edit that does land while a core HMR happens is caught by
  * the ETag comparison on the next activation.
  */
+import { hostRouteUrl } from './host-route-url.ts'
+
 export type ChunkName = 'terminal' | 'editor' | 'mermaid'
 
 /** The module exports a chunk factory provides (namespace-ish record). */
@@ -80,7 +82,7 @@ export const CHUNK_EXTERNALS: readonly string[] = [
 ]
 
 /** Chunk script endpoint served by the plugin host half (src/bundle-route.ts). */
-const CHUNK_URL = (name: ChunkName): string => `/sidebar/bundle/${name}.js`
+const CHUNK_URL = (name: ChunkName): string => hostRouteUrl(`sidebar/bundle/${name}.js`).href
 
 /** Bound on the revalidation HEAD round-trip. A timeout fails open (drop +
  *  re-fetch on the next open) so a stuck bundle route can never wedge lazy

--- a/src/client/host-route-url.ts
+++ b/src/client/host-route-url.ts
@@ -1,0 +1,19 @@
+/** Resolve one Host-owned client route against the injected document base.
+ * @param path - Root-style or relative Host route path.
+ * @param baseUrl - Browser document base or an explicit test base.
+ * @returns The absolute route URL.
+ */
+export function hostRouteUrl(path: string, baseUrl: string = document.baseURI): URL {
+  return new URL(path.replace(/^\/+/, ''), baseUrl)
+}
+
+/** Resolve one Host-owned WebSocket route against the injected document base.
+ * @param path - Root-style or relative Host WebSocket route path.
+ * @param baseUrl - Browser document base or an explicit test base.
+ * @returns The absolute ws: or wss: route URL.
+ */
+export function hostWebSocketUrl(path: string, baseUrl: string = document.baseURI): URL {
+  const url = hostRouteUrl(path, baseUrl)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url
+}

--- a/src/client/markdown-images.ts
+++ b/src/client/markdown-images.ts
@@ -62,14 +62,14 @@ function normalizeLocalPath(path: string): string {
  * @param text - The raw markdown source (inline + reference images).
  * @param scope - The session scope (sessionId + cwd) for the media route.
  * @param filePath - The absolute path of the opened `.md` file.
- * @param origin - The GUI's own origin (`window.location.origin`); injected
- * so the core rewrite stays pure and unit-testable.
+ * @param baseUrl - The injected document base URL; supplied explicitly so
+ * mounted reverse-proxy prefixes are preserved and the rewrite stays pure.
  * @returns The markdown with local image destinations rewritten in place.
  */
 /**
  * Resolve one media destination against the session's media route: local
- * (relative or absolute) paths become absolute `/sidebar/file` URLs (prefixed
- * with the GUI's own origin so the shared MarkdownText http(s) allowlist
+ * (relative or absolute) paths become absolute `/sidebar/file` URLs resolved
+ * against the injected document base so the shared MarkdownText http(s) allowlist
  * accepts them), while remote URLs, `#`-anchors and empty destinations are
  * returned untouched. Shared by the markdown image rewriter below and by the
  * preview's raw-HTML sanitizer (`markdown-html.tsx`, which meets the same
@@ -79,7 +79,7 @@ export function resolveLocalMediaDest(
   dest: string,
   scope: SessionScope,
   filePath: string,
-  origin: string,
+  baseUrl: string,
 ): string {
   const trimmed = dest.trim()
   if (trimmed === '' || trimmed.startsWith('#')) return dest
@@ -91,16 +91,16 @@ export function resolveLocalMediaDest(
   // absolute so the shared MarkdownText http(s) allowlist accepts it.
   const params = new URLSearchParams({ sessionId: scope.sessionId, path: normalizeLocalPath(candidate) })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
-  return hostRouteUrl(`sidebar/file?${params.toString()}`, origin).href
+  return hostRouteUrl(`sidebar/file?${params.toString()}`, baseUrl).href
 }
 
 export function rewriteLocalImageUrls(
   text: string,
   scope: SessionScope,
   filePath: string,
-  origin: string,
+  baseUrl: string,
 ): string {
-  const resolve = (dest: string): string => resolveLocalMediaDest(dest, scope, filePath, origin)
+  const resolve = (dest: string): string => resolveLocalMediaDest(dest, scope, filePath, baseUrl)
 
   // Mask fenced code blocks and inline code spans so image-looking text
   // inside documentation examples is never rewritten. The sentinel uses a

--- a/src/client/markdown-images.ts
+++ b/src/client/markdown-images.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SessionScope } from './api.ts'
+import { hostRouteUrl } from './host-route-url.ts'
 import { isAbsolutePath } from './paths.ts'
 
 /**
@@ -90,7 +91,7 @@ export function resolveLocalMediaDest(
   // absolute so the shared MarkdownText http(s) allowlist accepts it.
   const params = new URLSearchParams({ sessionId: scope.sessionId, path: normalizeLocalPath(candidate) })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
-  return `${origin}/sidebar/file?${params.toString()}`
+  return hostRouteUrl(`sidebar/file?${params.toString()}`, origin).href
 }
 
 export function rewriteLocalImageUrls(

--- a/tests/base-path.spec.ts
+++ b/tests/base-path.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { hostRouteUrl, hostWebSocketUrl } from '../src/client/host-route-url.ts'
+
+describe('Host route URLs', () => {
+  const baseUrl = 'https://example.test/dataops/dsh/'
+
+  it('retains the injected document base for every sidebar transport', () => {
+    expect(hostRouteUrl('/sidebar/api/fs.tree', baseUrl).href)
+      .toBe('https://example.test/dataops/dsh/sidebar/api/fs.tree')
+    expect(hostRouteUrl('/sidebar/file?sessionId=s', baseUrl).href)
+      .toBe('https://example.test/dataops/dsh/sidebar/file?sessionId=s')
+    expect(hostRouteUrl('/sidebar/bundle/editor.js', baseUrl).href)
+      .toBe('https://example.test/dataops/dsh/sidebar/bundle/editor.js')
+    expect(hostWebSocketUrl('/sidebar/ws/terminal', baseUrl).href)
+      .toBe('wss://example.test/dataops/dsh/sidebar/ws/terminal')
+  })
+})

--- a/tests/browser-globals.ts
+++ b/tests/browser-globals.ts
@@ -28,6 +28,7 @@ const elementStub = (): Record<string, unknown> => ({
 
 if (g.document === undefined) {
   g.document = {
+    baseURI: 'http://localhost/',
     createElement: () => elementStub(),
     createDocumentFragment: () => elementStub(),
     addEventListener: () => {},

--- a/tests/chunk-loader.spec.ts
+++ b/tests/chunk-loader.spec.ts
@@ -103,7 +103,7 @@ describe('production path (script injection + global registry + externals requir
       simulateScript('editor', (require) => ({ TextEditor: `view:${String(require('react'))}` }))
     })
     const exports = await loadChunk('editor')
-    expect(loaded).toEqual(['/sidebar/bundle/editor.js'])
+    expect(loaded).toEqual(['http://localhost/sidebar/bundle/editor.js'])
     expect(exports).toEqual({ TextEditor: 'view:[object Object]' })
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
     // The injection also lands on a plugin-owned global so chunk-bundle
@@ -128,7 +128,7 @@ describe('production path (script injection + global registry + externals requir
       simulateScript('editor', (require) => ({ TextEditor: `view:${String(require('react'))}` }))
     })
     const exports = await loadChunk('editor')
-    expect(loaded).toEqual(['/sidebar/bundle/editor.js'])
+    expect(loaded).toEqual(['http://localhost/sidebar/bundle/editor.js'])
     expect(exports).toEqual({ TextEditor: 'view:[object Object]' })
     // Externals resolved through the module system's seed branch, once.
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
@@ -147,7 +147,7 @@ describe('production path (script injection + global registry + externals requir
     })
     await loadChunk('terminal')
     await loadChunk('editor')
-    expect(seen).toEqual(['/sidebar/bundle/terminal.js', '/sidebar/bundle/editor.js'])
+    expect(seen).toEqual(['http://localhost/sidebar/bundle/terminal.js', 'http://localhost/sidebar/bundle/editor.js'])
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
   })
 
@@ -237,8 +237,10 @@ describe('revalidateChunksOnReactivate (HMR re-activation keeps unchanged chunks
     }))
   }
 
-  /** Let the fire-and-forget ETag recorder (recordEtag) settle. */
-  const settleEtag = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 5))
+  /** Wait until the fire-and-forget ETag recorder has issued its HEAD request. */
+  const settleEtag = async (): Promise<void> => {
+    await vi.waitFor(() => { expect(vi.mocked(globalThis.fetch)).toHaveBeenCalled() })
+  }
 
   it('keeps the resolved exports of an unchanged chunk — no re-inject / re-execute', async () => {
     installModuleSystem()

--- a/tests/markdown-html-render.spec.tsx
+++ b/tests/markdown-html-render.spec.tsx
@@ -20,7 +20,7 @@ import { analyzeMarkdownHtml } from '../src/client/markdown-html.ts'
 const media: MarkdownHtmlMedia = {
   scope: { sessionId: 's1', cwd: '/ws' },
   path: '/ws/docs/README.md',
-  origin: 'http://gui.origin',
+  baseUrl: 'http://gui.origin/dsh/',
 }
 const codeLabels = { copyLabel: 'Copy', copiedLabel: 'Copied' }
 
@@ -83,7 +83,7 @@ describe('MarkdownDocument (HTML leaves)', () => {
   it('rewrites local media sources through the /sidebar/file route', async () => {
     const { container, root } = await renderDocument('<picture><img src="./shot.png" alt="shot"/></picture>')
     const img = container.querySelector('img')
-    expect(img?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fshot.png&cwd=%2Fws')
+    expect(img?.getAttribute('src')).toBe('http://gui.origin/dsh/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fshot.png&cwd=%2Fws')
     await unmount(root)
   })
 })

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -1,3 +1,4 @@
+import './browser-globals.ts'
 import { describe, expect, it } from 'vitest'
 import { isAbsolutePath, relativeTo } from '../src/client/paths.ts'
 import { resolveSidebarPath } from '../src/client/produced-files.ts'
@@ -60,10 +61,10 @@ describe('path helpers', () => {
     // The marker is platform-neutral now: the host resolves the decoded
     // '//server/share/...' form per-platform, so no cwd/OS signal is needed.
     expect(htmlUrl({ sessionId: 's' }, '\\\\server\\share\\proj\\a.html'))
-      .toBe('/sidebar/html/s//server/share/proj/a.html')
+      .toBe('http://localhost/sidebar/html/s//server/share/proj/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '//server/share/a.html'))
-      .toBe('/sidebar/html/s//server/share/a.html')
+      .toBe('http://localhost/sidebar/html/s//server/share/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '/home/me/index.html'))
-      .toBe('/sidebar/html/s/home/me/index.html')
+      .toBe('http://localhost/sidebar/html/s/home/me/index.html')
   })
 })

--- a/tests/sandbox-views.spec.tsx
+++ b/tests/sandbox-views.spec.tsx
@@ -50,7 +50,7 @@ describe('HTML preview iframe sandbox', () => {
     expect(HTML_IFRAME_SANDBOX).not.toContain('allow-same-origin')
     expect(HTML_IFRAME_SANDBOX).not.toContain('allow-top-navigation')
     // Cross-origin framing by construction: route-src (never srcdoc).
-    expect(iframe).toContain('src="/sidebar/html/s1/p/a/index.html"')
+    expect(iframe).toContain('src="http://localhost/sidebar/html/s1/p/a/index.html"')
     expect(iframe).not.toContain('srcdoc=')
     // Referrer + permissions policy stay locked even when sandboxed.
     // (React SSR renders the referrerPolicy prop camelCase as written.)


### PR DESCRIPTION
## Summary
- resolve sidebar API, upload, media, HTML preview, and lazy bundle URLs against the injected document base
- preserve the same reverse-proxy prefix for terminal and agent WebSocket transports
- add focused base-path coverage and make chunk revalidation fixtures wait on observable HEAD requests

## Verification
- `pnpm exec vitest run tests/base-path.spec.ts tests/upload.spec.ts tests/markdown-images.spec.ts tests/chunk-loader.spec.ts tests/html-route.spec.ts`
- `pnpm run typecheck`
- `pnpm run build`