### PR TITLE
fix(terminal): contain transient resize failures

### DIFF
--- a/src/agent-pty.ts
+++ b/src/agent-pty.ts
@@ -41,6 +41,28 @@ export function clampDims(cols: number, rows: number): { cols: number; rows: num
 }
 
 /**
+ * Best-effort resize for WebSocket-driven terminal views. Layout animation
+ * can briefly produce unusable dimensions, and node-pty can reject a resize
+ * after the socket setup's outer try/catch has returned. Ignore that one
+ * frame so the host stays alive and a later valid measurement can retry.
+ * Returns whether node-pty accepted the resize.
+ */
+export function tryResizePty(
+  pty: Pick<IPty, 'resize'>,
+  cols: number,
+  rows: number,
+): boolean {
+  if (!Number.isFinite(cols) || !Number.isFinite(rows)) return false
+  const dims = clampDims(cols, rows)
+  try {
+    pty.resize(dims.cols, dims.rows)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Serializable snapshot of one agent terminal — the shape the model sees
  * through `terminal_list` and the sidebar sees through the push endpoint.
  * Carries no pty reference and no transcript (those are reached through

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ import { launchExternal } from './open-external.ts'
 import * as git from './git.ts'
 import { SettingsConflictError, settingsNamespace, type SettingsNamespace } from '@deepseek-ai/dsh-settings'
 import { defaultShell, ensureSpawnHelper, PtyManager, shellDisplayName } from './pty-manager.ts'
-import { AgentPtyRegistry, clampDims, type AgentTerminalHandle } from './agent-pty.ts'
+import { AgentPtyRegistry, tryResizePty, type AgentTerminalHandle } from './agent-pty.ts'
 import {
   DSH_NODE_PTY_RANGE,
   depsStatus,
@@ -1199,8 +1199,7 @@ async function attachTerminal(
         && control.type === 'resize'
         && typeof control.cols === 'number' && typeof control.rows === 'number'
       ) {
-        const dims = clampDims(control.cols, control.rows)
-        handle.pty.resize(dims.cols, dims.rows)
+        tryResizePty(handle.pty, control.cols, control.rows)
       } else {
         handle.pty.write(text)
       }
@@ -1268,8 +1267,7 @@ function pumpAgentTerminal(
       && control.type === 'resize'
       && typeof control.cols === 'number' && typeof control.rows === 'number'
     ) {
-      const dims = clampDims(control.cols, control.rows)
-      handle.pty.resize(dims.cols, dims.rows)
+      tryResizePty(handle.pty, control.cols, control.rows)
     } else if (control === null) {
       // Raw text input (a JSON-looking string the pty would have received
       // verbatim is reachable in theory but is exotic for an agent terminal;

--- a/tests/agent-pty.spec.ts
+++ b/tests/agent-pty.spec.ts
@@ -5,8 +5,14 @@
  * console noise from node-pty's ConPTY module on Windows is expected and
  * does not affect the assertions.
  */
-import { describe, expect, it } from 'vitest'
-import { AgentPtyRegistry, ALLOWED_SIGNALS, snapshotOf, type AgentTerminalSnapshot } from '../src/agent-pty.ts'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AgentPtyRegistry,
+  ALLOWED_SIGNALS,
+  snapshotOf,
+  tryResizePty,
+  type AgentTerminalSnapshot,
+} from '../src/agent-pty.ts'
 
 /**
  * Resolve a shell binary for tests: on Windows use PowerShell (available on
@@ -32,6 +38,35 @@ async function waitForTranscript(
   const handle = registry.get(uuid)
   return handle?.transcript ?? ''
 }
+
+describe('tryResizePty', () => {
+  it('clamps valid dimensions before resizing', () => {
+    const resize = vi.fn()
+
+    expect(tryResizePty({ resize }, 5000, 80.9)).toBe(true)
+    expect(resize).toHaveBeenCalledWith(1024, 80)
+  })
+
+  it('contains a node-pty resize failure', () => {
+    const resize = vi.fn(() => {
+      throw new Error('Usage: pty.resize(fd, cols, rows, xPixel, yPixel)')
+    })
+
+    expect(tryResizePty({ resize }, 80, 24)).toBe(false)
+    expect(resize).toHaveBeenCalledWith(80, 24)
+  })
+
+  it.each([
+    [Number.NaN, 24],
+    [Number.POSITIVE_INFINITY, 24],
+    [80, Number.NEGATIVE_INFINITY],
+  ])('rejects non-finite dimensions without calling node-pty (%s, %s)', (cols, rows) => {
+    const resize = vi.fn()
+
+    expect(tryResizePty({ resize }, cols, rows)).toBe(false)
+    expect(resize).not.toHaveBeenCalled()
+  })
+})
 
 describe('AgentPtyRegistry', () => {
   it('creates a terminal with a uuid, writes the command to stdin, and lists it', async () => {


### PR DESCRIPTION
Closes #426.

## What changed

- route both UI-tab and agent-terminal WebSocket resize messages through one best-effort PTY resize guard
- reject `NaN` and infinite layout measurements before calling `node-pty`
- preserve the existing 2–1024 integer clamp for finite measurements
- contain synchronous native resize exceptions inside the asynchronous WebSocket callback, so one transient panel frame cannot terminate the Host
- leave `AgentPtyRegistry.resize` unchanged, so direct model/tool resize failures still surface to callers

## Evidence

Before the patch, an EventEmitter reproduction of the current WebSocket callback lets the reported `Usage: pty.resize(fd, cols, rows, xPixel, yPixel)` exception escape. The new regression exercises that exact throw and confirms it is contained.

Verification at exact head `cc23a0e5364dd7362c69e4f36a4a1524efbb1a92`:

- focused terminal tests: 25/25
- full suite: 1,060 passed, 3 skipped, 0 failed
- `pnpm typecheck`
- `pnpm build`
- independent exact-head review: no blocking findings

The Bash-only consumer-type script was not runnable from this Windows checkout because the checked-in script is CRLF (`pipefail\r`); the production build, declarations, and TypeScript checks pass, and no workaround was added to this patch.