### PR TITLE
Feat/restore fs events refresh

### DIFF
--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -69,6 +69,11 @@ function isFileDrag(event: DragEvent): boolean {
 /** How long the row's "copied" label stays after a successful write. */
 const COPIED_MS = 1200
 
+/** Reconnect backoff for the passive fs-events socket. */
+const FS_RETRY_BASE_MS = 1000
+const FS_RETRY_MAX_MS = 30_000
+const FS_RETRY_STABLE_MS = 10_000
+
 /**
  * The drop overlay's hero art: an arrow rising out of a notched tray
  * (upload zone — the same glyph family as the toolbar's upload icon) and a
@@ -266,12 +271,29 @@ export function FileTree(props: {
     setData(dataRef.current)
   }, [])
 
-  const loadDir = useCallback((dir: string) => {
-    if (dataRef.current[dir] !== undefined) return
-    storeLevel(dir, {})
+  /** Latest request generation per directory; stale responses never win. */
+  const requestVersionRef = useRef(new Map<string, number>())
+  /** Directories visible during the previous render (collapsed levels can go stale). */
+  const visibleDirsRef = useRef<{ cwd: string | undefined; expanded: Set<string> }>({
+    cwd: undefined,
+    expanded: new Set(),
+  })
+
+  const loadDir = useCallback((dir: string, force = false) => {
+    const previous = dataRef.current[dir]
+    if (!force && previous !== undefined) return
+    const version = (requestVersionRef.current.get(dir) ?? 0) + 1
+    requestVersionRef.current.set(dir, version)
+    // Initial loads show the loading row. Refreshes keep the previous listing
+    // mounted and swap the new entries in atomically, avoiding tree flicker.
+    if (previous === undefined) storeLevel(dir, {})
     api.fsTree({ sessionId, cwd }, dir).then((listing) => {
+      if (requestVersionRef.current.get(dir) !== version) return
       storeLevel(dir, { entries: listing.entries })
     }).catch((error: unknown) => {
+      if (requestVersionRef.current.get(dir) !== version) return
+      // A passive refresh failure must not replace a usable tree with an error.
+      if (previous?.entries !== undefined) return
       storeLevel(dir, { error: error instanceof Error ? error.message : String(error) })
     })
   }, [sessionId, cwd, storeLevel])
@@ -340,24 +362,103 @@ export function FileTree(props: {
       })
   }
 
-  // The caller's refresh tick wipes the cache (declared BEFORE the load
-  // effect so the reload below sees the empty cache).
+  const expandedKey = expanded.join('\0')
+
+  /** Revalidate the visible tree without clearing any rendered rows. */
+  const refreshVisible = useCallback(() => {
+    if (cwd === undefined) return
+    loadDir(cwd, true)
+    for (const dir of expanded) loadDir(dir, true)
+  }, [cwd, expandedKey, loadDir])
+
+  // The caller's refresh tick force-reloads the visible set in place
+  // (declared BEFORE the load effect; the load effect's cache check then
+  // no-ops for already-loaded levels).
   const lastTick = useRef(refreshTick)
   useEffect(() => {
     if (lastTick.current === refreshTick) return
     lastTick.current = refreshTick
-    dataRef.current = {}
-    setData({})
-  }, [refreshTick])
+    refreshVisible()
+  }, [refreshTick, refreshVisible])
 
   useEffect(() => {
     // Load the visible set; already-loaded levels (kept in the cache) are
-    // not refetched. Only the refresh tick wipes the cache.
+    // not refetched. The refresh tick above force-reloads them in place.
     const root = cwd
     if (root === undefined) return
+    const previous = visibleDirsRef.current.cwd === root
+      ? visibleDirsRef.current.expanded
+      : new Set<string>()
     loadDir(root)
-    for (const dir of expanded) loadDir(dir)
-  }, [cwd, expanded, refreshTick, loadDir])
+    // A directory can change while collapsed because it is intentionally not
+    // watched then. Re-expansion therefore performs one background revalidate.
+    for (const dir of expanded) loadDir(dir, !previous.has(dir))
+    visibleDirsRef.current = { cwd: root, expanded: new Set(expanded) }
+  }, [cwd, expandedKey, loadDir])
+
+  /**
+   * Passive file-tree refresh: subscribe to host fs.watch events for the
+   * visible/expanded directories. The host pushes `{type:'change', path}`
+   * when a watched directory's contents change; we revalidate that level in
+   * the background and atomically swap the result. No polling or blank state.
+   */
+  useEffect(() => {
+    if (cwd === undefined) return
+    let socket: WebSocket | null = null
+    let retry: number | undefined
+    let stable: number | undefined
+    let closed = false
+    let failures = 0
+    let openedOnce = false
+    const connect = (): void => {
+      if (closed) return
+      const url = new URL('/sidebar/ws/fs-events', location.origin)
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      url.search = new URLSearchParams({ sessionId, cwd }).toString()
+      socket = new WebSocket(url.toString())
+      socket.onopen = () => {
+        window.clearTimeout(stable)
+        stable = window.setTimeout(() => { failures = 0 }, FS_RETRY_STABLE_MS)
+        const dirs = [cwd, ...expanded]
+        for (const dir of dirs) {
+          if (socket?.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: 'watch', path: dir }))
+          }
+        }
+        // Changes can happen during a broken connection. A reconnect closes
+        // that blind spot with one no-flicker revalidation of visible levels.
+        if (openedOnce) refreshVisible()
+        openedOnce = true
+      }
+      socket.onmessage = (event) => {
+        if (typeof event.data !== 'string') return
+        try {
+          const msg = JSON.parse(event.data) as { type?: unknown; path?: unknown }
+          if (msg?.type !== 'change' || typeof msg.path !== 'string') return
+          const changed = msg.path
+          if (dataRef.current[changed] === undefined && cwd !== changed && !expanded.includes(changed)) return
+          loadDir(changed, true)
+        } catch {
+          // Malformed push: ignore (the next real change will refresh).
+        }
+      }
+      socket.onclose = () => {
+        if (closed) return
+        window.clearTimeout(stable)
+        failures += 1
+        const delay = Math.min(FS_RETRY_BASE_MS * (2 ** Math.min(failures - 1, 5)), FS_RETRY_MAX_MS)
+        retry = window.setTimeout(connect, delay)
+      }
+      socket.onerror = () => { socket?.close() }
+    }
+    connect()
+    return () => {
+      closed = true
+      window.clearTimeout(retry)
+      window.clearTimeout(stable)
+      socket?.close()
+    }
+  }, [sessionId, cwd, expandedKey, loadDir, refreshVisible])
 
   // Bring a "Show in folder" reveal into view: the ancestors expand above
   // (revealPaths), but the row may not be scrolled into sight — a reveal on

--- a/src/index.ts
+++ b/src/index.ts
@@ -1535,12 +1535,12 @@ async function attachAgentList(
 }
 
 /** Subscribe an explorer socket to host fs.watch notifications for its cwd. */
-function attachFsEvents(
+async function attachFsEvents(
   ctx: Context,
   hub: FsWatchHub,
   ws: WebSocket,
   req: SidebarHttpRequest,
-): void {
+): Promise<void> {
   try {
     const url = new URL(req.url ?? '/', 'http://dsh.internal')
     const sessionId = url.searchParams.get('sessionId')
@@ -1548,7 +1548,7 @@ function attachFsEvents(
       ws.close(1008, 'sessionId is required')
       return
     }
-    const cwd = sessionCwdOf(ctx, sessionId, url.searchParams.get('cwd') ?? undefined)
+    const cwd = await sessionCwdOf(ctx, sessionId, url.searchParams.get('cwd') ?? undefined)
     ws.on('message', (data) => {
       try {
         const msg = JSON.parse(String(data)) as { type?: unknown; path?: unknown }

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,16 +174,57 @@ const READ_HEAD_LIMIT = 4096
 
 /** Debounce for batched fs.watch notifications per directory. */
 const FS_WATCH_DEBOUNCE_MS = 120
+/** How long to wait before retrying a per-directory fs.watch after an error. */
+const FS_WATCH_RETRY_MS = 1000
 
 /**
- * Directories whose contents do not need to drive live file-tree refreshes.
- * These are heavyweight/generated/system paths; the tree can still be
- * refreshed manually when the user is working inside one of them.
+ * Directory names whose contents do not need to drive live file-tree
+ * refreshes. These are heavyweight/generated/system paths; the tree can
+ * still be refreshed manually when the user is working inside one of them.
+ * The workspace root itself is never ignored based on its absolute path,
+ * so a session whose cwd happens to live under `tmp/` or `build/` still gets
+ * auto-refresh.
  */
-const WATCH_IGNORED = /(^|[\\/])(\.git|node_modules|dist|build|\.next|out|coverage|\.cache|\.config|\.vscode|\.idea|\.vs|\.svn|\.hg|AppData|Application Data|Local Settings|\.venv|venv|__pycache__|obj|Temp|tmp)([\\/]|$)/i
+const IGNORED_DIRECTORY_NAMES = new Set([
+  '.git', 'node_modules', 'dist', 'build', '.next', 'out', 'coverage',
+  '.cache', '.config', '.vscode', '.idea', '.vs', '.svn', '.hg',
+  'appdata', 'application data', 'local settings', '.venv', 'venv',
+  '__pycache__', 'obj', 'temp', 'tmp',
+])
 
-function isIgnoredWatchPath(path: string): boolean {
-  return WATCH_IGNORED.test(path)
+function normalizedPath(path: string): string {
+  return path.replace(/[\\/]+/g, '/').replace(/\/$/, '')
+}
+
+function pathSegmentsRelativeToCwd(path: string, cwd: string): string[] {
+  const normalized = normalizedPath(path)
+  const normalizedCwd = normalizedPath(cwd)
+  if (normalized.toLowerCase() === normalizedCwd.toLowerCase()) return []
+  const prefix = `${normalizedCwd.toLowerCase()}/`
+  if (!normalized.toLowerCase().startsWith(prefix)) {
+    return normalized.split('/').filter(Boolean)
+  }
+  return normalized.slice(normalizedCwd.length + 1).split('/').filter(Boolean)
+}
+
+function isIgnoredDirectoryName(name: string): boolean {
+  return IGNORED_DIRECTORY_NAMES.has(name.toLowerCase())
+}
+
+function isIgnoredWatchPath(path: string, cwd: string): boolean {
+  return pathSegmentsRelativeToCwd(path, cwd).some(isIgnoredDirectoryName)
+}
+
+/**
+ * Whether a filesystem event should be suppressed. Creation/removal/rename
+ * of an ignored directory itself is still relevant to its parent (e.g. a new
+ * `node_modules` folder changes the root listing), so only events strictly
+ * inside an ignored subtree are dropped.
+ */
+function isIgnoredChangeEvent(path: string, cwd: string): boolean {
+  const segments = pathSegmentsRelativeToCwd(path, cwd)
+  if (segments.length === 0) return false
+  return segments.slice(0, -1).some(isIgnoredDirectoryName)
 }
 
 interface DirWatchEntry {
@@ -217,58 +258,80 @@ interface WindowsRootWatch {
  * subfolders" failures while still mapping recursive events back to the
  * individual directories the client asked to watch.
  */
-class FsWatchHub {
+export class FsWatchHub {
+  private readonly platform: NodeJS.Platform
+  private readonly subscriptions = new Map<string, Set<WebSocket>>()
   private readonly directories = new Map<string, DirWatchEntry>()
   private readonly windowsRoots = new Map<string, WindowsRootWatch>()
+  private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private disposed = false
 
-  watch(dir: string, socket: WebSocket): void {
-    if (isIgnoredWatchPath(dir)) return
-    if (process.platform === 'win32') {
-      this.watchWindows(dir, socket)
+  constructor(platform: NodeJS.Platform = process.platform) {
+    this.platform = platform
+  }
+
+  watch(dir: string, socket: WebSocket, cwd: string): void {
+    if (this.disposed || isIgnoredWatchPath(dir, cwd)) return
+    this.subscribe(dir, socket)
+    if (this.platform === 'win32') {
+      this.watchWindows(dir, socket, cwd)
     } else {
       this.watchDirectory(dir, socket)
     }
   }
 
   unwatch(dir: string, socket: WebSocket): void {
-    if (process.platform === 'win32') {
-      for (const [root, entry] of this.windowsRoots) {
-        const watched = entry.sockets.get(socket)
-        if (watched === undefined) continue
-        watched.delete(dir)
-        if (watched.size === 0) {
-          entry.sockets.delete(socket)
-          if (entry.sockets.size === 0) this.dropWindowsRoot(root)
-        }
-      }
-      return
+    if (this.disposed) return
+    if (this.platform === 'win32') {
+      this.unwatchWindows(dir, socket)
+    } else {
+      this.unwatchDirectory(dir, socket)
     }
-    const entry = this.directories.get(dir)
-    if (entry === undefined) return
-    entry.sockets.delete(socket)
-    if (entry.sockets.size === 0) this.dropDirectory(dir)
+    this.unsubscribe(dir, socket)
   }
 
   removeSocket(socket: WebSocket): void {
-    if (process.platform === 'win32') {
-      for (const [root, entry] of this.windowsRoots) {
-        if (!entry.sockets.has(socket)) continue
-        entry.sockets.delete(socket)
-        if (entry.sockets.size === 0) this.dropWindowsRoot(root)
+    if (this.disposed) return
+    for (const [dir, sockets] of this.subscriptions) {
+      if (sockets.delete(socket) && sockets.size === 0) {
+        this.subscriptions.delete(dir)
+        this.clearRetry(dir)
+        const entry = this.directories.get(dir)
+        if (entry !== undefined) this.dropActiveDirectory(dir)
       }
-      return
     }
-    for (const [dir, entry] of this.directories) {
-      if (entry.sockets.delete(socket) && entry.sockets.size === 0) this.dropDirectory(dir)
+    if (this.platform !== 'win32') return
+    for (const [root, entry] of this.windowsRoots) {
+      if (!entry.sockets.has(socket)) continue
+      entry.sockets.delete(socket)
+      if (entry.sockets.size === 0) this.dropWindowsRoot(root)
     }
   }
 
   dispose(): void {
-    if (process.platform === 'win32') {
-      for (const root of [...this.windowsRoots.keys()]) this.dropWindowsRoot(root)
-      return
+    if (this.disposed) return
+    this.disposed = true
+    for (const timer of this.retryTimers.values()) clearTimeout(timer)
+    this.retryTimers.clear()
+    for (const dir of [...this.directories.keys()]) this.dropActiveDirectory(dir)
+    for (const root of [...this.windowsRoots.keys()]) this.dropWindowsRoot(root)
+    this.subscriptions.clear()
+  }
+
+  private subscribe(dir: string, socket: WebSocket): void {
+    const sockets = this.subscriptions.get(dir) ?? new Set<WebSocket>()
+    sockets.add(socket)
+    this.subscriptions.set(dir, sockets)
+  }
+
+  private unsubscribe(dir: string, socket: WebSocket): void {
+    const sockets = this.subscriptions.get(dir)
+    if (sockets === undefined) return
+    sockets.delete(socket)
+    if (sockets.size === 0) {
+      this.subscriptions.delete(dir)
+      this.clearRetry(dir)
     }
-    for (const dir of [...this.directories.keys()]) this.dropDirectory(dir)
   }
 
   private watchDirectory(dir: string, socket: WebSocket): void {
@@ -277,6 +340,12 @@ class FsWatchHub {
       existing.sockets.add(socket)
       return
     }
+    this.tryStartDirectory(dir)
+  }
+
+  private tryStartDirectory(dir: string): void {
+    if (this.disposed || this.directories.has(dir) || !this.hasSubscribers(dir)) return
+    this.clearRetry(dir)
     let watcher: FSWatcher
     try {
       watcher = fsWatch(dir, { persistent: false }, (eventType) => {
@@ -285,37 +354,58 @@ class FsWatchHub {
         if (eventType === 'rename') this.scheduleDirectory(dir)
       })
     } catch {
+      this.scheduleRetry(dir)
       return
     }
     watcher.on('error', () => {
       this.notifyDirectory(dir)
-      this.dropDirectory(dir)
+      this.dropActiveDirectory(dir)
+      this.scheduleRetry(dir)
     })
-    this.directories.set(dir, { watcher, sockets: new Set([socket]), timer: null })
+    this.directories.set(dir, { watcher, sockets: new Set(this.subscriptions.get(dir) ?? []), timer: null })
   }
 
-  private watchWindows(dir: string, socket: WebSocket): void {
-    // The client's first watch is always the session cwd; use it as the
-    // recursive root and allow later expanded subdirectories to share it.
-    const existing = this.findWindowsRoot(socket, dir)
-    if (existing !== undefined) {
-      const watched = existing.sockets.get(socket) ?? new Set<string>()
-      watched.add(dir)
-      existing.sockets.set(socket, watched)
-      return
+  private unwatchDirectory(dir: string, socket: WebSocket): void {
+    const entry = this.directories.get(dir)
+    if (entry !== undefined) entry.sockets.delete(socket)
+    if (!this.hasSubscribers(dir)) {
+      this.clearRetry(dir)
+      this.dropActiveDirectory(dir)
     }
-    const root = dir
-    let entry = this.windowsRoots.get(root)
+  }
+
+  private scheduleRetry(dir: string): void {
+    if (this.disposed || !this.hasSubscribers(dir) || this.retryTimers.has(dir)) return
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(dir)
+      this.tryStartDirectory(dir)
+    }, FS_WATCH_RETRY_MS)
+    this.retryTimers.set(dir, timer)
+  }
+
+  private clearRetry(dir: string): void {
+    const timer = this.retryTimers.get(dir)
+    if (timer === undefined) return
+    clearTimeout(timer)
+    this.retryTimers.delete(dir)
+  }
+
+  private hasSubscribers(dir: string): boolean {
+    return (this.subscriptions.get(dir)?.size ?? 0) > 0
+  }
+
+  private watchWindows(dir: string, socket: WebSocket, cwd: string): void {
+    let entry = this.windowsRoots.get(cwd)
     if (entry === undefined) {
-      const created: WindowsRootWatch = { root, watcher: undefined as unknown as FSWatcher, sockets: new Map(), pending: new Set(), timer: null }
+      const created: WindowsRootWatch = { root: cwd, watcher: undefined as unknown as FSWatcher, sockets: new Map(), pending: new Set(), timer: null }
       try {
-        const watcher = fsWatch(root, { persistent: false, recursive: true }, (_eventType, filename) => {
+        const watcher = fsWatch(cwd, { persistent: false, recursive: true }, (_eventType, filename) => {
           if (_eventType !== 'rename') return
           if (filename == null || typeof filename !== 'string' || filename === '') {
-            created.pending.add(root)
+            created.pending.add(cwd)
           } else {
-            const eventPath = join(root, filename)
-            if (isIgnoredWatchPath(eventPath)) return
+            const eventPath = join(cwd, filename)
+            if (isIgnoredChangeEvent(eventPath, cwd)) return
             const parent = parentOf(eventPath)
             for (const watched of this.windowsWatchedDirectories(created)) {
               if (eventPath === watched || parent === watched) created.pending.add(watched)
@@ -330,12 +420,24 @@ class FsWatchHub {
       created.watcher.on('error', () => {
         this.dropWindowsRoot(created.root)
       })
-      this.windowsRoots.set(root, created)
+      this.windowsRoots.set(cwd, created)
       entry = created
     }
     const watched = entry.sockets.get(socket) ?? new Set<string>()
     watched.add(dir)
     entry.sockets.set(socket, watched)
+  }
+
+  private unwatchWindows(dir: string, socket: WebSocket): void {
+    for (const [root, entry] of this.windowsRoots) {
+      const watched = entry.sockets.get(socket)
+      if (watched === undefined) continue
+      watched.delete(dir)
+      if (watched.size === 0) {
+        entry.sockets.delete(socket)
+        if (entry.sockets.size === 0) this.dropWindowsRoot(root)
+      }
+    }
   }
 
   private scheduleDirectory(dir: string): void {
@@ -350,10 +452,10 @@ class FsWatchHub {
   }
 
   private notifyDirectory(dir: string): void {
-    const entry = this.directories.get(dir)
-    if (entry === undefined) return
+    const sockets = this.subscriptions.get(dir)
+    if (sockets === undefined || sockets.size === 0) return
     const message = JSON.stringify({ type: 'change', path: dir })
-    for (const socket of [...entry.sockets]) {
+    for (const socket of [...sockets]) {
       if (socket.readyState === WebSocket.OPEN) socket.send(message)
     }
   }
@@ -387,14 +489,7 @@ class FsWatchHub {
     return watched
   }
 
-  private findWindowsRoot(socket: WebSocket, dir: string): WindowsRootWatch | undefined {
-    for (const entry of this.windowsRoots.values()) {
-      if (isWithin(entry.root, dir) && entry.sockets.has(socket)) return entry
-    }
-    return undefined
-  }
-
-  private dropDirectory(dir: string): void {
+  private dropActiveDirectory(dir: string): void {
     const entry = this.directories.get(dir)
     if (entry === undefined) return
     if (entry.timer !== null) clearTimeout(entry.timer)
@@ -1460,8 +1555,17 @@ function attachFsEvents(
         if (typeof msg?.path !== 'string') return
         const absolute = requireAbsolute(msg.path)
         if (!isWithin(cwd, absolute)) return
-        if (msg.type === 'watch') hub.watch(absolute, ws)
-        else if (msg.type === 'unwatch') hub.unwatch(absolute, ws)
+        if (msg.type === 'watch') {
+          // Resolve through realpath so a symlink inside the workspace cannot
+          // make fs.watch follow a directory that escapes the session cwd.
+          void ensureWorkspacePath(cwd, absolute).then(() => {
+            if (ws.readyState === WebSocket.OPEN) hub.watch(absolute, ws, cwd)
+          }).catch(() => {
+            // The path is outside the workspace (or vanished); skip it.
+          })
+        } else if (msg.type === 'unwatch') {
+          hub.unwatch(absolute, ws)
+        }
       } catch {
         // Malformed message: ignore.
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
  * processes are keyed by session.
  */
 import { mkdir, open, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { watch as fsWatch, type FSWatcher } from 'node:fs'
 import { basename, dirname, extname, isAbsolute, join } from 'node:path'
 import type { IncomingMessage } from 'node:http'
 import type { Duplex } from 'node:stream'
@@ -29,7 +30,7 @@ import {
   type SidebarConfig,
   type SidebarPrefs,
 } from './config.ts'
-import { parentOf, requireAbsolute, listDirectory, rootLabel } from './fs-tree.ts'
+import { isWithin, parentOf, requireAbsolute, listDirectory, rootLabel } from './fs-tree.ts'
 import { resolveSessionPath } from './session-path.ts'
 import { renameWorkspaceEntry, removeWorkspaceEntry, writeWorkspaceUpload } from './fs-operations.ts'
 import { ensureWorkspacePath, ensureWorkspaceWritePath } from './path-security.ts'
@@ -170,6 +171,245 @@ async function resolveGitPath(cwd: string, raw: string, selected?: string): Prom
 
 /** How many leading bytes a binary read returns for client-side detect sniffing. */
 const READ_HEAD_LIMIT = 4096
+
+/** Debounce for batched fs.watch notifications per directory. */
+const FS_WATCH_DEBOUNCE_MS = 120
+
+/**
+ * Directories whose contents do not need to drive live file-tree refreshes.
+ * These are heavyweight/generated/system paths; the tree can still be
+ * refreshed manually when the user is working inside one of them.
+ */
+const WATCH_IGNORED = /(^|[\\/])(\.git|node_modules|dist|build|\.next|out|coverage|\.cache|\.config|\.vscode|\.idea|\.vs|\.svn|\.hg|AppData|Application Data|Local Settings|\.venv|venv|__pycache__|obj|Temp|tmp)([\\/]|$)/i
+
+function isIgnoredWatchPath(path: string): boolean {
+  return WATCH_IGNORED.test(path)
+}
+
+interface DirWatchEntry {
+  watcher: FSWatcher
+  sockets: Set<WebSocket>
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+interface WindowsRootWatch {
+  root: string
+  watcher: FSWatcher
+  /** Per-socket watched directories under this root (client sends watch/unwatch). */
+  sockets: Map<WebSocket, Set<string>>
+  /** Directories that changed since the last debounce flush. */
+  pending: Set<string>
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+/**
+ * Shared fs.watch hub for the explorer's passive file-tree refresh.
+ *
+ * On non-Windows the hub follows PR #137 exactly: one `fs.watch` per visible
+ * directory, reference-counted across sockets, `rename` events debounced and
+ * pushed as `{type:'change', path}`.
+ *
+ * Windows uses a single recursive `fs.watch` handle on the workspace root.
+ * Opening one handle per visible directory on Windows makes the OS refuse to
+ * move/rename a parent directory while descendant `obj`, `bin`, or any other
+ * child directory still has an open watcher handle. A single recursive root
+ * handle avoids that whole class of "cannot move folder with generated
+ * subfolders" failures while still mapping recursive events back to the
+ * individual directories the client asked to watch.
+ */
+class FsWatchHub {
+  private readonly directories = new Map<string, DirWatchEntry>()
+  private readonly windowsRoots = new Map<string, WindowsRootWatch>()
+
+  watch(dir: string, socket: WebSocket): void {
+    if (isIgnoredWatchPath(dir)) return
+    if (process.platform === 'win32') {
+      this.watchWindows(dir, socket)
+    } else {
+      this.watchDirectory(dir, socket)
+    }
+  }
+
+  unwatch(dir: string, socket: WebSocket): void {
+    if (process.platform === 'win32') {
+      for (const [root, entry] of this.windowsRoots) {
+        const watched = entry.sockets.get(socket)
+        if (watched === undefined) continue
+        watched.delete(dir)
+        if (watched.size === 0) {
+          entry.sockets.delete(socket)
+          if (entry.sockets.size === 0) this.dropWindowsRoot(root)
+        }
+      }
+      return
+    }
+    const entry = this.directories.get(dir)
+    if (entry === undefined) return
+    entry.sockets.delete(socket)
+    if (entry.sockets.size === 0) this.dropDirectory(dir)
+  }
+
+  removeSocket(socket: WebSocket): void {
+    if (process.platform === 'win32') {
+      for (const [root, entry] of this.windowsRoots) {
+        if (!entry.sockets.has(socket)) continue
+        entry.sockets.delete(socket)
+        if (entry.sockets.size === 0) this.dropWindowsRoot(root)
+      }
+      return
+    }
+    for (const [dir, entry] of this.directories) {
+      if (entry.sockets.delete(socket) && entry.sockets.size === 0) this.dropDirectory(dir)
+    }
+  }
+
+  dispose(): void {
+    if (process.platform === 'win32') {
+      for (const root of [...this.windowsRoots.keys()]) this.dropWindowsRoot(root)
+      return
+    }
+    for (const dir of [...this.directories.keys()]) this.dropDirectory(dir)
+  }
+
+  private watchDirectory(dir: string, socket: WebSocket): void {
+    const existing = this.directories.get(dir)
+    if (existing !== undefined) {
+      existing.sockets.add(socket)
+      return
+    }
+    let watcher: FSWatcher
+    try {
+      watcher = fsWatch(dir, { persistent: false }, (eventType) => {
+        // Only directory-entry changes (create/delete/rename) alter the tree;
+        // file content edits don't need an explorer refresh.
+        if (eventType === 'rename') this.scheduleDirectory(dir)
+      })
+    } catch {
+      return
+    }
+    watcher.on('error', () => {
+      this.notifyDirectory(dir)
+      this.dropDirectory(dir)
+    })
+    this.directories.set(dir, { watcher, sockets: new Set([socket]), timer: null })
+  }
+
+  private watchWindows(dir: string, socket: WebSocket): void {
+    // The client's first watch is always the session cwd; use it as the
+    // recursive root and allow later expanded subdirectories to share it.
+    const existing = this.findWindowsRoot(socket, dir)
+    if (existing !== undefined) {
+      const watched = existing.sockets.get(socket) ?? new Set<string>()
+      watched.add(dir)
+      existing.sockets.set(socket, watched)
+      return
+    }
+    const root = dir
+    let entry = this.windowsRoots.get(root)
+    if (entry === undefined) {
+      const created: WindowsRootWatch = { root, watcher: undefined as unknown as FSWatcher, sockets: new Map(), pending: new Set(), timer: null }
+      try {
+        const watcher = fsWatch(root, { persistent: false, recursive: true }, (_eventType, filename) => {
+          if (_eventType !== 'rename') return
+          if (filename == null || typeof filename !== 'string' || filename === '') {
+            created.pending.add(root)
+          } else {
+            const eventPath = join(root, filename)
+            if (isIgnoredWatchPath(eventPath)) return
+            const parent = parentOf(eventPath)
+            for (const watched of this.windowsWatchedDirectories(created)) {
+              if (eventPath === watched || parent === watched) created.pending.add(watched)
+            }
+          }
+          if (created.pending.size > 0) this.scheduleWindowsRoot(created)
+        })
+        created.watcher = watcher
+      } catch {
+        return
+      }
+      created.watcher.on('error', () => {
+        this.dropWindowsRoot(created.root)
+      })
+      this.windowsRoots.set(root, created)
+      entry = created
+    }
+    const watched = entry.sockets.get(socket) ?? new Set<string>()
+    watched.add(dir)
+    entry.sockets.set(socket, watched)
+  }
+
+  private scheduleDirectory(dir: string): void {
+    const entry = this.directories.get(dir)
+    if (entry === undefined || entry.timer !== null) return
+    entry.timer = setTimeout(() => {
+      const current = this.directories.get(dir)
+      if (current === undefined) return
+      current.timer = null
+      this.notifyDirectory(dir)
+    }, FS_WATCH_DEBOUNCE_MS)
+  }
+
+  private notifyDirectory(dir: string): void {
+    const entry = this.directories.get(dir)
+    if (entry === undefined) return
+    const message = JSON.stringify({ type: 'change', path: dir })
+    for (const socket of [...entry.sockets]) {
+      if (socket.readyState === WebSocket.OPEN) socket.send(message)
+    }
+  }
+
+  private scheduleWindowsRoot(entry: WindowsRootWatch): void {
+    if (entry.timer !== null) return
+    entry.timer = setTimeout(() => {
+      const current = this.windowsRoots.get(entry.root)
+      if (current === undefined) return
+      current.timer = null
+      this.notifyWindowsRoot(current)
+    }, FS_WATCH_DEBOUNCE_MS)
+  }
+
+  private notifyWindowsRoot(entry: WindowsRootWatch): void {
+    const pending = [...entry.pending]
+    entry.pending.clear()
+    for (const dir of pending) {
+      const message = JSON.stringify({ type: 'change', path: dir })
+      for (const [socket, watched] of entry.sockets) {
+        if (watched.has(dir) && socket.readyState === WebSocket.OPEN) socket.send(message)
+      }
+    }
+  }
+
+  private windowsWatchedDirectories(entry: WindowsRootWatch): Set<string> {
+    const watched = new Set<string>()
+    for (const dirs of entry.sockets.values()) {
+      for (const dir of dirs) watched.add(dir)
+    }
+    return watched
+  }
+
+  private findWindowsRoot(socket: WebSocket, dir: string): WindowsRootWatch | undefined {
+    for (const entry of this.windowsRoots.values()) {
+      if (isWithin(entry.root, dir) && entry.sockets.has(socket)) return entry
+    }
+    return undefined
+  }
+
+  private dropDirectory(dir: string): void {
+    const entry = this.directories.get(dir)
+    if (entry === undefined) return
+    if (entry.timer !== null) clearTimeout(entry.timer)
+    entry.watcher.close()
+    this.directories.delete(dir)
+  }
+
+  private dropWindowsRoot(root: string): void {
+    const entry = this.windowsRoots.get(root)
+    if (entry === undefined) return
+    if (entry.timer !== null) clearTimeout(entry.timer)
+    entry.watcher.close()
+    this.windowsRoots.delete(root)
+  }
+}
 
 /** Text read of a file with the size cap; binary detection via NUL probe.
  *  Binary reads also return the first {@link READ_HEAD_LIMIT} bytes (base64)
@@ -739,6 +979,10 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // `/sidebar/ws/agent-opens` socket. Unlike the pty registry it has no
   // native dependencies — the tool works even in node-pty degraded mode.
   const agentOpenRegistry = new AgentOpenRegistry()
+  // File-manager workspace watcher: serves passive file-tree refresh pushes.
+  // The hub is reference-counted and starts watching only when the file tree
+  // subscribes, so an idle sidebar does not hold filesystem handles.
+  const fsWatchHub = new FsWatchHub()
 
   // ── User-facing "Side card" preferences ──────────────────────────────────
   // Register the namespace with the settings provider so the Settings page
@@ -1100,15 +1344,40 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
     },
   }), 'dsh-better-sidebar: agent-opens push WebSocket')
 
+  // ── File-tree change push WebSocket ─────────────────────────────────────
+  // Passive file-tree refresh: the explorer subscribes to fs.watch events for
+  // the directories it currently shows. The host watches only those
+  // directories (reference-counted) and pushes a lightweight change notice;
+  // the client revalidates the changed directory in the background and
+  // atomically swaps the listing. On Windows one recursive root handle serves
+  // every expanded directory to avoid blocking parent-directory renames while
+  // descendant watcher handles are open.
+  const fsEventsWss = new WebSocketServer({ noServer: true })
+  ctx.effect(() => ctx.webServer.registerUpgrade({
+    path: '/sidebar/ws/fs-events',
+    handler: (req, socket, head) => {
+      if (!fence(req)) {
+        socket.destroy()
+        return
+      }
+      fsEventsWss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
+        void attachFsEvents(ctx, fsWatchHub, ws, req)
+      })
+    },
+  }), 'dsh-better-sidebar: file-tree change WebSocket')
+
+
   ctx.effect(() => () => {
     toolsDisposers?.()
     openToolsDisposers?.()
     ptyManager?.disposeAll()
     agentPtyRegistry?.disposeAll()
     agentOpenRegistry.dispose()
+    fsWatchHub.dispose()
     wss.close()
     agentListWss.close()
     agentOpenWss.close()
+    fsEventsWss.close()
   }, 'dsh-better-sidebar: teardown')
 }
 
@@ -1165,6 +1434,41 @@ async function attachAgentList(
     const unsubscribe = registry?.subscribe(send)
     ws.on('close', () => { unsubscribe?.() })
     ws.on('error', () => { unsubscribe?.() })
+  } catch (error) {
+    ws.close(1011, error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Subscribe an explorer socket to host fs.watch notifications for its cwd. */
+function attachFsEvents(
+  ctx: Context,
+  hub: FsWatchHub,
+  ws: WebSocket,
+  req: SidebarHttpRequest,
+): void {
+  try {
+    const url = new URL(req.url ?? '/', 'http://dsh.internal')
+    const sessionId = url.searchParams.get('sessionId')
+    if (sessionId === null) {
+      ws.close(1008, 'sessionId is required')
+      return
+    }
+    const cwd = sessionCwdOf(ctx, sessionId, url.searchParams.get('cwd') ?? undefined)
+    ws.on('message', (data) => {
+      try {
+        const msg = JSON.parse(String(data)) as { type?: unknown; path?: unknown }
+        if (typeof msg?.path !== 'string') return
+        const absolute = requireAbsolute(msg.path)
+        if (!isWithin(cwd, absolute)) return
+        if (msg.type === 'watch') hub.watch(absolute, ws)
+        else if (msg.type === 'unwatch') hub.unwatch(absolute, ws)
+      } catch {
+        // Malformed message: ignore.
+      }
+    })
+    const cleanup = (): void => { hub.removeSocket(ws) }
+    ws.on('close', cleanup)
+    ws.on('error', cleanup)
   } catch (error) {
     ws.close(1011, error instanceof Error ? error.message : String(error))
   }

--- a/tests/file-tree-refresh.spec.tsx
+++ b/tests/file-tree-refresh.spec.tsx
@@ -1,0 +1,107 @@
+/**
+ * FileTree refresh invalidation: a refresh tick must not leave cached but
+ * collapsed directories stale. Expanding one after a refresh has to refetch
+ * the fresh listing instead of reusing the pre-refresh cache.
+ */
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { FileTree } from '../src/client/FileTree.tsx'
+import { createSidebarStore } from '../src/client/state.ts'
+import type { FsEntry } from '../src/client/api.ts'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+const rootEntries: FsEntry[] = [
+  { name: 'src', path: '/tmp/src', isDir: true, hidden: false, isSymlink: false, broken: false },
+  { name: 'a.ts', path: '/tmp/a.ts', isDir: false, hidden: false, isSymlink: false, broken: false },
+]
+
+const calls: string[] = []
+const srcListings: FsEntry[][] = [
+  [{ name: 'old.ts', path: '/tmp/src/old.ts', isDir: false, hidden: false, isSymlink: false, broken: false }],
+  [{ name: 'new.ts', path: '/tmp/src/new.ts', isDir: false, hidden: false, isSymlink: false, broken: false }],
+]
+
+vi.mock('../src/client/api.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/client/api.ts')>('../src/client/api.ts')
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      fsTree: async (_scope: unknown, dir: string) => {
+        if (dir === '/tmp') return { entries: rootEntries }
+        if (dir === '/tmp/src') {
+          const listing = srcListings[Math.min(calls.filter(call => call === '/tmp/src').length, srcListings.length - 1)]!
+          calls.push(dir)
+          return { entries: listing }
+        }
+        return { entries: [] }
+      },
+    },
+  }
+})
+
+let container: HTMLDivElement
+let root: Root
+let refreshTick: number
+let expanded: string[]
+
+function render(): void {
+  root.render(createElement(FileTree, {
+    sessionId: 's1',
+    cwd: '/tmp',
+    store: createSidebarStore(),
+    expanded,
+    revealed: [],
+    onToggle: () => {},
+    onOpenFile: () => {},
+    onReferenceFile: () => {},
+    refreshTick,
+    onUploadRequest: () => {},
+    busy: false,
+  }))
+}
+
+beforeEach(async () => {
+  calls.length = 0
+  refreshTick = 0
+  expanded = ['/tmp/src']
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => {
+    render()
+  })
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+})
+
+describe('FileTree refresh invalidation', () => {
+  it('refetches a collapsed cached directory after a refresh tick', async () => {
+    expect(container.textContent).toContain('old.ts')
+    expect(calls.filter(call => call === '/tmp/src')).toHaveLength(1)
+
+    // Collapse the directory and refresh the visible set (one single bump).
+    await act(async () => {
+      refreshTick = 1
+      expanded = []
+      render()
+    })
+
+    // Re-expand WITHOUT another refresh tick: the stale cache must be
+    // reloaded because the single refresh invalidated it while collapsed.
+    await act(async () => {
+      expanded = ['/tmp/src']
+      render()
+    })
+
+    expect(calls.filter(call => call === '/tmp/src')).toHaveLength(2)
+    expect(container.textContent).toContain('new.ts')
+  })
+})

--- a/tests/fs-watch-hub.spec.ts
+++ b/tests/fs-watch-hub.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * FsWatchHub regression coverage:
+ * - watch/unwatch/removeSocket reference counting
+ * - ignored directories never subscribe on their own
+ * - ignored directory creation still refreshes its parent
+ * - disposed hub cannot create new watchers
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { WebSocket as WsWebSocket } from 'ws'
+import { FsWatchHub } from '../src/index.ts'
+
+interface FakeSocket {
+  readyState: number
+  send: ReturnType<typeof vi.fn>
+}
+
+const OPEN = 1
+
+function fakeSocket(): FakeSocket {
+  return { readyState: OPEN, send: vi.fn() }
+}
+
+async function waitFor(expectation: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now()
+  while (!expectation()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out')
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+}
+
+let roots: string[]
+let hub: FsWatchHub | null = null
+
+beforeEach(() => {
+  roots = []
+  hub = null
+})
+
+afterEach(() => {
+  hub?.dispose()
+  hub = null
+  for (const root of roots) {
+    try {
+      rmSync(root, { recursive: true, force: true })
+    } catch {
+      // Windows may still be releasing handles; CI cleanup best effort.
+    }
+  }
+  roots = []
+})
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-fs-watch-hub-'))
+  roots.push(root)
+  return root
+}
+
+function waitForWatcherStable(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 100))
+}
+
+describe('FsWatchHub', () => {
+  it('notifies a subscribed socket when a direct directory entry changes', async () => {
+    const root = tempRoot()
+    const socket = fakeSocket()
+    hub = new FsWatchHub()
+    hub.watch(root, socket as unknown as WsWebSocket, root)
+    await waitForWatcherStable()
+
+    writeFileSync(join(root, 'new-file.ts'), 'x')
+    await waitFor(() => socket.send.mock.calls.length > 0)
+
+    expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ type: 'change', path: root }))
+    hub.removeSocket(socket as unknown as WsWebSocket)
+  })
+
+  it('does not subscribe to an ignored directory itself', async () => {
+    const root = tempRoot()
+    const nodeModules = join(root, 'node_modules')
+    mkdirSync(nodeModules)
+    const socket = fakeSocket()
+    hub = new FsWatchHub()
+    hub.watch(nodeModules, socket as unknown as WsWebSocket, root)
+    await waitForWatcherStable()
+
+    writeFileSync(join(nodeModules, 'x.txt'), 'x')
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(socket.send).not.toHaveBeenCalled()
+    hub.removeSocket(socket as unknown as WsWebSocket)
+  })
+
+  it('still refreshes the parent when an ignored directory is created', async () => {
+    const root = tempRoot()
+    const socket = fakeSocket()
+    hub = new FsWatchHub()
+    hub.watch(root, socket as unknown as WsWebSocket, root)
+    await waitForWatcherStable()
+
+    mkdirSync(join(root, 'node_modules'))
+    await waitFor(() => socket.send.mock.calls.length > 0)
+
+    expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ type: 'change', path: root }))
+    hub.removeSocket(socket as unknown as WsWebSocket)
+  })
+
+  it('reference-counts subscribers: one unwatch keeps the other live', async () => {
+    const root = tempRoot()
+    const first = fakeSocket()
+    const second = fakeSocket()
+    hub = new FsWatchHub()
+    hub.watch(root, first as unknown as WsWebSocket, root)
+    hub.watch(root, second as unknown as WsWebSocket, root)
+    await waitForWatcherStable()
+
+    writeFileSync(join(root, 'a.ts'), 'x')
+    await waitFor(() => first.send.mock.calls.length > 0)
+
+    expect(second.send).toHaveBeenCalled()
+    hub.unwatch(root, first as unknown as WsWebSocket)
+
+    writeFileSync(join(root, 'b.ts'), 'y')
+    await waitFor(() => second.send.mock.calls.length > 1)
+
+    expect(first.send).toHaveBeenCalledTimes(1)
+    hub.removeSocket(second as unknown as WsWebSocket)
+  })
+
+  it('does not start new watchers after dispose', async () => {
+    const root = tempRoot()
+    const socket = fakeSocket()
+    hub = new FsWatchHub()
+    hub.watch(root, socket as unknown as WsWebSocket, root)
+    await waitForWatcherStable()
+
+    hub.dispose()
+    writeFileSync(join(root, 'after-dispose.txt'), 'x')
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(socket.send).not.toHaveBeenCalled()
+    // Explicit post-dispose watch must be a no-op, not re-create handles.
+    hub.watch(root, socket as unknown as WsWebSocket, root)
+    writeFileSync(join(root, 'after-post-dispose-watch.txt'), 'x')
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    expect(socket.send).not.toHaveBeenCalled()
+  })
+})

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -110,7 +110,7 @@ describe('host plugin smoke', () => {
       '/sidebar/file',
       '/sidebar/html',
     ])
-    expect(upgrades.map(route => route.path)).toEqual(['/sidebar/ws/terminal', '/sidebar/ws/agent-terminals', '/sidebar/ws/agent-opens'])
+    expect(upgrades.map(route => route.path)).toEqual(['/sidebar/ws/terminal', '/sidebar/ws/agent-terminals', '/sidebar/ws/agent-opens', '/sidebar/ws/fs-events'])
     // Teardown runs without throwing (pty manager has nothing open).
     for (const cleanup of effects) cleanup()
   })


### PR DESCRIPTION
## 背景

文件树只能靠手动刷新按钮。外部文件变化（git clone、编辑器增删文件、构建产物）在点击刷新前对侧边栏不可见。

## 方案

按仓库管理员在 #196 的建议、以 #137 的契约为主线，恢复被动事件驱动的
文件树自动刷新：

- host 使用 `node:fs` 原生 `fs.watch` 实现 reference-counted hub，不新增依赖。
- 客户端通过 `/sidebar/ws/fs-events` 发送 `watch/unwatch`，host 推送 `{type:'change', path}`，客户端只 revalidate 变更目录，无轮询、无整树闪烁。
- 断线使用指数退避重连，重建后对可见目录做一次无闪烁 revalidate。

## 契约增强：Windows 单根递归 watcher

Windows 上如果按每个可见目录分别打开 `fs.watch` 句柄，会因子目录
（`obj`、`bin` 等）仍被 watch 而阻止父目录改名/移动。本实现改为对会话
cwd 使用单个递归 `fs.watch` 根句柄，再将递归事件映射回客户端实际 watch
的目录，避免 Windows 的句柄阻塞问题。

同时忽略 `.git`、`node_modules`、`dist`、`build`、`.next`、`out`、 `coverage`、`.cache`、`.config`、`.vscode`、`.idea`、`.vs`、`.svn`、 `.hg`、`AppData`、`.venv`、`venv`、`__pycache__`、`obj`、`Temp`、`tmp` 等不需要随时刷新的目录；这些目录仍可手动刷新。

## 改动

- `src/index.ts`：`FsWatchHub`、`/sidebar/ws/fs-events` upgrade route、 `attachFsEvents`、teardown。
- `src/client/FileTree.tsx`：无闪烁 revalidate、可见目录跟踪、自动刷新 socket、指数退避重连；手动刷新也改为原位 revalidate，不再清空整棵树。
- `tests/file-tree-refresh.spec.tsx`：折叠目录后刷新再重新展开必须拿到 新数据，不能读陈旧缓存。

## 测试

- `pnpm typecheck`
- `pnpm build`
- `pnpm vitest run tests/file-tree-refresh.spec.tsx`