### PR TITLE
docs: add dsh-better-sidebar-icons to the enhancements catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ GitHub topic [`dsh-better-sidebar`](https://github.com/topics/dsh-better-sidebar
 ### 🧰 增强与工具
 
 <details>
-<summary><b>2 个插件（点击展开）</b></summary>
+<summary><b>3 个插件（点击展开）</b></summary>
 
 | 插件 | ⭐ | 简介 |
 |---|---|---|
+| [eg-bole/dsh-better-sidebar-icons](https://github.com/eg-bole/dsh-better-sidebar-icons) | <img alt="stars" src="https://img.shields.io/github/stars/eg-bole/dsh-better-sidebar-icons?style=flat&color=4d6bfe" /> | VSCode 风格文件 / 文件夹图标主题：文件树与编辑器 Tab 换上熟悉的开发环境图标（vscode-icons 移植，纯 DOM 覆盖零侵入，安装 / 卸载零残留） |
 | [dong-victor/dsh-better-sidebar-terminal-plus](https://github.com/dong-victor/dsh-better-sidebar-terminal-plus) | <img alt="stars" src="https://img.shields.io/github/stars/dong-victor/dsh-better-sidebar-terminal-plus?style=flat&color=4d6bfe" /> | 终端增强：内嵌 Nerd Font 图标字体、修复 xterm 图标渲染、稳定终端 cwd |
 | [Max-Null/dsh-sidebar-preview-select](https://github.com/Max-Null/dsh-sidebar-preview-select) | <img alt="stars" src="https://img.shields.io/github/stars/Max-Null/dsh-sidebar-preview-select?style=flat&color=4d6bfe" /> | 预览划选增强：侧边栏预览里划选文本 → 浮动「发送到会话」 |
 


### PR DESCRIPTION
﻿### 变更内容

在 README 的「🧰 增强与工具」插件目录中新增一行，收录 [eg-bole/dsh-better-sidebar-icons](https://github.com/eg-bole/dsh-better-sidebar-icons)：

- **VSCode 风格文件 / 文件夹图标主题**：为 better-sidebar 的文件树与编辑器 Tab 提供 vscode-icons 移植图标
- 纯 DOM 覆盖实现：不修改 better-sidebar 源码，安装 / 卸载零残留
- 已发布到 npm（`dsh-better-sidebar-icons@0.1.2`），`dsh plugin add dsh-better-sidebar-icons` 即可安装

纯文档改动，仅 README 一行表格。
