### PR TITLE
fix(composer): insert @-references at the caret instead of appending to the end

### DIFF
--- a/src/client/conversation-draft.ts
+++ b/src/client/conversation-draft.ts
@@ -1,16 +1,65 @@
 /**
- * Append text to the current session's composer draft through the
+ * Insert text into the current session's composer draft through the
  * conversation service — the shared path behind the explorer's @-reference
- * button and the viewer selection popup. The service is resolved lazily
+ * button and the viewer selection popup. Prefers the caret position of the
+ * live composer textarea (the native @-mention pick path: splice over a
+ * draftRev-CAS'd span); every miss — no composer textarea in the DOM, a
+ * shell without the verb (older DSH), or a stale draft revision — falls
+ * back to the space-separated append. The service is resolved lazily
  * through `ctx.get` (the inject-free read the app's own plugins use); a
  * missing service or scope degrades to a logged no-op, never a crash.
  */
-import type { Context, SidebarConversation } from '../context-types.ts'
+import type { Context, SidebarConversation, SidebarSessionInput } from '../context-types.ts'
 
 /**
- * Append `text` to the session's composer draft (space-separated, like the
- * @-mentions). Returns false — and logs — when the conversation service or
- * the session scope is unavailable.
+ * Splice `text` at the composer textarea's caret. Returns false — leaving
+ * the append fallback to the caller — whenever the caret cannot be trusted.
+ */
+function insertAtCaret(
+  input: SidebarSessionInput,
+  snapshot: { draft: string; draftRev?: number },
+  text: string,
+): boolean {
+  // The verb lives on the per-session shell, not the published SessionInput
+  // contract — duck-typed so an older DSH degrades to the append path.
+  if (typeof input.insertText !== 'function') return false
+  if (snapshot.draftRev === undefined) return false
+  // The caret exists only in the DOM: the composer textarea is the single
+  // textarea carrying the input machine's data-phase attribute.
+  const el = document.querySelector<HTMLTextAreaElement>('textarea[data-phase]')
+  if (el === null) return false
+  // The DOM draft must match the machine snapshot: a different session's
+  // composer (or a mid-flight re-render) makes the DOM caret meaningless.
+  if (el.value !== snapshot.draft) return false
+  const draft = snapshot.draft
+  const start = el.selectionStart ?? draft.length
+  const end = el.selectionEnd ?? start
+  if (start < 0 || end < start || end > draft.length) return false
+  // Space-separation exactly where the neighbours would otherwise glue.
+  const prefix = start > 0 && !/\s/u.test(draft[start - 1] ?? '') ? ' ' : ''
+  const suffix = end < draft.length && !/\s/u.test(draft[end] ?? '') ? ' ' : ''
+  const inserted = `${prefix}${text}${suffix}`
+  if (!input.insertText(inserted, { start, end, draftRev: snapshot.draftRev })) return false
+  // The controlled re-render resets the DOM caret; put it after the splice
+  // (the same rAF shape the composer's own restoreCaret uses) and hand
+  // focus back so typing continues where the reference landed.
+  const caret = start + inserted.length
+  requestAnimationFrame(() => {
+    try {
+      el.focus({ preventScroll: true })
+      el.setSelectionRange(caret, caret)
+    } catch {
+      // A disposed textarea has nothing to restore.
+    }
+  })
+  return true
+}
+
+/**
+ * Insert `text` into the session's composer draft at the caret (the native
+ * @-mention shape), appending at the end as the fallback. Returns false —
+ * and logs — when the conversation service or the session scope is
+ * unavailable.
  */
 export function appendToDraft(ctx: Context, sessionId: string, text: string): boolean {
   try {
@@ -19,6 +68,10 @@ export function appendToDraft(ctx: Context, sessionId: string, text: string): bo
     const conversation = ctx.get('conversation') as SidebarConversation | undefined
     if (conversation === undefined) return false
     const input = conversation.input.for(actx)
+    if (insertAtCaret(input, input.state.getSnapshot(), text)) return true
+    // Re-read before appending: a failed CAS means the snapshot we hold is
+    // stale, and writing it back would swallow a concurrent draft edit
+    // (an autocomplete splice racing this click).
     const draft = input.state.getSnapshot().draft
     input.setDraft(draft.trim() === '' ? text : `${draft} ${text}`)
     return true

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -423,12 +423,19 @@ export interface SidebarLocaleService {
 
 /** The composer draft face the sidebar reaches through `ctx.conversation.input`. */
 export interface SidebarSessionInput {
-  /** The live input store (draft read for append). */
+  /** The live input store (draft read for append; draftRev for the caret-span CAS). */
   state: {
-    getSnapshot(): { draft: string }
+    getSnapshot(): { draft: string; draftRev?: number }
   }
   /** Replace the draft text (the input machine's single public write path). */
   setDraft(text: string): void
+  /**
+   * Splice `text` over a draftRev-CAS'd span at the caret — the native
+   * @-mention pick verb. Present on the per-session shell; optional here
+   * because the published SessionInput contract does not carry it, so an
+   * older DSH simply falls back to the append path.
+   */
+  insertText?(text: string, span: { start: number; end: number; draftRev: number }, keepCompleting?: boolean): boolean
 }
 
 /** The composer draft face the sidebar reaches through `ctx.get('conversation')`. */


### PR DESCRIPTION
## Problem

Clicking the explorer's **@-reference** button (or the editor-selection *"add to conversation"* popup) always glues the text onto the **end** of the composer draft, no matter where the caret is.

Root cause — `appendToDraft()` only used the published `setDraft` verb:

```ts
const draft = input.state.getSnapshot().draft
input.setDraft(draft.trim() === '' ? text : `${draft} ${text}`)
```

`src/client/conversation-draft.ts` is byte-identical in 0.17.1, so this is currently unfixed upstream.

## Fix

Prefer the caret-aware splice the native @-mention pick path uses, keep the append as the fallback:

- Read the caret from the composer textarea — `textarea[data-phase]`, the only `textarea` carrying the input machine's phase attribute.
- Splice through the per-session shell's `insertText(text, { start, end, draftRev })` — the same draftRev-CAS'd verb the native pick path funnels through (`slash/input-insert-text`).
- Space-pad only where the neighbouring characters would otherwise glue; no trailing space at end-of-draft, so later inserts can't produce double spaces.
- Restore the DOM caret after the controlled re-render (the same rAF shape the composer's own `restoreCaret` uses) and hand focus back to the composer.
- Every miss degrades to the legacy append: no composer textarea in the DOM, a shell without the verb (older DSH), a DOM↔machine draft mismatch (another session's composer mounted), or a CAS failure.

`SidebarSessionInput` gains the optional `insertText` / `draftRev` surface. The verb lives on the per-session shell, not the published `SessionInput` contract — hence optional and duck-typed, so older DSH versions simply take the append path.

## Verification

A 10-case scenario harness over the built bundle: mid-word caret splice, start/end caret, selection replace, empty draft, no-double-space guard, and all four fallback paths (no textarea / no verb / stale DOM value / draftRev CAS miss).

Manual repro: place the caret in the middle of the draft → click the explorer's @ button → the reference now lands at the caret and focus returns to the composer.

## 中文摘要

侧栏文件树的 @ 引用（及编辑器选区弹窗）插入主聊天输入框时，原来固定拼接到草稿末尾，无视光标位置。本 PR 改为优先走原生 @ 补全的同款光标处拼接路径（`insertText` + draftRev CAS，光标取自 `textarea[data-phase]`），并在受控重渲染后恢复光标、归还焦点；DOM 不可达、旧版 DSH 无该动词、会话不匹配或 CAS 失败时一律回退到原末尾追加行为，不会回归。