### PR TITLE
fix(git): support worktree listing on older Git versions

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -323,11 +323,27 @@ function pathIdentity(path: string): string {
   return process.platform === 'win32' ? absolute.toLowerCase() : absolute
 }
 
+/** Whether the current Git binary supports NUL-framed `worktree list` output.
+ * Git < 2.36 rejects `-z`; cache the capability after the first attempt so
+ * the SCM panel's polling does not repeatedly spawn a command known to fail. */
+let worktreeListSupportsZ: boolean | undefined
+
 /** Raw usable checkout records, shared by inventory and target validation.
  * Prunable records point at missing paths and are deliberately excluded from
  * both the selector and the command-target allowlist. */
 async function listedWorktrees(cwd: string): Promise<GitWorktreeRecord[]> {
-  const raw = await runGit(cwd, ['worktree', 'list', '--porcelain', '-z'])
+  let raw: string
+  if (worktreeListSupportsZ === false) {
+    raw = await runGit(cwd, ['worktree', 'list', '--porcelain'])
+  } else {
+    try {
+      raw = await runGit(cwd, ['worktree', 'list', '--porcelain', '-z'])
+      worktreeListSupportsZ = true
+    } catch {
+      worktreeListSupportsZ = false
+      raw = await runGit(cwd, ['worktree', 'list', '--porcelain'])
+    }
+  }
   return parseWorktreeList(raw).filter(entry => !entry.prunable)
 }
 

--- a/tests/git-spawn.spec.ts
+++ b/tests/git-spawn.spec.ts
@@ -6,7 +6,7 @@ const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
-import { isGitRepo } from '../src/git.ts'
+import { isGitRepo, worktrees } from '../src/git.ts'
 
 afterEach(() => {
   spawnMock.mockReset()
@@ -37,5 +37,53 @@ describe('git subprocess spawning', () => {
       ['-C', 'C:\\repo', '--no-pager', '-c', 'color.ui=false', 'rev-parse', '--is-inside-work-tree'],
       expect.objectContaining({ windowsHide: true }),
     )
+  })
+
+  it('falls back when worktree list does not support -z', async () => {
+    const gitChild = (stdoutText = '', stderrText = '', code = 0): EventEmitter => {
+      const child = new EventEmitter()
+      const stdout = new PassThrough()
+      const stderr = new PassThrough()
+      Object.assign(child, { stdout, stderr, kill: vi.fn() })
+      queueMicrotask(() => {
+        stdout.end(stdoutText)
+        stderr.end(stderrText)
+        child.emit('close', code)
+      })
+      return child
+    }
+
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      const command = args.slice(5)
+      if (command[0] === 'rev-parse' && command[1] === '--is-inside-work-tree') return gitChild('true\n')
+      if (command[0] === 'rev-parse' && command[1] === '--show-toplevel') return gitChild('C:\\repo\n')
+      if (command[0] === 'rev-parse' && command[1] === '--abbrev-ref') return gitChild('main\n')
+      if (command[0] === 'status') return gitChild('')
+      if (command[0] === 'worktree' && command.includes('-z')) {
+        return gitChild('', "error: unknown switch `z'\n", 129)
+      }
+      if (command[0] === 'worktree') {
+        return gitChild([
+          'worktree C:\\repo',
+          'HEAD abc',
+          'branch refs/heads/main',
+          '',
+        ].join('\n'))
+      }
+      throw new Error(`unexpected git command: ${command.join(' ')}`)
+    })
+
+    await expect(worktrees('C:\\repo')).resolves.toEqual([
+      { path: 'C:\\repo', branch: 'main', current: true, changes: 0 },
+    ])
+    await expect(worktrees('C:\\repo')).resolves.toEqual([
+      { path: 'C:\\repo', branch: 'main', current: true, changes: 0 },
+    ])
+
+    const nulAttempts = spawnMock.mock.calls.filter((call) => {
+      const args = call[1] as string[]
+      return args.includes('worktree') && args.includes('-z')
+    })
+    expect(nulAttempts).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## 修复内容

* 当当前 Git 版本不支持 `git worktree list --porcelain -z` 时，自动回退到 `git worktree list --porcelain`
* 缓存 `-z` 支持能力，避免 SCM 面板轮询时重复执行已知会失败的命令
* 在新版本 Git 上继续保留 NUL 分隔输出，避免降低 worktree 路径解析的可靠性
* 增加回归测试，覆盖旧版本 Git 的回退逻辑和能力缓存行为

## 验证

* 在 `tests/git-spawn.spec.ts` 中补充了旧版本 Git 不支持 `-z` 时的回归测试
* 确认本分支仅修改 `src/git.ts` 和 `tests/git-spawn.spec.ts`

Fixes #440
