### PR TITLE
fix: resolve Linux absolute paths in WSL workspaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   type SidebarPrefs,
 } from './config.ts'
 import { parentOf, requireAbsolute, listDirectory, rootLabel } from './fs-tree.ts'
+import { resolveSessionPath } from './session-path.ts'
 import { writeWorkspaceUpload } from './fs-operations.ts'
 import { ensureWorkspacePath, ensureWorkspaceWritePath } from './path-security.ts'
 import { searchFiles } from './fs-search.ts'
@@ -156,7 +157,7 @@ function selectedRepoOf(payload: unknown): string | undefined {
  * cwd when the root cannot be resolved, e.g. a bare directory).
  */
 async function resolveGitPath(cwd: string, raw: string, selected?: string): Promise<string> {
-  if (isAbsolute(raw)) return requireAbsolute(raw)
+  if (isAbsolute(raw)) return requireAbsolute(resolveSessionPath(cwd, raw))
   // Prefer the session-relative interpretation when it names an existing
   // path. Git status reports repository-root-relative names, but the sidebar
   // security boundary is the session workspace; this preference keeps files

--- a/src/path-security.ts
+++ b/src/path-security.ts
@@ -2,6 +2,7 @@
 import { realpath } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import { isWithin, requireAbsolute } from './fs-tree.ts'
+import { resolveSessionPath } from './session-path.ts'
 import { SidebarError } from './wire.ts'
 
 /** Resolve a path and convert filesystem resolution failures to an API error. */
@@ -25,14 +26,14 @@ function assertWithinWorkspace(workspace: string, target: string): void {
  * enforce containment.
  *
  * @param cwd - Session workspace directory.
- * @param target - Client-supplied absolute path.
+ * @param target - Client-supplied absolute path in the session's namespace.
  * @param fence - Whether containment is enforced (the settings-page
  * `workspaceFence` switch). Even when false the paths are still resolved
  * through symlinks so callers always receive the canonical target.
  * @returns The canonical absolute path used for the filesystem operation.
  */
 export async function ensureWorkspacePath(cwd: string, target: string, fence = true): Promise<string> {
-  const absolute = requireAbsolute(target)
+  const absolute = requireAbsolute(resolveSessionPath(cwd, target))
   const [realCwd, realTarget] = await Promise.all([
     resolveRealPath(cwd, 'workspace'),
     resolveRealPath(absolute, 'target'),
@@ -49,13 +50,13 @@ export async function ensureWorkspacePath(cwd: string, target: string, fence = t
  * symlink is never left in the path passed to the write operation.
  *
  * @param cwd - Session workspace directory.
- * @param target - Client-supplied absolute destination path.
+ * @param target - Client-supplied absolute destination path in the session's namespace.
  * @param fence - Whether containment is enforced (the settings-page
  * `workspaceFence` switch). Resolution/canonicalization is identical either way.
  * @returns A canonical path for an existing target or its nearest existing ancestor.
  */
 export async function ensureWorkspaceWritePath(cwd: string, target: string, fence = true): Promise<string> {
-  const absolute = requireAbsolute(target)
+  const absolute = requireAbsolute(resolveSessionPath(cwd, target))
   const realCwd = await resolveRealPath(cwd, 'workspace')
   let existingPath = absolute
   const missingSegments: string[] = []

--- a/src/session-path.ts
+++ b/src/session-path.ts
@@ -1,0 +1,37 @@
+import { win32 } from 'node:path'
+
+/** `\\wsl.localhost\<distro>` root of a Windows-hosted WSL workspace. */
+const WSL_LOCALHOST_ROOT = /^\\\\wsl\.localhost\\([^\\]+)(?:\\|$)/i
+
+/**
+ * Reinterpret an already-absolute path in the namespace of one session.
+ *
+ * Windows treats `/foo` as rooted on the current drive, so `path.resolve()`
+ * turns it into e.g. `C:\\foo`. That is wrong for a session whose cwd is a
+ * WSL UNC path: in that namespace `/foo` means the distro's Linux `/foo`.
+ * Project only that unambiguous combination onto the matching distro root;
+ * drive paths, UNC paths, ordinary Windows sessions and non-Windows hosts
+ * keep their existing semantics.
+ *
+ * Workspace containment is intentionally NOT handled here. A projected path
+ * such as `/tmp/x` can still be rejected later for lying outside the session
+ * workspace; the important part is that it is checked as WSL `/tmp/x`, not
+ * silently redirected to `C:\\tmp\\x`.
+ */
+export function resolveSessionPath(
+  cwd: string,
+  target: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== 'win32' || !/^\/(?!\/)/.test(target)) return target
+
+  // Session cwd can be spelled with either separator style. Normalize only
+  // for detection; the returned host path is always canonical win32 UNC.
+  const normalizedCwd = cwd.replace(/\//g, '\\')
+  const match = WSL_LOCALHOST_ROOT.exec(normalizedCwd)
+  if (match === null) return target
+
+  const distroRoot = `\\\\wsl.localhost\\${match[1]}`
+  const relative = target.slice(1).replace(/\//g, '\\')
+  return win32.resolve(distroRoot, relative)
+}

--- a/tests/session-path.spec.ts
+++ b/tests/session-path.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSessionPath } from '../src/session-path.ts'
+
+const WSL_CWD = '\\\\wsl.localhost\\archlinux\\home\\zdaar\\project'
+
+describe('resolveSessionPath', () => {
+  it('maps a Linux absolute path into the WSL distro root on win32', () => {
+    expect(resolveSessionPath(WSL_CWD, '/home/zdaar/project/src/a.ts', 'win32'))
+      .toBe('\\\\wsl.localhost\\archlinux\\home\\zdaar\\project\\src\\a.ts')
+  })
+
+  it('maps a path outside the workspace into the same distro before containment checks', () => {
+    expect(resolveSessionPath(WSL_CWD, '/tmp/dsh-issue.md', 'win32'))
+      .toBe('\\\\wsl.localhost\\archlinux\\tmp\\dsh-issue.md')
+  })
+
+  it('normalizes Linux dot segments without escaping the distro share root', () => {
+    expect(resolveSessionPath(WSL_CWD, '/home/zdaar/project/../other/a.ts', 'win32'))
+      .toBe('\\\\wsl.localhost\\archlinux\\home\\zdaar\\other\\a.ts')
+    expect(resolveSessionPath(WSL_CWD, '/../etc/hosts', 'win32'))
+      .toBe('\\\\wsl.localhost\\archlinux\\etc\\hosts')
+  })
+
+  it('preserves Windows drive paths in a WSL session', () => {
+    const target = 'C:\\Users\\zdaar\\file.md'
+    expect(resolveSessionPath(WSL_CWD, target, 'win32')).toBe(target)
+  })
+
+  it('preserves UNC paths in a WSL session', () => {
+    const backslash = '\\\\server\\share\\file.md'
+    const forwardSlash = '//server/share/file.md'
+    expect(resolveSessionPath(WSL_CWD, backslash, 'win32')).toBe(backslash)
+    expect(resolveSessionPath(WSL_CWD, forwardSlash, 'win32')).toBe(forwardSlash)
+  })
+
+  it('does not reinterpret slash-rooted paths for ordinary Windows sessions', () => {
+    expect(resolveSessionPath('C:\\Users\\zdaar\\project', '/tmp/a.ts', 'win32')).toBe('/tmp/a.ts')
+    expect(resolveSessionPath('\\\\server\\share\\project', '/tmp/a.ts', 'win32')).toBe('/tmp/a.ts')
+  })
+
+  it('does not reinterpret paths on non-Windows hosts', () => {
+    expect(resolveSessionPath('/home/zdaar/project', '/tmp/a.ts', 'linux')).toBe('/tmp/a.ts')
+    expect(resolveSessionPath('/Users/zdaar/project', '/tmp/a.ts', 'darwin')).toBe('/tmp/a.ts')
+  })
+
+  it('recognizes wsl.localhost case-insensitively and with forward-slash cwd spelling', () => {
+    expect(resolveSessionPath('//WSL.LOCALHOST/Ubuntu/home/me/project', '/home/me/project/a.ts', 'win32'))
+      .toBe('\\\\wsl.localhost\\Ubuntu\\home\\me\\project\\a.ts')
+  })
+})


### PR DESCRIPTION
## 背景

修复 #399。

当 DSH 运行在 Windows、会话 workspace 位于 WSL UNC 路径（例如 `\\wsl.localhost\archlinux\home\user\project`）时，sidebar 会把 `/home/...`、`/tmp/...` 这类 Linux 绝对路径交给 Windows `path.resolve()`。

结果 `/tmp/x` 会被错误解析为 `C:\tmp\x`，可能导致文件无法打开，甚至在 C: 上存在同名文件时访问错误的文件。

## 修改

- 新增 session-aware 路径解析：
  - 仅在 Windows host；
  - 且 session cwd 为 `\\wsl.localhost\<distro>\...`；
  - 且目标是单 `/` 开头的 Linux 绝对路径时；
  - 将 `/foo/bar` 映射为 `\\wsl.localhost\<distro>\foo\bar`。
- Windows drive path、已有 UNC path、普通 Windows workspace 与非 Windows host 保持原有行为。
- `ensureWorkspacePath` / `ensureWorkspaceWritePath` 在执行 realpath 与 workspace containment 前完成 WSL 路径投影。
- `resolveGitPath` 的绝对路径分支同步使用 session-aware 解析，避免 `fs.read` 等调用在进入 workspace guard 前就把 `/home/...` 转成 `C:\home\...`。
- 不改变现有 workspace 安全边界。例如 WSL `/tmp/x` 会先正确映射到该 distro 的 `/tmp/x`，随后如果它位于 workspace 外，仍会按现有规则拒绝，而不会错误访问 `C:\tmp\x`。

## 测试

以下测试已经通过：
- `pnpm typecheck`
- `pnpm build` 
- `pnpm test` 

新增 `tests/session-path.spec.ts`，覆盖：

- WSL workspace 中的 `/home/...` 映射
- `/tmp/...` 映射
- `.` / `..` 路径归一化
- Windows drive path 保持不变
- UNC path 保持不变
- 普通 Windows workspace 不启用 WSL 映射
- Linux / macOS host 不启用映射
- `wsl.localhost` 大小写与正斜杠 cwd 形式

Fixes #399