### PR TITLE
perf(sidebar): reduce repeated center-column DOM queries

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -47,6 +47,7 @@ import { IconPanelBottomOutline16, IconPanelRightOutline16 } from './icons.tsx'
 import { Workbench, type WorkbenchActions } from './split-pane.tsx'
 import { isNarrowWidth, useViewportSize } from './breakpoints.ts'
 import { layoutPushSize } from './layout-push.ts'
+import { resolveCenterColumn } from './center-column.ts'
 import { parseDesktopEnv } from './desktop-env.ts'
 import { getWcoSnapshot, subscribeWco } from './wco.ts'
 import { getShellPreset } from './shell-presets.ts'
@@ -738,8 +739,10 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // (observed: a 1px sliver at the viewport's left edge).
     const locate = (): void => {
       if (disposed) return
-      const col = document.querySelector('#root [data-slot="conversation"]')
-        ?.parentElement as HTMLElement | undefined
+      // Hot path (#403): streaming output mutates #root at token cadence.
+      // Reuse a still-connected center column and only query after boot/HMR
+      // detached the cached node.
+      const col = resolveCenterColumn(centerColRef.current)
       if (col === undefined || !col.isConnected) {
         if (centerColRef.current !== null) {
           centerColRef.current = null
@@ -771,7 +774,7 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
       // Mid-drag every frame writes --dsh-sidebar-* on <html>'s style
       // attribute, which is the mutation this watcher observes — relocating
       // per drag frame is pointless (the center column node cannot change
-      // while the pointer is captured) and adds a querySelector to every
+      // while the pointer is captured) and adds locator work to every
       // frame's budget (#315). The 1.5s retry below still covers any node
       // swap that somehow lands mid-drag.
       if (draggingRef.current) return
@@ -798,8 +801,9 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
     // may end up byte-identical, and the col may be swapped before the
     // subtree watcher attaches). A slow unconditional re-locate makes the
     // panel converge on the real column within a couple of seconds no
-    // matter what sequence the shell used. locate() is cheap when nothing
-    // changed (one querySelector + an identity compare; no forced layout).
+    // matter what sequence the shell used. locate() is query-free while the
+    // cached column stays connected; only a detached/missing cache falls
+    // back to the document selector.
     const retry = window.setInterval(locate, 1500)
     return () => {
       disposed = true

--- a/src/client/center-column.ts
+++ b/src/client/center-column.ts
@@ -1,22 +1,82 @@
 /** Stable selector for the DSH AppFrame conversation slot. */
 const CENTER_COLUMN_SELECTOR = '#root [data-slot="conversation"]'
 
+/** Match Sidebar's existing last-resort retry cadence (issue #248). */
+export const CENTER_COLUMN_REVALIDATE_MS = 1500
+
+interface CenterColumnResolveOptions {
+  /** Explicit document for tests / callers that do not yet have a cached node. */
+  document?: Document
+  /** Injectable DOM lookup for tests. */
+  query?: () => Element | null
+  /** Injectable clock for deterministic retry-boundary tests. */
+  now?: () => number
+  /** Injectable <html style> fingerprint for deterministic HMR tests. */
+  htmlStyle?: () => string | null
+  /** Override only for tests; production follows the 1.5s safety-net cadence. */
+  revalidateMs?: number
+}
+
+/** Last full DOM validation for each center-column node. Weak keys avoid leaks. */
+const validatedAt = new WeakMap<HTMLElement, number>()
+
 /**
- * Resolve the AppFrame center column while keeping the hot path query-free.
+ * The html-style watcher is an HMR/layout resync signal. Remember the last
+ * fingerprint per document so a style change can bypass the connected-node
+ * fast path immediately, without requiring Sidebar to run a second locator.
+ */
+const documentStyleState = new WeakMap<Document, string | null>()
+
+/**
+ * Resolve the AppFrame center column while keeping streaming mutations cheap.
  *
- * Streaming chat output mutates `#root` at token cadence, so Sidebar's
- * MutationObserver can call this once per animation frame. Once the center
- * column has been found, its DOM identity is stable for the conversation
- * lifecycle; checking `isConnected` is enough to reuse it without scanning
- * the whole app tree again. Boot/HMR replacement still falls through to the
- * document query as soon as the cached node is detached.
+ * Sidebar intentionally keeps both recovery mechanisms that predate #403:
+ * the `#root` subtree MutationObserver catches boot/HMR DOM swaps, and the
+ * 1.5s interval is a last-resort safety net for interleavings no observer is
+ * guaranteed to see (#248). The expensive part was letting every scheduled
+ * locate scan `#root` with querySelector at streaming-token cadence.
+ *
+ * Once a connected column is cached, normal calls therefore reuse it without
+ * a document query. A full query is still forced when either:
+ * - the cached node disconnects;
+ * - `<html style>` changes (the existing HMR/layout resync signal); or
+ * - 1.5s has elapsed since the last full validation (the safety-net cadence).
+ *
+ * This preserves recovery semantics while bounding whole-tree selector work
+ * to low-frequency validation instead of chat mutation frequency.
  */
 export function resolveCenterColumn(
   current: HTMLElement | null,
-  query: () => Element | null = () => document.querySelector(CENTER_COLUMN_SELECTOR),
+  options: CenterColumnResolveOptions = {},
 ): HTMLElement | undefined {
-  if (current !== null && current.isConnected) return current
+  const doc = options.document ?? current?.ownerDocument ?? document
+  const now = (options.now ?? Date.now)()
+  const revalidateMs = options.revalidateMs ?? CENTER_COLUMN_REVALIDATE_MS
+  const htmlStyle = (options.htmlStyle ?? (() => doc.documentElement.getAttribute('style')))()
 
-  const col = query()?.parentElement
-  return col !== null && col !== undefined && col.isConnected ? col : undefined
+  const previousStyle = documentStyleState.get(doc)
+  const styleChanged = previousStyle !== undefined && previousStyle !== htmlStyle
+  documentStyleState.set(doc, htmlStyle)
+
+  if (current !== null && current.isConnected) {
+    const lastValidation = validatedAt.get(current)
+
+    // A connected node passed in for the first time is already a trustworthy
+    // cache hit. Start its safety-net window without paying an eager query.
+    if (lastValidation === undefined && !styleChanged) {
+      validatedAt.set(current, now)
+      return current
+    }
+
+    if (!styleChanged && lastValidation !== undefined && now - lastValidation < revalidateMs) {
+      return current
+    }
+  }
+
+  const query = options.query ?? (() => doc.querySelector(CENTER_COLUMN_SELECTOR))
+  const col = query()?.parentElement as HTMLElement | null | undefined
+  if (col === null || col === undefined || !col.isConnected) return undefined
+
+  validatedAt.set(col, now)
+  return col
 }

--- a/src/client/center-column.ts
+++ b/src/client/center-column.ts
@@ -1,0 +1,22 @@
+/** Stable selector for the DSH AppFrame conversation slot. */
+const CENTER_COLUMN_SELECTOR = '#root [data-slot="conversation"]'
+
+/**
+ * Resolve the AppFrame center column while keeping the hot path query-free.
+ *
+ * Streaming chat output mutates `#root` at token cadence, so Sidebar's
+ * MutationObserver can call this once per animation frame. Once the center
+ * column has been found, its DOM identity is stable for the conversation
+ * lifecycle; checking `isConnected` is enough to reuse it without scanning
+ * the whole app tree again. Boot/HMR replacement still falls through to the
+ * document query as soon as the cached node is detached.
+ */
+export function resolveCenterColumn(
+  current: HTMLElement | null,
+  query: () => Element | null = () => document.querySelector(CENTER_COLUMN_SELECTOR),
+): HTMLElement | undefined {
+  if (current !== null && current.isConnected) return current
+
+  const col = query()?.parentElement
+  return col !== null && col !== undefined && col.isConnected ? col : undefined
+}

--- a/tests/center-column-locator.spec.ts
+++ b/tests/center-column-locator.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveCenterColumn } from '../src/client/center-column.ts'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function connectedColumn(): { col: HTMLDivElement; slot: HTMLDivElement } {
+  const col = document.createElement('div')
+  const slot = document.createElement('div')
+  slot.dataset.slot = 'conversation'
+  col.append(slot)
+  document.body.append(col)
+  return { col, slot }
+}
+
+describe('center-column locator (issue #403)', () => {
+  it('reuses a connected cached column without querying the app tree', () => {
+    const { col } = connectedColumn()
+    const query = vi.fn<() => Element | null>(() => null)
+
+    expect(resolveCenterColumn(col, query)).toBe(col)
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('queries and adopts the replacement after the cached column detaches', () => {
+    const stale = connectedColumn().col
+    stale.remove()
+    const { col: replacement, slot } = connectedColumn()
+    const query = vi.fn<() => Element | null>(() => slot)
+
+    expect(resolveCenterColumn(stale, query)).toBe(replacement)
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('queries when no column has been cached yet', () => {
+    const { col, slot } = connectedColumn()
+    const query = vi.fn<() => Element | null>(() => slot)
+
+    expect(resolveCenterColumn(null, query)).toBe(col)
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a missing or detached query result', () => {
+    expect(resolveCenterColumn(null, () => null)).toBeUndefined()
+
+    const detachedCol = document.createElement('div')
+    const detachedSlot = document.createElement('div')
+    detachedCol.append(detachedSlot)
+    expect(resolveCenterColumn(null, () => detachedSlot)).toBeUndefined()
+  })
+})

--- a/tests/center-column-locator.spec.ts
+++ b/tests/center-column-locator.spec.ts
@@ -1,53 +1,103 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { resolveCenterColumn } from '../src/client/center-column.ts'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CENTER_COLUMN_REVALIDATE_MS,
+  resolveCenterColumn,
+} from '../src/client/center-column.ts'
 
-afterEach(() => {
-  document.body.innerHTML = ''
-})
+interface Fixture {
+  doc: Document
+  col: HTMLDivElement
+  slot: HTMLDivElement
+}
 
-function connectedColumn(): { col: HTMLDivElement; slot: HTMLDivElement } {
-  const col = document.createElement('div')
-  const slot = document.createElement('div')
+function connectedColumn(doc = document.implementation.createHTMLDocument()): Fixture {
+  const col = doc.createElement('div')
+  const slot = doc.createElement('div')
   slot.dataset.slot = 'conversation'
   col.append(slot)
-  document.body.append(col)
-  return { col, slot }
+  doc.body.append(col)
+  return { doc, col, slot }
 }
 
 describe('center-column locator (issue #403)', () => {
-  it('reuses a connected cached column without querying the app tree', () => {
-    const { col } = connectedColumn()
-    const query = vi.fn<() => Element | null>(() => null)
+  it('reuses a connected cached column without querying during the hot-path window', () => {
+    const { doc, col, slot } = connectedColumn()
+    let now = 0
+    const query = vi.fn<() => Element | null>(() => slot)
+    const options = { document: doc, query, now: () => now }
 
-    expect(resolveCenterColumn(col, query)).toBe(col)
+    expect(resolveCenterColumn(col, options)).toBe(col)
+    now = CENTER_COLUMN_REVALIDATE_MS - 1
+    expect(resolveCenterColumn(col, options)).toBe(col)
     expect(query).not.toHaveBeenCalled()
   })
 
-  it('queries and adopts the replacement after the cached column detaches', () => {
-    const stale = connectedColumn().col
+  it('fully revalidates a connected cache at the 1.5s safety-net boundary', () => {
+    const { doc, col, slot } = connectedColumn()
+    let now = 0
+    const query = vi.fn<() => Element | null>(() => slot)
+    const options = { document: doc, query, now: () => now }
+
+    expect(resolveCenterColumn(col, options)).toBe(col)
+    expect(query).not.toHaveBeenCalled()
+
+    now = CENTER_COLUMN_REVALIDATE_MS
+    expect(resolveCenterColumn(col, options)).toBe(col)
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('revalidates immediately when the html style signal changes', () => {
+    const { doc, col, slot } = connectedColumn()
+    let now = 0
+    const query = vi.fn<() => Element | null>(() => slot)
+    const options = { document: doc, query, now: () => now }
+
+    expect(resolveCenterColumn(col, options)).toBe(col)
+    expect(query).not.toHaveBeenCalled()
+
+    doc.documentElement.style.setProperty('--dsh-sidebar-width', '320px')
+    now = 1
+    expect(resolveCenterColumn(col, options)).toBe(col)
+    expect(query).toHaveBeenCalledTimes(1)
+
+    // The same fingerprint is cheap again; one style change causes one full
+    // validation instead of turning later streaming mutations into queries.
+    now = 2
+    expect(resolveCenterColumn(col, options)).toBe(col)
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('queries and adopts the replacement as soon as the cached column detaches', () => {
+    const first = connectedColumn()
+    const stale = first.col
     stale.remove()
-    const { col: replacement, slot } = connectedColumn()
+    const { col: replacement, slot } = connectedColumn(first.doc)
     const query = vi.fn<() => Element | null>(() => slot)
 
-    expect(resolveCenterColumn(stale, query)).toBe(replacement)
+    expect(resolveCenterColumn(stale, { document: first.doc, query, now: () => 1 })).toBe(replacement)
     expect(query).toHaveBeenCalledTimes(1)
   })
 
   it('queries when no column has been cached yet', () => {
-    const { col, slot } = connectedColumn()
+    const { doc, col, slot } = connectedColumn()
     const query = vi.fn<() => Element | null>(() => slot)
 
-    expect(resolveCenterColumn(null, query)).toBe(col)
+    expect(resolveCenterColumn(null, { document: doc, query, now: () => 0 })).toBe(col)
     expect(query).toHaveBeenCalledTimes(1)
   })
 
   it('rejects a missing or detached query result', () => {
-    expect(resolveCenterColumn(null, () => null)).toBeUndefined()
+    const doc = document.implementation.createHTMLDocument()
+    expect(resolveCenterColumn(null, { document: doc, query: () => null, now: () => 0 })).toBeUndefined()
 
-    const detachedCol = document.createElement('div')
-    const detachedSlot = document.createElement('div')
+    const detachedCol = doc.createElement('div')
+    const detachedSlot = doc.createElement('div')
     detachedCol.append(detachedSlot)
-    expect(resolveCenterColumn(null, () => detachedSlot)).toBeUndefined()
+    expect(resolveCenterColumn(null, {
+      document: doc,
+      query: () => detachedSlot,
+      now: () => 1,
+    })).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 变更说明

- center column 仍 connected 时直接复用缓存，避免流式输出期间反复执行 `querySelector`
- 缓存节点 detached 或 `<html style>` 变化时立即重新定位
- 每 1.5s 强制完整复核一次，保留 #248 的 safety-net
- 保留现有 `#root` subtree MutationObserver 和 HMR 恢复逻辑
- 补充 locator 行为测试

## 本 PR 为什么只处理 locator 热路径，没有完全采用 #403 的方案

#403 中还提到了两个更大的方向，但它们都不适合在缺少进一步验证的情况下顺手合入本 PR。

目前能够明确确认的问题是：流式 DOM mutation 会进一步触发重复的全树 `querySelector`。这一层可以在不改变恢复机制的情况下安全消除，因此本 PR 先处理它。

至于 MutationObserver callback / scheduling 本身是否仍然构成显著瓶颈，需要实际 Performance trace 才能判断。

如果它仍然占据明显时间，后续也不能简单把 `subtree: true` 删除，因为当前 observer 同时参与 boot → AppFrame、HMR replacement 等恢复路径。更合理的下一步是重新设计 locator lifecycle，例如：

`recovery -> 开启 observer -> 定位成功 -> 进入 stable 状态 -> 暂停 observer`

并依靠明确的 HMR / AppFrame 生命周期信号重新进入 recovery。

这属于恢复机制本身的行为调整，风险和验证范围明显大于本 PR 的 hot-path 优化，因此应单独处理。

#403 中提到的大分组 DOM mount 是另一类独立问题。

这里不能直接假设加一个 `content-visibility` 或 virtualization 就可以完成修复。需要先确认：

- 大量 session row 的实际渲染耗时占比
- session list 的 DOM / React ownership
- row 高度、滚动定位、选中态等行为是否依赖完整挂载
- virtualization 是否会影响现有 session navigation / scroll 行为

如果 profiling 显示主要耗时确实来自 `DOM creation / Recalculate Style / Layout / Paint`，再根据实际瓶颈选择方案：

- layout / paint 为主：优先评估 `content-visibility`
- React render / DOM creation 为主：再考虑真正的 list virtualization

因此这部分更适合作为独立性能改动，而不是和 center-column locator 的恢复逻辑一起修改。

## 后续优化

如果 profiling 后性能仍然不足，可以继续：

1. center column 定位稳定后暂停 subtree observer，只在 recovery 时重新启用
2. 如果 DSH 有可靠的 AppFrame lifecycle signal，用它替代 `#root` 全树监听
3. 将 1.5s interval 改为仅 recovery 状态下运行
4. 如果主要瓶颈是 Layout / Paint，尝试 `content-visibility`
5. 如果主要瓶颈是 React render / DOM creation，再做 session list virtualization

## 测试

新增 `tests/center-column-locator.spec.ts`，覆盖缓存复用、1.5s 复核、style/HMR 变化、节点替换和初次定位。

Refs #403
