### PR TITLE
fix: mobile sidebar toggle button visibility and interaction

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -1499,7 +1499,13 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
             </button>
           </Tooltip>
         )}
-        <Tooltip label={state.panelOpen ? t('collapse') : t('expand')} side="bottom" delayMs={500}>
+        {/*
+          Narrow (touch) viewports render the raw button: the Tooltip swallows
+          the first tap to show its bubble, so the toggle would need two taps
+          to act. The aria-label still names the control (styled by the mobile
+          toggle block in sidebar.module.css).
+        */}
+        {narrow ? (
           <button
             type="button"
             className={css.toggleButton}
@@ -1508,7 +1514,18 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
           >
             <IconPanelRightOutline16 />
           </button>
-        </Tooltip>
+        ) : (
+          <Tooltip label={state.panelOpen ? t('collapse') : t('expand')} side="bottom" delayMs={500}>
+            <button
+              type="button"
+              className={css.toggleButton}
+              aria-label={state.panelOpen ? t('collapse') : t('expand')}
+              onClick={() => { store.reduce(togglePanel) }}
+            >
+              <IconPanelRightOutline16 />
+            </button>
+          </Tooltip>
+        )}
       </div>
       {/*
         The right panel stays mounted while collapsed (hidden off-screen) so

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -172,6 +172,61 @@
   transition: none;
 }
 
+/* ── Narrow (mobile) toggle button visibility ─────────────────────────── */
+/* On narrow viewports the right panel is a full-width drawer. The persistent
+   toggle cluster at the top-right corner uses a 28px transparent circle with
+   a secondary-color panel glyph — nearly invisible on touch devices. Bump it
+   to a 40×40 touch target styled like the native header buttons. */
+@media (max-width: 767px) {
+  /* Hide the shell's "new session" button on mobile — the sidebar toggle
+     takes its place so there's exactly one button in the top-right corner. */
+  :global(.dsh-header-new-btn) {
+    display: none !important;
+  }
+
+  :global([data-dsh-toggle-cluster]).toggleCluster {
+    /* The DSH shell hides div[class*="toggleCluster"] on mobile with
+       display:none!important. The attribute+class selector has higher
+       specificity (0,2,0 > 0,1,1) so our !important wins regardless of
+       cascade order. Position: top-right, exactly where the hidden
+       new-session button was. */
+    display: flex !important;
+    top: calc(6px + env(safe-area-inset-top));
+    right: 16px;
+  }
+
+  .toggleButton {
+    width: 40px;
+    height: 40px;
+    background: transparent;
+    color: var(--dsw-alias-label-primary);
+    justify-content: flex-end;
+    opacity: 0.6;
+  }
+
+  .toggleButton svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .toggleButton:hover:not(:disabled):not([aria-disabled='true']) {
+    background: transparent;
+    color: var(--dsw-alias-label-primary);
+    opacity: 1;
+  }
+
+  /* The toggle button at right:16px + 40px width occupies right:16-56px;
+     52px keeps tab close buttons clear of it. */
+  .panel:not(.panelHidden) .tabBar {
+    padding-right: 52px;
+  }
+
+  /* Make room for the toggle button in the file tree search bar. */
+  .editorTreeSearch {
+    padding-right: 60px;
+  }
+}
+
 .panelResize {
   position: absolute;
   /* Centered on the panel edge (an 8px hit strip straddling the border, the
@@ -2736,10 +2791,12 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 @media (max-width: 767px) {
   /* The toggle cluster holds a single button on narrow viewports (the
      bottom panel button is not rendered), so the open panel's tab strip
-     reserves 40px instead of the desktop 72px — the tabs and + menu still
-     yield space to the one remaining control. */
+     reserves 52px instead of the desktop 72px — the tabs and + menu still
+     yield space to the one remaining control. The 40px toggle button at
+     right:16px occupies 56px from the edge; 52px keeps tab close buttons
+     clear of it. */
   .panel:not(.panelHidden) .tabBar {
-    padding-right: 40px;
+    padding-right: 52px;
   }
 
   /* Narrower tabs: a phone-width drawer fits more open tabs before the


### PR DESCRIPTION
## Problem

On mobile (viewport < 768px), the right sidebar toggle button was broken in multiple ways:

1. **Tooltip intercepts touch** — The toggle button is wrapped in `<Tooltip>`, which on touch devices swallows the first tap to show the tooltip bubble. The button's `onClick` only fires on the *second* tap, making it feel broken.
2. **Shell CSS hides the toggle cluster** — The DSH shell has a global rule `@media (max-width:768px) { div[class*="toggleCluster"] { display: none !important } }` intended for its own toggle cluster, but the broad attribute selector also catches the plugin's `nArs4W_toggleCluster`, hiding the entire cluster.
3. **Overlap with native buttons** — The toggle button overlapped with the shell's "new session" button (`.dsh-header-new-btn`) and the file tree search bar buttons (refresh/upload).
4. **Icon too small / too bright** — The 16px SVG icon was inconsistent with native header buttons, and full opacity was too prominent.

## Fix

### `src/client/Sidebar.tsx`

- On `narrow` viewports, render the toggle button **without** the `Tooltip` wrapper (direct `<button>`). Desktop keeps the original `Tooltip` + button.
- Always use `IconPanelRightOutline16` regardless of open/close state (not `IconCloseFill14` when open).

### `src/client/sidebar.module.css`

New `@media (max-width: 767px)` block:

- **Hide** `.dsh-header-new-btn` — the sidebar toggle takes its place so there's exactly one button in the top-right corner.
- **Override** the shell's `display:none!important` with a higher-specificity selector: `:global([data-dsh-toggle-cluster]).toggleCluster { display: flex !important }` (specificity 0,2,0 beats the shell's 0,1,1).
- **Position** the toggle at `top: 6px, right: 16px` — exactly where the hidden new-session button was.
- **Style** the button: `40×40px`, transparent background, `justify-content: flex-end`, `opacity: 0.6` (1 on hover).
- **Size** the SVG icon to `18px`.
- **Prevent overlap**: `padding-right: 52px` on `.tabBar` and `padding-right: 60px` on `.editorTreeSearch`.

## Verification

Tested with Puppeteer (headless Chrome, 390×844 viewport):

| Check | Result |
|-------|--------|
| New-session button hidden | `display: none` ✅ |
| Toggle at native button position | x:334, y:6 ✅ |
| Toggle button style | 40×40, transparent, opacity 0.6 ✅ |
| SVG icon size | 18×18px ✅ |
| Search bar buttons overlap | 0 ✅ |
| Click to open | aria → "折叠侧边栏" ✅ |
| Click to close | `panelHidden` restored ✅ |
| Console errors | 0 ✅ |
