### PR TITLE
fix(layout): prevent sidebar overlay in Desktop advanced mode

### DIFF
--- a/src/client/layout.css
+++ b/src/client/layout.css
@@ -35,6 +35,17 @@
     width var(--ds-transition-duration-slow) var(--ds-ease-in-out);
 }
 
+/* DSH Desktop 2.0.4 advanced mode installs its shell stylesheet at runtime
+   after plugins may already have loaded. Its `#root { width: 100% }` has the
+   same specificity as the generic rule above, so a later Desktop style can
+   re-expand the root while our margin-right remains active and make the
+   fixed sidebar cover the conversation. Scope the stronger width ownership
+   only to Desktop's explicit advanced-mode marker instead of using
+   !important or overriding every host shell. */
+body[data-dsh-desktop-mode="advanced"] #root {
+  width: calc(100% - var(--dsh-sidebar-width, 0px));
+}
+
 /* The AppFrame's center column, anchored by data attributes (see above).
    Composite selector: DSH 0.1.x versions name the center grid item
    `[data-pane="conversation"]`, while rc.8-era shells put a

--- a/tests/e2e/desktop-advanced-layout.e2e.ts
+++ b/tests/e2e/desktop-advanced-layout.e2e.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression lane for #459: DSH Desktop 2.0.4 advanced mode installs its
+ * desktop-owned stylesheet at runtime and includes `#root { width: 100% }`.
+ * If that later rule wins over better-sidebar's layout push, #root keeps the
+ * full viewport width while retaining margin-right, so the fixed sidebar
+ * overlays the conversation instead of making the shell give up space.
+ *
+ * This test deliberately appends the Desktop rule AFTER the plugin has
+ * mounted, matching the failure-producing cascade order without requiring an
+ * Electron/Windows runner. The advanced-mode body marker is part of the
+ * Desktop shell contract and lets the compatibility override stay scoped.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { PAGE_URL, createHostApi, hostRpc } from './host'
+
+const WORKSPACE_PATH = process.env.DSH_E2E_DESKTOP_ADVANCED_WORKSPACE
+  ?? join(tmpdir(), 'dsh-e2e-desktop-advanced-workspace')
+
+let api: APIRequestContext
+
+async function seedSession(): Promise<void> {
+  mkdirSync(WORKSPACE_PATH, { recursive: true })
+  writeFileSync(join(WORKSPACE_PATH, 'seed.txt'), 'desktop advanced layout lane\n')
+  const workspace = await hostRpc<{ workspace: { workspaceId: string } }>(
+    api,
+    'workspace.create',
+    { path: WORKSPACE_PATH },
+  )
+  await hostRpc(api, 'session.create', { workspaceId: workspace.value.workspace.workspaceId })
+}
+
+test.beforeAll(async () => {
+  api = await createHostApi()
+  await seedSession()
+})
+
+test.afterAll(async () => {
+  await api?.dispose()
+})
+
+test('Desktop advanced late root width cannot defeat the sidebar layout push (#459)', async ({ page }) => {
+  await page.goto(PAGE_URL, { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('#root > *')).not.toHaveCount(0, { timeout: 90_000 })
+
+  const sidebar = page.locator('[data-dsh-better-sidebar]')
+  await expect(sidebar).toBeAttached({ timeout: 90_000 })
+
+  // Keyless DSH boots may stack onboarding takeovers above the shell. Dismiss
+  // them using the same bounded loop as the other mount lanes before clicking
+  // the sidebar toggle.
+  try {
+    await expect
+      .poll(() => page.getByRole('button', { name: /^(Continue|Configure later)$/ }).count(), { timeout: 60_000 })
+      .toBeGreaterThan(0)
+  } catch {
+    console.warn('[e2e-desktop-advanced] no onboarding takeover appeared; proceeding')
+  }
+  for (let round = 0; round < 8; round++) {
+    let dismissed = false
+    for (const name of ['Continue', 'Configure later']) {
+      const button = page.getByRole('button', { name, exact: true }).first()
+      if ((await button.count()) === 0) continue
+      try {
+        await button.click({ timeout: 4_000 })
+        dismissed = true
+        await page.waitForTimeout(800)
+      } catch {
+        // A higher takeover may mask this button; retry in the next round.
+      }
+    }
+    if (!dismissed) break
+  }
+
+  // Reproduce dsh-desktop v2.0.4 advanced-shell ordering: the shell marker is
+  // present and Desktop appends its owned stylesheet after plugin CSS. Keep
+  // the relevant margin rule too so the containing block matches the real
+  // Desktop stylesheet rather than relying on the web shell's body defaults.
+  await page.evaluate(() => {
+    document.body.dataset.dshDesktopMode = 'advanced'
+    const style = document.createElement('style')
+    style.dataset.testDesktopOwnedStyles = 'issue-459'
+    style.textContent = `
+      html, body, #root { width: 100%; height: 100%; }
+      body[data-dsh-desktop-mode="advanced"] { margin: 0; background: transparent !important; }
+    `
+    document.head.appendChild(style)
+  })
+
+  const expandButton = sidebar.getByRole('button', { name: 'Expand sidebar' })
+  await expect(expandButton).toHaveCount(1)
+  await expandButton.click()
+
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.style.getPropertyValue('--dsh-sidebar-width')))
+    .not.toBe('')
+
+  // The push animates, so poll the geometric invariant instead of sleeping for
+  // an assumed transition duration. Under the broken cascade rootWidth stays
+  // equal to viewportWidth while marginRight becomes non-zero, making this
+  // invariant remain false after the transition has settled.
+  await expect
+    .poll(() => page.evaluate(() => {
+      const root = document.querySelector<HTMLElement>('#root')
+      if (root === null) return false
+      const rect = root.getBoundingClientRect()
+      const marginRight = Number.parseFloat(getComputedStyle(root).marginRight)
+      if (!Number.isFinite(marginRight) || marginRight <= 0) return false
+      return Math.abs(rect.width - (window.innerWidth - marginRight)) <= 2
+    }), { timeout: 30_000 })
+    .toBe(true)
+
+  const geometry = await page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>('#root')
+    if (root === null) throw new Error('#root missing')
+    const rect = root.getBoundingClientRect()
+    const marginRight = Number.parseFloat(getComputedStyle(root).marginRight)
+    return {
+      viewportWidth: window.innerWidth,
+      rootWidth: rect.width,
+      marginRight,
+      miss: Math.abs(rect.width - (window.innerWidth - marginRight)),
+    }
+  })
+
+  expect(geometry.marginRight, 'expanded sidebar must apply a non-zero layout push').toBeGreaterThan(0)
+  expect(geometry.rootWidth, 'Desktop advanced root must actually surrender horizontal space').toBeLessThan(geometry.viewportWidth)
+  expect(
+    geometry.miss,
+    `root must shrink by the sidebar width: viewport=${geometry.viewportWidth}, root=${geometry.rootWidth}, margin=${geometry.marginRight}`,
+  ).toBeLessThanOrEqual(2)
+})


### PR DESCRIPTION
## 修改内容

修复 #459 中 dsh-desktop 2.0.4 增强模式下右侧栏覆盖对话区域的问题。

根因是 better-sidebar 和 Desktop advanced shell 同时控制 `#root` 的宽度：

- better-sidebar 使用 `width: calc(100% - var(--dsh-sidebar-width))` 推挤主界面；
- dsh-desktop 2.0.4 advanced 模式会在运行时后插入 `#root { width: 100% }`；
- 两条规则原本 specificity 相同，因此最终结果依赖样式加载顺序，Desktop 后加载时会重新把 `#root` 撑到 100%，导致 sidebar 覆盖 conversation。

本次修改针对 Desktop 明确提供的 advanced mode marker 增加更高 specificity 的宽度规则：

- 仅在 `data-dsh-desktop-mode="advanced"` 下处理该布局冲突。
- 不使用 `!important`，不影响普通 Web 环境，不影响 compatibility 模式。

同时增加 Playwright 回归测试，模拟 dsh-desktop 2.0.4 在插件 CSS 加载后动态插入 `#root { width: 100% }` 的真实 cascade 顺序，并验证展开侧栏后 `#root` 仍会正确缩小 sidebar width。

Closes #459