### PR TITLE
fix(editor): keep reading position across preview/edit switches

### DIFF
--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -13,7 +13,7 @@
  * the FileViewerProps toolbar callbacks so the host's path-input header
  * renders the controls instead.
  */
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import clsx from 'clsx'
 import { EditorState } from '@codemirror/state'
@@ -52,6 +52,14 @@ type ViewMode = 'preview' | 'edit'
  */
 export const HTML_IFRAME_SANDBOX = 'allow-scripts allow-popups allow-downloads allow-modals'
 
+/** Per-file preview scroll memory. Module-level so it survives viewer
+ *  remounts: the save-then-switch-to-preview reload (EditorHost #215 case B)
+ *  rebuilds the whole TextEditor instance, and without this the preview
+ *  would remount at the top. Keyed by session + path; a fresh entry reads 0
+ *  (new file opens at the top), re-opens/toggles restore the last position. */
+const previewScrollMemory = new Map<string, number>()
+const previewScrollKey = (scope: { sessionId: string }, path: string): string => `${scope.sessionId}::${path}`
+
 export function TextEditor(props: FileViewerProps) {
   const { ctx, scope, path, viewerId, content, truncated } = props
   const [mode, setMode] = useState<ViewMode>('preview')
@@ -70,6 +78,22 @@ export function TextEditor(props: FileViewerProps) {
   const mdRef = useRef<HTMLDivElement>(null)
   const markdown = viewerId === 'markdown'
   const html = viewerId === 'html'
+  /** Preview scroll position across the preview<->edit toggle. The preview
+   *  container re-mounts on every mode switch and its scrollTop lives on that
+   *  element, so capture it on scroll and restore after each remount. Seeded
+   *  from the module-level per-file memory so a full viewer rebuild
+   *  (save-then-switch-to-preview reload) also keeps the position. */
+  const previewScrollRef = useRef(previewScrollMemory.get(previewScrollKey(scope, path)) ?? 0)
+  /** True while a programmatic restore is in flight; raw scroll events caused
+   *  by the restore (or by the browser clamping a collapsed reload container
+   *  to 0) must not overwrite the remembered position. */
+  const restoringRef = useRef(false)
+  /** Preview-side handoff data for the preview -> edit switch: the text at the
+   *  top of the preview viewport (best-effort) plus the scroll ratio. Captured
+   *  throttled on preview scroll; consumed when entering edit mode so the
+   *  editor opens where the reader was instead of at the file top. */
+  const previewSyncRef = useRef<{ text: string | null; ratio: number }>({ text: null, ratio: 0 })
+  const anchorThrottleRef = useRef(false)
 
   /**
    * The floating "add to conversation" popup (viewport-anchored; null =
@@ -94,6 +118,12 @@ export function TextEditor(props: FileViewerProps) {
     setSaveState('idle')
     selectionPopup.hide()
   }, [content])
+
+  // A different file switches the remembered preview scroll position to that
+  // file's own entry (first open: none, so the preview starts at the top).
+  useEffect(() => {
+    previewScrollRef.current = previewScrollMemory.get(previewScrollKey(scope, path)) ?? 0
+  }, [path])
 
   // Create the CodeMirror editor once the content is loaded. The view owns
   // the document; React only tracks dirty state through the update listener
@@ -203,10 +233,49 @@ export function TextEditor(props: FileViewerProps) {
 
   // The editor may have been display:none while previewing; re-measure when
   // it becomes visible again (CodeMirror sizes itself on reveal). A mode
-  // flip also invalidates any anchored selection popup.
+  // flip also invalidates any anchored selection popup. When entering edit
+  // from a scrolled preview, the editor opens where the reader was: the line
+  // mapped from the text anchored at the preview viewport top (or, failing a
+  // unique text match, the proportional scroll position).
   useEffect(() => {
     selectionPopup.hide()
-    if (mode === 'edit') viewRef.current?.requestMeasure()
+    if (mode !== 'edit') return
+    const view = viewRef.current
+    if (view === null) return
+    const sync = previewSyncRef.current
+    if (!markdown) return
+    const doc = view.state.doc
+    let target: number | undefined
+    if (sync.text !== null) {
+      const lines = linesOfSelection(mdText, sync.text)
+      if (lines !== null) target = doc.line(Math.min(lines.start, doc.lines)).from
+    }
+    // ratio === 1 means the reader was at the very bottom (e.g. the last
+    // block's text is a repeated filler line that linesOfSelection rejects
+    // as ambiguous) — it must still land the editor at the bottom.
+    if (target === undefined && sync.ratio > 0 && sync.ratio <= 1) {
+      target = Math.max(1, Math.min(doc.length - 1, Math.round(doc.length * sync.ratio)))
+    }
+    if (target === undefined) return
+    // Position the editor by writing its OWN scroller directly (after a fresh
+    // measure) instead of CodeMirror's scrollIntoView: that path walks every
+    // scrollable ancestor — and even the window when the browser is zoomed
+    // (visualViewport < innerHeight) — to reveal the target, which dragged
+    // the whole sidebar up when the reader was at the very end of the
+    // document. A plain scrollTop write on the editor scroller can never
+    // touch anything outside the editor.
+    view.requestMeasure()
+    view.dispatch({ selection: { anchor: target } })
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const block = view.lineBlockAt(target)
+        view.scrollDOM.scrollTop = Math.max(0, block.top - 8)
+        // Force CodeMirror to re-measure and re-render its virtualized
+        // viewport at the NEW scroll position (its scroll-observer is async
+        // and can lag a direct write).
+        view.requestMeasure()
+      })
+    })
   }, [mode])
 
   // Snapshot the live document into the draft whenever the preview needs
@@ -243,6 +312,23 @@ export function TextEditor(props: FileViewerProps) {
    *  lookup. All preview renderers share this source so plain Markdown,
    *  Mermaid, and documents containing raw HTML behave consistently. */
   const previewMdText = markdown ? markdownPreviewSource(mdText) : mdText
+
+  // Re-apply the remembered preview scroll position whenever the preview
+  // container mounts or its content changes (mode flip back to preview, or a
+  // same-file reload — e.g. the save-then-switch-to-preview reload — which
+  // temporarily collapses the container and clamps scrollTop to 0). Restored
+  // in a before-paint layout effect so the user never sees the top flash.
+  useLayoutEffect(() => {
+    if (mode !== 'preview') return
+    const el = mdRef.current
+    if (el === null || previewScrollRef.current <= 0) return
+    if (el.scrollHeight <= el.clientHeight) return
+    if (el.scrollTop === previewScrollRef.current) return
+    restoringRef.current = true
+    el.scrollTop = previewScrollRef.current
+    requestAnimationFrame(() => { restoringRef.current = false })
+  }, [mode, previewMdText])
+
   /** The preview source with local image destinations rewritten to absolute
    *  media URLs (see {@link rewriteLocalImageUrls}). */
   const previewText = markdown
@@ -396,7 +482,36 @@ export function TextEditor(props: FileViewerProps) {
           className={css.editorMd}
           ref={mdRef}
           onMouseUp={handlePreviewMouseUp}
-          onScroll={selectionPopup.hide}
+          onScroll={(event) => {
+            const el = event.currentTarget
+            if (!restoringRef.current && el.scrollHeight > el.clientHeight) {
+              previewScrollRef.current = el.scrollTop
+              previewScrollMemory.set(previewScrollKey(scope, path), el.scrollTop)
+            }
+            if (!anchorThrottleRef.current) {
+              anchorThrottleRef.current = true
+              setTimeout(() => { anchorThrottleRef.current = false }, 120)
+              const ratio = el.scrollHeight > el.clientHeight
+                ? el.scrollTop / (el.scrollHeight - el.clientHeight)
+                : 0
+              // The first block below the viewport's top edge, chosen with
+              // layout coordinates (caretRangeFromPoint needs an in-viewport
+              // point and returns null when the panel is partially off-screen).
+              // Its text is the anchor the editor syncs to on preview -> edit.
+              let text: string | null = null
+              const base = el.getBoundingClientRect()
+              const blocks = el.querySelectorAll('h1, h2, h3, h4, h5, h6, p, li')
+              for (const block of blocks) {
+                if (block.getBoundingClientRect().top - base.top + el.scrollTop >= el.scrollTop - 2) {
+                  const t = (block.textContent ?? '').replace(/[ \t\r\n]+/g, ' ').trim()
+                  if (t.length >= 8) text = t
+                  break
+                }
+              }
+              previewSyncRef.current = { text, ratio }
+            }
+            selectionPopup.hide()
+          }}
         >
           {/* The fence copy-button labels must come from this plugin's own
               dictionary: the DSH MarkdownText/CodeBlock are cordis-free and


### PR DESCRIPTION
Closes 466

## 概述 / Summary

修复 markdown 文件在「预览 / 编辑」模式切换时**阅读位置丢失**的问题（双向）：

1. **编辑 → 预览**：预览滚动到中部/底部后，切编辑修改并保存再切回预览，预览**回到文件顶部**（用户观测为「先恢复、瞬间又跳回顶部」）。
2. **预览 → 编辑**：从滚动中的预览切入编辑，编辑器**停在文件顶部**，不跟随预览阅读位置。
3. **（修复中发现的衍生 bug）预览在文档末尾 → 切编辑**：CodeMirror 的 `scrollIntoView` 会滚动**所有可滚动祖先**（浏览器缩放时甚至滚动整个 window），导致整个侧边栏往上漂移约 1/6 页高、顶部按钮离开屏幕。

## 根因 / Root cause

1. **预览回顶**：预览容器 `.editorMd` 是条件渲染（`markdown && mode === 'preview'`），每次模式切换卸载重建，`scrollTop` 直接丢失；更关键的是「保存后切回预览」走 #215 的「切预览自动重载」路径——`EditorHost` 经 `reloadSeq` 重跑 load（loading 占位），**整个 `TextEditor` 组件卸载重建**（实测 CodeMirror DOM 节点在重载后重建），组件内 `ref` 记忆随之蒸发——所以组件内修复无效，滚动记忆必须提升到**模块级**（按 `session + path` 键控，即 #236 提出过的 scroll-memory 思路）。
2. **编辑器不跟随**：预览 → 编辑没有任何「预览阅读位置 → 编辑器位置」的映射，编辑器打开在默认（顶部）位置。
3. **侧边栏漂移**：`EditorView.scrollIntoView(target)` 内部（`scrollRectIntoView` 祖先遍历 + 缩放浏览器时的 `line.dom.scrollIntoView({block:'nearest'})` 分支）会滚动编辑器之外的所有滚动祖先来「确保目标可见」；文档末尾时编辑器内部滚无可滚，于是去滚侧边栏/window。

## 改动 / Changes（仅 `src/client/TextEditor.tsx`）

- **滚动记忆（模块级）**：`previewScrollMemory = Map<'sessionId::path', scrollTop>`；预览滚动时写入，预览容器挂载 / 内容变化（`[mode, mdText]`）时在 **before-paint `useLayoutEffect`** 中恢复，用户看不到回顶闪烁；恢复期间的滚动事件用 `restoringRef` 守卫，防止浏览器塌缩（reload 时容器高度为 0、scrollTop 被强制归 0）污染记忆。
- **预览 → 编辑锚点同步**：预览滚动时（节流 120ms）用**布局坐标**捕获视口顶部第一个块元素（h1-h6/p/li）的文本作锚点 + 滚动比例（`caretRangeFromPoint` 在面板半离屏时返回 null，故弃用）；切入编辑模式后用既有 `linesOfSelection`（唯一命中才取）反查源行，再**直接写 `view.scrollDOM.scrollTop`**（`lineBlockAt` 计算 + 双 rAF 等首次 measure 完成后执行 + 写后显式 `requestMeasure()` 让 CM 在**新滚动位置**重渲染虚拟化视口）。
- **绝不使用 `EditorView.scrollIntoView`**：直接写编辑器自身 scroller 从根本上杜绝祖先（含 window）被滚动（漂移根因）；比例兜底条件改为 `0 < ratio <= 1`，**预览恰好在底端（ratio === 1）**且锚点文本重复（如每节相同的填充行，`linesOfSelection` 判为歧义返回 null）时也能落到底部。

## 验证 / Verification（Playwright 驱动真实 GUI，headless Chromium，连续 3 轮全绿）

填充文档：150 节 / preview `scrollHeight` ≈ 24700、底端 `scrollTop` ≈ 23870。

| 路径 | 修复前 | 修复后（3/3 轮） |
| --- | --- | --- |
| 滚到底 → 编辑（修改）→ 预览 | 0 | **23870 ✓** |
| 纯切换（无修改） | 0 | **23870 ✓** |
| 滚到底 → 编辑 → 保存 → 预览（#215 重载路径，用户场景） | 0 | **23870 ✓**，20×150ms 采样全程零闪回 |
| 预览滚到中部 (12000) → 切编辑 | 编辑器顶部 `## Section 001` | 编辑器定位到 **Section 065/070**（ratio 0.50 → 0.52）✓ |
| 预览在文档末尾 → 切编辑（漂移回归） | 侧边栏向上漂移 ~1/6 页 | 编辑器落在**底部**（`scrollTop == scrollHeight - clientHeight`），`window.scrollY 0→0`、顶部按钮位置不变、**无任何祖先容器滚动** ✓ |

另有截图与复现脚本（本地），可提供。

## 关联 / Related

- #215 （切预览自动重载）— Bug 1 的直接触发路径
- #236 （已关闭未合并：查找栏/滚动记忆，动机与本问题一致）
- Issue 466