### PR TITLE
fix(files): auto-refresh the tree on window focus and via a dispatchable event

### DIFF
--- a/src/client/TreePanel.tsx
+++ b/src/client/TreePanel.tsx
@@ -72,6 +72,21 @@ export function TreePanel(props: {
   const [results, setResults] = useState<{ matches: string[]; truncated: boolean } | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [refreshTick, setRefreshTick] = useState(0)
+
+  // The tree caches loaded directories per refresh tick, so content changed
+  // outside DSH (another editor, a sync tool) stays stale until the manual
+  // refresh click. Re-focusing the window bumps the tick automatically, and
+  // integrations can force a refresh by dispatching a bubbling
+  // `dsh-sidebar:refresh-files` event on `window`.
+  useEffect(() => {
+    const bump = (): void => { setRefreshTick(tick => tick + 1) }
+    window.addEventListener('focus', bump)
+    window.addEventListener('dsh-sidebar:refresh-files', bump)
+    return () => {
+      window.removeEventListener('focus', bump)
+      window.removeEventListener('dsh-sidebar:refresh-files', bump)
+    }
+  }, [])
   /** One-line upload status under the search row ('' hides the hint). */
   const [uploadStatus, setUploadStatus] = useState('')
   /** Whether the status line is a failure/cancel (error color, stays visible). */


### PR DESCRIPTION
## 问题

Files 树按 `refreshTick` 缓存已加载目录，目录内容在 DSH 之外变化后（其他编辑器保存、同步插件从远端拉取）界面一直显示旧内容，必须手动点刷新按钮。

## 修复

在 `TreePanel` 增加两个自动 bump `refreshTick` 的来源：

1. **window 重新聚焦**：切回 DSH 时自动清缓存重拉，和磁盘状态对齐；
2. **自定义事件 `dsh-sidebar:refresh-files`**：外部插件在完成文件写入后可以 `window.dispatchEvent(new Event('dsh-sidebar:refresh-files'))` 主动触发刷新（事件不存在时零副作用）。

## 动机（真实场景）

[dsh-better-overleaf](https://github.com/Hoemr/dsh-better-overleaf)（Overleaf 双向同步插件）在 pull/push 之后文件落盘，但 Files 树仍显示旧内容；插件无法从外部触发刷新（`refreshTick` 是 TreePanel 局部 state）。这个事件约定让同步类插件可以接入，聚焦刷新则覆盖所有「外部修改后切回来」的场景。

## 验证

- `pnpm typecheck` 通过
- 手动：拉取 Overleaf 项目后派发事件，Files 树立即显示新文件；窗口切走改文件再切回，树自动更新

谢谢review！