### PR TITLE
fix(menu): flip overflowing DSH submenus left to stay in view (issue #490)

### DIFF
--- a/src/client/FileTree.tsx
+++ b/src/client/FileTree.tsx
@@ -37,6 +37,7 @@ import { relativeTo } from './paths.ts'
 import { t } from './locales.ts'
 import type { SidebarStore } from './state.ts'
 import { uploadItemsFromDrop, uploadItemsFromFiles, type UploadItem } from './upload.ts'
+import { useMenuSubmenuFit } from './menu-submenu-fit.ts'
 import css from './sidebar.module.css'
 
 interface LevelData {
@@ -165,6 +166,11 @@ export function FileTree(props: {
   /** Context-menu "upload here" target directory. */
   const pendingUploadDir = useRef<string | undefined>(undefined)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  // #490: the DSH Menu primitive never clamps submenus to the viewport, so the
+  // "open with" submenu falls off the right edge when the tree (at the window's
+  // right edge) opens its menu there. While the menu is open, flip overflowing
+  // submenus left — see menu-submenu-fit.ts.
+  useMenuSubmenuFit(rowMenu !== null)
 
   /** Reset all drag state (drop landed, the drag left, or a new drag begins). */
   const resetDrop = (): void => {

--- a/src/client/TabBar.tsx
+++ b/src/client/TabBar.tsx
@@ -18,6 +18,7 @@ import { isAgentTabId } from './state.ts'
 import { isPinnedVirtualTab } from './pinned.ts'
 import { IconPinOutline16 } from './icons.tsx'
 import { t } from './locales.ts'
+import { useMenuSubmenuFit } from './menu-submenu-fit.ts'
 import css from './sidebar.module.css'
 
 /** One + menu option. */
@@ -95,6 +96,10 @@ export function TabBar(props: {
   // The context target's index in the render-time tab snapshot; -1 when the
   // tab disappeared since the menu opened (the menu hides then).
   const tabMenuIndex = tabMenu === null ? -1 : tabs.findIndex(tab => tab.id === tabMenu.tabId)
+  // #490: the DSH Menu primitive never clamps submenus to the viewport, so the
+  // terminal "Pin ▸" submenu can fall off the right edge. Flip overflowing
+  // submenus left while the tab menu is open — see menu-submenu-fit.ts.
+  useMenuSubmenuFit(tabMenu !== null && tabMenuIndex >= 0)
 
   // Middle-click close: the press target is recorded on middle mousedown
   // (preventDefaulted to disarm Chrome's middle-click autoscroll — its

--- a/src/client/menu-submenu-fit.css
+++ b/src/client/menu-submenu-fit.css
@@ -1,0 +1,21 @@
+/*
+ * Submenu viewport flip for #490 — consumed via `data-dshb-submenu-side` set
+ * by src/client/menu-submenu-fit.ts on the DSH Menu primitive's submenu card.
+ * The primitive always opens submenus to the right of their parent row
+ * (`.submenu { left: calc(100% + 10px) }`); when the fit logic measured an
+ * overflow it flips the card LEFT, and this rule moves the hover bridge
+ * (`::before` — the primitive's gap-crossing hit area) to the opposite gap so
+ * moving the pointer diagonally does not close the submenu.
+ *
+ * Geometry only — no colors/tokens (skin contract untouched). `!important`
+ * keeps the correction independent of host stylesheet load order.
+ */
+[data-dshb-submenu-side='left'] {
+  left: auto !important;
+  right: calc(100% + 10px) !important;
+}
+[data-dshb-submenu-side='left']::before {
+  left: auto !important;
+  right: -10px !important;
+  width: 10px;
+}

--- a/src/client/menu-submenu-fit.ts
+++ b/src/client/menu-submenu-fit.ts
@@ -1,0 +1,129 @@
+/**
+ * Viewport fit for DSH Menu submenus (fix for #490).
+ *
+ * The harness Menu primitive positions a submenu with pure CSS — always to
+ * the RIGHT of its parent row (`.submenu { left: calc(100% + 10px) }`) — and
+ * never clamps it to the viewport. The main list IS clamped, so when the list
+ * sits against the right edge (the Files panel is at the window's right edge)
+ * the submenu falls off-screen and becomes unclickable.
+ *
+ * DSH source is off-limits for the plugin, so this module applies the
+ * standard measure → flip → clamp correction (VS Code's menu positioner /
+ * floating-ui's flip+shift) from the outside: while a plugin-owned Menu is
+ * open, watch the portaled list for a nested `[role="menu"]` (the submenu),
+ * measure it, and flip it LEFT — margin-clamped — when it would overflow the
+ * viewport's right edge.
+ *
+ * The submenu is located through ARIA semantics (`role="menu"` nested inside
+ * a `[role="menu"]` list), never through the primitive's class names; the
+ * flip is expressed with the plugin's own `data-dshb-submenu-side` attribute
+ * (driving menu-submenu-fit.css) plus inline styles, so no DSH class names or
+ * stylesheet load order are depended on.
+ */
+import { useEffect } from 'react'
+import './menu-submenu-fit.css'
+
+/** The submenu gap mirrored from the primitive (`.submenu { left: calc(100% + 10px) }`). */
+export const SUBMENU_GAP = 10
+/** Safe viewport margin, mirrored from the primitive's portal MARGIN (12). */
+export const VIEWPORT_MARGIN = 12
+/** Attribute set on a flipped submenu (drives the [data-dshb-submenu-side] rules). */
+export const FLIP_ATTR = 'data-dshb-submenu-side'
+export const FLIP_LEFT = 'left'
+
+/**
+ * Pure flip decision: true when the right-anchored submenu would overflow the
+ * viewport's right edge AND flipping it left still clears the left edge. When
+ * both sides fail the submenu stays right-anchored (the host's own clamp keeps
+ * the main list consistent) — floating-ui's "no fallback side" behavior.
+ */
+export function shouldFlipSubmenu(
+  parentLeft: number,
+  parentRight: number,
+  submenuWidth: number,
+  viewportWidth: number,
+  margin: number = VIEWPORT_MARGIN,
+): boolean {
+  const rightAnchoredRight = parentRight + SUBMENU_GAP + submenuWidth
+  const flippedLeft = parentLeft - SUBMENU_GAP - submenuWidth
+  return rightAnchoredRight > viewportWidth - margin && flippedLeft >= margin
+}
+
+/** The submenus currently rendered: `[role="menu"]` lists nested inside another `[role="menu"]`. */
+function nestedSubmenus(root: ParentNode): Element[] {
+  const found = new Set<Element>()
+  for (const outer of root.querySelectorAll('[role="menu"]')) {
+    for (const inner of outer.querySelectorAll('[role="menu"]')) found.add(inner)
+  }
+  return [...found]
+}
+
+/** Apply the fit correction to one submenu element. */
+export function fitSubmenuElement(el: Element, viewportWidth: number, viewportHeight: number): void {
+  const menuEl = el as HTMLElement
+  const parent = el.parentElement
+  if (parent === null) return
+  const parentRect = parent.getBoundingClientRect()
+  const width = el.getBoundingClientRect().width
+  if (shouldFlipSubmenu(parentRect.left, parentRect.right, width, viewportWidth)) {
+    menuEl.setAttribute(FLIP_ATTR, FLIP_LEFT)
+  } else {
+    menuEl.removeAttribute(FLIP_ATTR)
+  }
+  // Re-measure after the side flip so the vertical math sees the final position.
+  const rect = el.getBoundingClientRect()
+  // Vertical hardening: the submenu is bottom-anchored (`bottom: -4px`), so
+  // only its TOP can collide with the viewport. Cap the height first (the card
+  // scrolls), then re-anchor to the top edge when it would still start above
+  // the margin.
+  const maxHeight = viewportHeight - VIEWPORT_MARGIN * 2
+  if (rect.height > maxHeight) {
+    menuEl.style.maxHeight = `${maxHeight}px`
+    menuEl.style.overflowY = 'auto'
+  } else {
+    menuEl.style.maxHeight = ''
+    menuEl.style.overflowY = ''
+  }
+  if (rect.top < VIEWPORT_MARGIN) {
+    menuEl.style.bottom = 'auto'
+    menuEl.style.top = `${VIEWPORT_MARGIN - parentRect.top}px`
+  } else {
+    menuEl.style.top = ''
+    menuEl.style.bottom = ''
+  }
+}
+
+/**
+ * Keep every submenu of a plugin-owned Menu inside the viewport while `open`.
+ * The primitive remounts a submenu on each hover of its parent row, so the
+ * observer re-measures on every mount; resize/scroll re-place the main list,
+ * so the fit follows them too. The whole body is observed (the portaled list
+ * lives in `document.body`), coalesced to one pass per animation frame.
+ */
+export function useMenuSubmenuFit(open: boolean): void {
+  useEffect(() => {
+    if (!open) return
+    let raf = 0
+    const apply = (): void => {
+      raf = 0
+      const vw = window.innerWidth
+      const vh = window.innerHeight
+      for (const sub of nestedSubmenus(document.body)) fitSubmenuElement(sub, vw, vh)
+    }
+    const schedule = (): void => {
+      if (raf !== 0) return
+      raf = requestAnimationFrame(apply)
+    }
+    const mo = new MutationObserver(schedule)
+    mo.observe(document.body, { childList: true, subtree: true })
+    window.addEventListener('resize', schedule)
+    window.addEventListener('scroll', schedule, true)
+    schedule()
+    return () => {
+      if (raf !== 0) cancelAnimationFrame(raf)
+      mo.disconnect()
+      window.removeEventListener('resize', schedule)
+      window.removeEventListener('scroll', schedule, true)
+    }
+  }, [open])
+}

--- a/tests/e2e/mount.e2e.ts
+++ b/tests/e2e/mount.e2e.ts
@@ -548,6 +548,55 @@ test('plugin mounts into the DSH shell and survives a built-in tab sweep', async
   await page.screenshot({ path: 'test-results/mount-final.png' })
 })
 
+test('file tree "Open with" submenu stays inside the viewport (issue #490)', async ({ page }) => {
+  // #490 regression lane: the DSH Menu primitive opens submenus purely via CSS
+  // (always to the right of the parent row) and never clamps them to the
+  // viewport, so a context menu at the window's right edge used to spill its
+  // submenu off-screen and unclickable. The plugin's fit
+  // (src/client/menu-submenu-fit.ts) flips overflowing submenus left; this
+  // lane right-clicks a file row near the sidebar's right edge and requires
+  // the nested "Open with" submenu to stay fully in-view.
+  const sidebar = page.locator('[data-dsh-better-sidebar]')
+  await expect(sidebar).toBeAttached({ timeout: 90_000 })
+  // Re-activate the seeded Files explorer (later lanes leave other tabs
+  // active; its tree is the only one visible while it is active).
+  const filesTab = sidebar.locator('[title="Files"][draggable="true"]').first()
+  await expect(filesTab, 'the seeded files-window home tab must be in the tab strip').toHaveCount(1)
+  await filesTab.click()
+  // The tree row — NOT the same-named editor tab (tab-strip tabs carry
+  // draggable="true"; explorer rows do not).
+  const fileRow = sidebar.locator(`[role="button"][title$="${SEEDED_FILE}"]:visible:not([draggable])`)
+  await expect(fileRow, `the seeded "${SEEDED_FILE}" file must appear in the files window's tree`).toHaveCount(1, { timeout: 30_000 })
+  // Right-click near the row's RIGHT edge: the row menu opens at the cursor,
+  // and the sidebar hugs the window's right edge — the exact geometry that
+  // used to push the submenu off-screen. (x-60 stays clear of the
+  // hover-revealed @-reference button at the row's far right.)
+  const rowBox = await fileRow.boundingBox()
+  expect(rowBox, 'the seeded file row must have a measurable box').not.toBeNull()
+  await fileRow.click({ button: 'right', position: { x: Math.max(rowBox!.width - 60, 8), y: 8 } })
+  const openWith = page.getByRole('menuitem', { name: /open with/i })
+  await expect(openWith, 'the row menu must offer the "Open with" submenu parent').toBeVisible({ timeout: 10_000 })
+  await openWith.hover()
+  const submenu = page.locator('[role="menu"] [role="menu"]').filter({ hasText: /File Manager|VS Code/ })
+  await expect(submenu, 'hovering "Open with" must mount the nested submenu').toBeVisible({ timeout: 10_000 })
+  // The fit runs on the frame after the submenu mounts; poll until the whole
+  // card is inside the viewport (the bug left it hanging off the right edge).
+  const viewport = page.viewportSize() ?? { width: 1280, height: 720 }
+  await expect
+    .poll(
+      async () => {
+        const box = await submenu.boundingBox()
+        if (box === null) return false
+        return box.x >= 0 && box.y >= 0 && box.x + box.width <= viewport.width && box.y + box.height <= viewport.height
+      },
+      { timeout: 5_000 },
+    )
+    .toBe(true)
+  // Leave the shell clean for the later lanes.
+  await page.keyboard.press('Escape')
+  await expect(openWith, 'Escape must close the row menu').not.toBeVisible()
+})
+
 test('conservative auto: URL stamps alone never modify the layout; plugin chrome carries the stable data attributes', async ({ page }) => {
   // The official DSH Desktop shell stamps every render URL with
   // dsh-desktop-mode / dsh-desktop-platform. Under the conservative AUTO

--- a/tests/menu-submenu-fit.spec.ts
+++ b/tests/menu-submenu-fit.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Submenu viewport fit (fix for #490).
+ *
+ * The DSH Menu primitive opens submenus purely via CSS (`left: calc(100% + 10px)`)
+ * with no viewport clamp, so a menu at the window's right edge spills its
+ * submenu off-screen and unclickable. The plugin's fit applies the standard
+ * measure → flip → clamp correction from the outside (see
+ * src/client/menu-submenu-fit.ts). These tests lock the pure flip decision and
+ * the DOM applier.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import {
+  FLIP_ATTR, FLIP_LEFT, fitSubmenuElement, shouldFlipSubmenu, useMenuSubmenuFit, VIEWPORT_MARGIN,
+} from '../src/client/menu-submenu-fit.ts'
+
+;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+
+const VW = 1600
+const VH = 900
+
+/** A jsdom-friendly rect mock (jsdom's getBoundingClientRect returns zeros). */
+function rect(left: number, right: number, top: number, bottom: number): DOMRect {
+  return {
+    left, right, top, bottom,
+    width: right - left,
+    height: bottom - top,
+    x: left, y: top,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+/** Mount a menu list + one submenu in body with the given geometry. */
+function mountSubmenu(
+  wrap: { left: number; right: number; top: number; bottom: number },
+  sub: { left: number; right: number; top: number; bottom: number },
+): { list: HTMLDivElement; wrap: HTMLDivElement; submenu: HTMLDivElement } {
+  const list = document.createElement('div')
+  list.setAttribute('role', 'menu')
+  const w = document.createElement('div')
+  const s = document.createElement('div')
+  s.setAttribute('role', 'menu')
+  w.appendChild(s)
+  list.appendChild(w)
+  document.body.appendChild(list)
+  w.getBoundingClientRect = () => rect(wrap.left, wrap.right, wrap.top, wrap.bottom)
+  s.getBoundingClientRect = () => rect(sub.left, sub.right, sub.top, sub.bottom)
+  return { list, wrap: w, submenu: s }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('shouldFlipSubmenu', () => {
+  it('keeps the submenu right-anchored when it fits', () => {
+    // Menu mid-screen: 400 + 10 gap + 170 wide = 580, comfortably inside.
+    expect(shouldFlipSubmenu(200, 400, 170, VW)).toBe(false)
+  })
+
+  it('flips left when the right edge would overflow', () => {
+    // Menu right-clamped: 1588 + 10 + 170 = 1768 > 1588; flipped left edge
+    // 1388 - 10 - 170 = 1208 still clears the 12px margin.
+    expect(shouldFlipSubmenu(1388, 1588, 170, VW)).toBe(true)
+  })
+
+  it('stays right-anchored when both sides fail (no fallback side)', () => {
+    // Narrow viewport: right overflows AND the flipped edge (-290) is off-screen.
+    expect(shouldFlipSubmenu(20, 200, 300, 400)).toBe(false)
+  })
+
+  it('does not flip at the exact boundary', () => {
+    // Right edge lands exactly on vw - margin: not strictly greater.
+    expect(shouldFlipSubmenu(200, 400, 170, 400 + 10 + 170 + VIEWPORT_MARGIN)).toBe(false)
+  })
+})
+
+describe('fitSubmenuElement', () => {
+  it('marks an overflowing submenu with the left-flip attribute', () => {
+    const { submenu } = mountSubmenu(
+      { left: 1388, right: 1588, top: 100, bottom: 200 },
+      { left: 1610, right: 1780, top: 100, bottom: 270 },
+    )
+    fitSubmenuElement(submenu, VW, VH)
+    expect(submenu.getAttribute(FLIP_ATTR)).toBe(FLIP_LEFT)
+  })
+
+  it('clears the flip when the submenu fits again', () => {
+    const { submenu } = mountSubmenu(
+      { left: 1388, right: 1588, top: 100, bottom: 200 },
+      { left: 1610, right: 1780, top: 100, bottom: 270 },
+    )
+    fitSubmenuElement(submenu, VW, VH)
+    expect(submenu.getAttribute(FLIP_ATTR)).toBe(FLIP_LEFT)
+    // The list moves mid-screen: the right-anchored submenu fits again.
+    submenu.parentElement!.getBoundingClientRect = () => rect(200, 400, 100, 200)
+    fitSubmenuElement(submenu, VW, VH)
+    expect(submenu.getAttribute(FLIP_ATTR)).toBeNull()
+  })
+
+  it('re-anchors to the top edge when the submenu would start above the margin', () => {
+    const { submenu } = mountSubmenu(
+      { left: 1388, right: 1588, top: 100, bottom: 200 },
+      { left: 1610, right: 1780, top: -20, bottom: 150 },
+    )
+    fitSubmenuElement(submenu, VW, VH)
+    expect(submenu.style.bottom).toBe('auto')
+    expect(submenu.style.top).toBe(`${VIEWPORT_MARGIN - 100}px`)
+  })
+
+  it('caps an over-tall submenu with a scroll region', () => {
+    const { submenu } = mountSubmenu(
+      { left: 1388, right: 1588, top: 100, bottom: 200 },
+      { left: 1610, right: 1780, top: -400, bottom: 500 }, // 900px tall
+    )
+    fitSubmenuElement(submenu, VW, VH)
+    expect(submenu.style.maxHeight).toBe(`${VH - VIEWPORT_MARGIN * 2}px`)
+    expect(submenu.style.overflowY).toBe('auto')
+  })
+})
+
+describe('useMenuSubmenuFit', () => {
+  it('flips a submenu that mounts while the menu is open, and stops after close', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    let root!: Root
+    const Comp = ({ open }: { open: boolean }) => { useMenuSubmenuFit(open); return null }
+    await act(async () => { root = createRoot(container); root.render(createElement(Comp, { open: true })) })
+
+    const { submenu } = mountSubmenu(
+      { left: 1388, right: 1588, top: 100, bottom: 200 },
+      { left: 1610, right: 1780, top: 100, bottom: 270 },
+    )
+    // The MutationObserver schedules a rAF pass; give it a frame.
+    await new Promise(resolve => setTimeout(resolve, 60))
+    expect(submenu.getAttribute(FLIP_ATTR)).toBe(FLIP_LEFT)
+
+    // Menu closes: the observer disconnects, later mounts stay untouched.
+    await act(async () => { root.render(createElement(Comp, { open: false })) })
+    const late = mountSubmenu(
+      { left: 1388, right: 1588, top: 100, bottom: 200 },
+      { left: 1610, right: 1780, top: 100, bottom: 270 },
+    )
+    await new Promise(resolve => setTimeout(resolve, 60))
+    expect(late.submenu.getAttribute(FLIP_ATTR)).toBeNull()
+
+    await act(async () => { root.unmount() })
+    container.remove()
+  })
+})


### PR DESCRIPTION
Fixes #490

## Problem

The DSH `Menu` primitive positions submenus purely via CSS — always to the right of the parent row (`.submenu { left: calc(100% + 10px) }`) — and never clamps them to the viewport. The main list **is** clamped, so when the context menu sits against the window's right edge (the Files panel), the "Open with ▸" submenu falls off-screen and becomes unclickable.

## Approach

Plugin-side **measure → flip → clamp** correction (`src/client/menu-submenu-fit.ts`), mirroring VS Code's menu positioner / floating-ui's flip+shift:

- While a plugin-owned `Menu` is open, a `MutationObserver` watches the portaled list for a nested `[role="menu"]` (the submenu — located through ARIA semantics, never DSH class names)
- On mount (the primitive remounts the submenu on each hover), measure it; if the right-anchored position would overflow the viewport's right edge, flip it LEFT (own `data-dshb-submenu-side` attribute + inline styles — no dependence on host stylesheet load order)
- The hover bridge (`::before`) moves to the opposite gap so diagonal pointer moves don't close the submenu
- Vertical hardening: caps over-tall submenus (scroll region) and re-anchors the top edge inside the viewport margin

Wired into both submenu sites: FileTree ("Open with") and TabBar ("Pin ▸").

## Tests

- `tests/menu-submenu-fit.spec.ts` — pure flip decision + DOM applier + hook lifecycle (9 tests)
- `tests/e2e/mount.e2e.ts` — regression lane: right-click a tree row near the sidebar's right edge, hover "Open with", assert the nested submenu's bounding box stays fully inside the viewport
- `pnpm typecheck` / `pnpm build` / unit suite green locally (only pre-existing Windows-environmental failures: symlink EPERM + git autocrlf CRLF, unrelated to this change)

Note: the root cause lives in the harness `Menu` primitive (verified identical across 0.1.1-rc.1 → alpha.3, documented in #490). This PR is the plugin-side fix; if the upstream primitive gains submenu viewport fitting, this correction can be dropped.
