### PR TITLE
feat: show the manual refresh button for toolbar-less viewers (pdf / image / binary)

### DIFF
--- a/src/client/EditorHost.tsx
+++ b/src/client/EditorHost.tsx
@@ -436,7 +436,13 @@ export function EditorHost(props: {
         {saveLabel !== '' && (
           <span className={clsx(css.editorStatus, toolbar?.saveState === 'failed' && css.editorStatusError)}>{saveLabel}</span>
         )}
-        {toolbar !== null && (
+        {/* Manual refresh is NOT toolbar-gated: viewers without a hoisted
+          toolbar (pdf / image / binary-download) see it too, so an on-disk
+          change to e.g. a PDF is one click away (issue #167 extends to every
+          file tab). The 'loading' pass unmounts the current viewer and the
+          fresh 'ready' pass remounts it, so even viewers that re-fetch by
+          path (PdfView) pick up the new bytes. */}
+        {!showEmpty && (
           <button
             type="button"
             className={css.iconButton}

--- a/tests/editor-refresh.spec.tsx
+++ b/tests/editor-refresh.spec.tsx
@@ -3,7 +3,9 @@
  * re-runs the load (A), returning from edit to preview reloads unless the
  * draft is dirty or the save failed (B), and a preview-mode save reloads on
  * the 'saved' edge (C). A mock viewer reports a hoisted toolbar so the host
- * chrome renders exactly like the real text editor.
+ * chrome renders exactly like the real text editor — and a toolbar-less
+ * viewer (pdf / image / binary-download) must see the same refresh button
+ * (D), since those previewers re-fetch on remount.
  */
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -32,6 +34,8 @@ function reads(): number {
 interface MockViewerProps {
   initialMode?: 'preview' | 'edit'
   dirty?: boolean
+  /** Report a hoisted toolbar (text-editor-like); false = pdf/image-like. */
+  reportToolbar?: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onToolbarState?: (state: any) => void
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,24 +43,26 @@ interface MockViewerProps {
 }
 
 /** A viewer that hoists a real toolbar (mode toggle + save state). */
-function MockTextViewer({ initialMode = 'preview', dirty = false, onToolbarState, onToolbarControls }: MockViewerProps) {
+function MockTextViewer({ initialMode = 'preview', dirty = false, reportToolbar = true, onToolbarState, onToolbarControls }: MockViewerProps) {
   const [mode, setMode] = useState(initialMode)
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'failed'>('idle')
   useEffect(() => {
-    onToolbarState?.({ modes: true, mode, dirty, editable: true, saveState })
-  }, [mode, saveState, dirty, onToolbarState])
+    if (reportToolbar) onToolbarState?.({ modes: true, mode, dirty, editable: true, saveState })
+  }, [mode, saveState, dirty, onToolbarState, reportToolbar])
   useEffect(() => {
-    onToolbarControls?.({
-      setMode,
-      // A synchronous save (saving then saved in one batch) drives the edge.
-      save: () => { setSaveState('saving'); setSaveState('saved') },
-    })
-    return () => { onToolbarControls?.(null) }
-  }, [onToolbarControls])
+    if (reportToolbar) {
+      onToolbarControls?.({
+        setMode,
+        // A synchronous save (saving then saved in one batch) drives the edge.
+        save: () => { setSaveState('saving'); setSaveState('saved') },
+      })
+      return () => { onToolbarControls?.(null) }
+    }
+  }, [onToolbarControls, reportToolbar])
   return createElement('div', null, `mock-${mode}`)
 }
 
-function setup(initialMode: 'preview' | 'edit' = 'preview', dirty = false): {
+function setup(initialMode: 'preview' | 'edit' = 'preview', dirty = false, reportToolbar = true): {
   ctx: Context
   fileTab: () => SidebarTab
 } {
@@ -71,6 +77,7 @@ function setup(initialMode: 'preview' | 'edit' = 'preview', dirty = false): {
     component: (props: FileViewerProps) => createElement(MockTextViewer, {
       initialMode,
       dirty,
+      reportToolbar,
       onToolbarState: props.onToolbarState,
       onToolbarControls: props.onToolbarControls,
     }),
@@ -180,6 +187,26 @@ describe('EditorHost refresh (issue #167)', () => {
       expect(reads()).toBe(1)
       const save = container.querySelector('button[aria-label="Save"]') as HTMLButtonElement
       click(save)
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(2)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('D: the refresh button renders for a viewer without a toolbar (pdf/image-like) and re-runs the load', async () => {
+    const { ctx, fileTab } = setup('preview', false, false)
+    const { container, unmount } = mount(ctx, fileTab)
+    try {
+      await act(async () => { await Promise.resolve() })
+      expect(reads()).toBe(1)
+      const refresh = refreshButton(container)
+      expect(refresh).not.toBeNull()
+      // No toolbar -> the mode toggle / save controls stay absent, only the
+      // refresh (and the tree toggle) remain in the header.
+      expect(Array.from(container.querySelectorAll('button'))
+        .some(button => button.textContent === 'Preview')).toBe(false)
+      click(refresh!)
       await act(async () => { await Promise.resolve() })
       expect(reads()).toBe(2)
     } finally {


### PR DESCRIPTION
## 背景

刷新按钮（#167）被 `toolbar !== null` 条件挡住：只有会向上报告 toolbar 的**文本类** viewer（markdown/html/code）能看到它。而 **pdf / image / binary-download** 这类预览器从不挂 toolbar，所以用户打开 PDF 标签、文件在磁盘上更新后，没有任何入口重新加载——这正是 #167 要解决的场景的漏网分支。

## 改动

`src/client/EditorHost.tsx`：把刷新按钮的门槛从 `toolbar !== null` 放宽为 `!showEmpty`（仅隐藏无路径的「文件主页」空态标签）。刷新机制本身无需改动——load effect 的 `'loading'` 阶段会卸载当前 viewer、`'ready'` 阶段重新挂载，因此像 `PdfView` 这类按 path 重新 fetch 的预览器会重建 blob URL、读到磁盘新字节（服务端 `/sidebar/file` 带 `cache-control: no-cache`，无需缓存破坏参数）。

脏草稿确认逻辑保持不变（`toolbar?.dirty`，仅文本编辑有 toolbar）。

## 测试

`tests/editor-refresh.spec.tsx` 新增用例 D：注册一个不报告 toolbar 的 viewer（模拟 pdf/image 形态），断言
1. 刷新按钮照常渲染；
2. 无 Preview/Save 控件；
3. 点击刷新后 load 重新执行（fsRead 调用数 1→2）。

全量 107 文件 / 1138 用例通过，`pnpm typecheck` 通过。