### PR TITLE
fix(client): intercept chat file opens via Remote

### DIFF
--- a/docs/plans/2026-08-22-open-with-menu-design.md
+++ b/docs/plans/2026-08-22-open-with-menu-design.md
@@ -9,7 +9,7 @@
 - 内置 **资源管理器（在文件管理器中显示）、VS Code、Cursor、Zed** 四个打开方式；每个子菜单行右侧有**图钉**，点击可把该方式固定为右键菜单的**顶层直达项**（再点取消固定）。
 - **远端 SSH**：设置中配置可选 SSH host（`user@host` 或 `~/.ssh/config` 别名）。非空即整个工作区视为远端：VSCode 系条目（VS Code / Cursor / 自定义且勾选"VSCode 系"）改用 `<scheme>://vscode-remote/ssh-remote+<host>/<path>` 打开；本地专用条目（资源管理器 / Zed / 非 VSCode 系自定义）从菜单隐藏。
 - **自定义编辑器**：名称 + URL 模板（`{path}` 占位符，如 `cursor://file/{path}`）+ 「是否 VSCode 系」开关；配置入口在**侧边栏设置 Files 卡片齿轮**（与既有 `editorExplorer` 下拉同一弹窗）。
-- 打开动作经宿主新路由 `POST /sidebar/api/open.external` 执行（argv 数组 spawn，无 shell 注入），浏览器模式与 DSH Desktop 行为一致；**不经过** `ctx.workspaces.openPath`（该入口已被 `wrapOpenPath` 劫持到侧边栏编辑器，见 `src/client/openpath-intercept.ts`）。
+- 打开动作经宿主新路由 `POST /sidebar/api/open.external` 执行（argv 数组 spawn，无 shell 注入），浏览器模式与 DSH Desktop 行为一致；**不经过**聊天文件打开入口 `ctx.remote.session.openWorkspacePath`（该入口由 `wrapOpenWorkspacePath` 接管到侧边栏编辑器，见 `src/client/openpath-intercept.ts`）。
 
 ## 调研结论（reuse gate）
 

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -34,10 +34,10 @@ import './layout.css'
 /** Services required before mounting (provided by the client runtime; the
  *  locale service backs the sidebar's copy — see locales.ts). `modules`
  *  (rc.8+) is the client module system the chunk loader resolves its
- *  externals through; `connection` (0.1.2-alpha.2+) is the Remote transport's
- *  recovery lifecycle the side chat's disconnect banner reads — Cordis guards
- *  service access without inject. */
-export const inject = ['slots', 'sessions', 'workspaces', 'locale', 'modules', 'connection']
+ *  externals through; `remote.session` owns the alpha.3 chat file-open funnel;
+ *  `connection` is the Remote transport's recovery lifecycle the side chat's
+ *  disconnect banner reads — Cordis guards service access without inject. */
+export const inject = ['slots', 'sessions', 'remote', 'remote.session', 'locale', 'modules', 'connection']
 
 /**
  * Error boundary over the sidebar tree (root scope): a render error in the

--- a/src/client/intercept.tsx
+++ b/src/client/intercept.tsx
@@ -11,7 +11,7 @@ import type { Context } from '../context-types.ts'
 import { firstLeaf, revealPaths, togglePanel, type SidebarStore } from './state.ts'
 import { t } from './locales.ts'
 import { resolveSidebarPath, selectProducedFiles } from './produced-files.ts'
-import { wrapOpenPath } from './openpath-intercept.ts'
+import { wrapOpenWorkspacePath } from './openpath-intercept.ts'
 import css from './sidebar.module.css'
 
 /** Open a file in the sidebar's editor (used by the intercepted row and the explorer). */
@@ -151,17 +151,18 @@ export function registerTurnTailInterception(ctx: Context, store: SidebarStore):
 }
 
 /**
- * Register the chat file-open interception: wraps `ctx.workspaces.openPath`
- * — the single funnel every chat-side file open goes through (tool-row path
- * links, the produced-files row, prose mentions) — so opens land in the
- * sidebar editor instead of the Host OS. The folder-reveal gesture ("Show in
- * folder" passes `'.'`) is the one exception: it is routed to the explorer.
+ * Register the chat file-open interception: wraps
+ * `ctx.remote.session.openWorkspacePath` — the DSH 0.1.2-alpha.3 funnel every
+ * chat-side file open goes through (tool-row path links, the produced-files
+ * row, prose mentions) — so opens land in the sidebar editor instead of the
+ * Host OS. The folder-reveal gesture ("Show in folder" passes `'.'`) is the
+ * one exception: it is routed to the explorer.
  * Gated by BOTH the `interceptOpenPath` pref and the editor tab's enable
  * switch; declined opens fall through to the original method. Returns the
  * disposer restoring the original (HMR-safe).
  */
 export function registerOpenPathInterception(ctx: Context, store: SidebarStore): () => void {
-  return wrapOpenPath(ctx.workspaces, {
+  return wrapOpenWorkspacePath(ctx.remote.session, {
     takeoverEnabled: () => !store.getSuspended()
       && store.getPrefs().interceptOpenPath !== false
       && store.getPrefs().tabsEnabled['editor'] !== false,

--- a/src/client/openpath-intercept.ts
+++ b/src/client/openpath-intercept.ts
@@ -1,21 +1,34 @@
 /**
- * Interception of the chat's file-open funnel. The client runtime's
- * `ctx.workspaces.openPath` is the SINGLE door every chat-side file open goes
- * through — ui-conversation's apply.ts resolves the path against the session
- * cwd and calls it for tool-row path links, the produced-files row, and
- * prose file mentions alike (verified against the DSH source:
- * `packages/client/ui-conversation/src/client/apply.ts` is the only
- * production caller). Wrapping that one method reroutes those opens into the
- * sidebar editor instead of the Host OS — no DSH modification needed.
+ * Interception of the chat's file-open funnel. DSH 0.1.2-alpha.3 resolves
+ * chat-side paths against the current session cwd, then calls
+ * `ctx.remote.session.openWorkspacePath({ path })` for tool-row path links,
+ * the produced-files row, and prose file mentions alike. Wrapping that one
+ * Remote method reroutes those opens into the sidebar editor instead of the
+ * Host OS — no DSH modification needed.
  *
  * The wrapper is dependency-free by design (no React / ui-primitives), so
  * the takeover logic is unit-testable and the file stays importable from the
  * test runtime.
  */
 
-/** The one service method the wrapper replaces (mirror of the runtime IWorkspaces). */
-export interface OpenPathService {
-  openPath(path: string): Promise<void>
+/** The request accepted by DSH's `session.openWorkspacePath` Remote method. */
+export interface OpenWorkspacePathRequest {
+  readonly path: string
+}
+
+/** The successful business value returned by the Host native opener. */
+export interface OpenWorkspacePathValue {
+  readonly opened: true
+}
+
+/** The generated Remote client envelope (carrier failures use the error arm). */
+export type OpenWorkspacePathResult =
+  | { readonly ok: true; readonly value: OpenWorkspacePathValue }
+  | { readonly ok: false; readonly error: unknown }
+
+/** The one Remote method the wrapper replaces. */
+export interface OpenWorkspacePathService {
+  openWorkspacePath(request: OpenWorkspacePathRequest): Promise<OpenWorkspacePathResult>
 }
 
 /** Per-call decisions the wrapper needs (wired to the store + ctx in the client half). */
@@ -48,32 +61,38 @@ export function isFolderRevealPath(path: string): boolean {
 }
 
 /**
- * Wrap `workspaces.openPath`: intercepted calls open the file in the sidebar
- * editor instead of the Host OS and resolve as success (the original's
- * callers ignore the result); anything that declines falls through to the
- * original method untouched. The one exception is the folder-reveal gesture,
- * which is routed to {@link OpenPathInterceptDeps.revealInExplorer} instead.
- * @param workspaces - the client workspaces service to wrap.
+ * Wrap `remote.session.openWorkspacePath`: intercepted calls open the file in
+ * the sidebar editor instead of the Host OS and resolve with the same success
+ * envelope the generated Remote client returns. Anything that declines falls
+ * through to the original method untouched. The one exception is the
+ * folder-reveal gesture, which is routed to
+ * {@link OpenPathInterceptDeps.revealInExplorer} instead.
+ * @param sessionRemote - the generated `remote.session` namespace to wrap.
  * @param deps - per-call takeover decisions.
  * @returns the disposer restoring the original method (HMR-safe).
  */
-export function wrapOpenPath(workspaces: OpenPathService, deps: OpenPathInterceptDeps): () => void {
-  // The RAW method reference (never a bound copy): restore must put back the
-  // exact original so a chain of wrappers (other plugins wrapping the same
-  // method) keeps working across disposals in any order.
-  const original = workspaces.openPath
-  workspaces.openPath = (path: string): Promise<void> => {
+export function wrapOpenWorkspacePath(
+  sessionRemote: OpenWorkspacePathService,
+  deps: OpenPathInterceptDeps,
+): () => void {
+  // Keep the raw method reference (rather than a bound copy), so disposal can
+  // restore the exact function that was present when this wrapper registered.
+  const original = sessionRemote.openWorkspacePath
+  sessionRemote.openWorkspacePath = (request): Promise<OpenWorkspacePathResult> => {
+    const { path } = request
     if (deps.takeoverEnabled()) {
       const sessionId = deps.currentSessionId()
       if (sessionId !== undefined) {
         if (isFolderRevealPath(path)) deps.revealInExplorer(path, sessionId)
         else deps.openInSidebar(path, sessionId)
-        return Promise.resolve()
+        // ui-chat reads `result.ok` before it considers the open complete. A
+        // void result would open the sidebar and then crash the caller.
+        return Promise.resolve({ ok: true, value: { opened: true } })
       }
     }
-    return original.call(workspaces, path)
+    return original.call(sessionRemote, request)
   }
   return () => {
-    workspaces.openPath = original
+    sessionRemote.openWorkspacePath = original
   }
 }

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -405,15 +405,19 @@ export interface SidebarConversation {
   }
 }
 
-/**
- * The client workspaces service face (mirror of the runtime IWorkspaces). Only
- * the chat's file-open funnel is touched: `openPath` hands an absolute path
- * to the Host OS's default application, and every chat-side file open
- * (tool rows, produced-files, prose mentions) funnels through it.
- */
-export interface SidebarWorkspacesService {
-  /** Open a filesystem path with the Host operating system's default application. */
-  openPath(path: string): Promise<void>
+/** Generated Remote result envelope used by the client gateway. */
+export type SidebarRemoteResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: unknown }
+
+/** The Session Remote slice used for chat-side native path opens. */
+export interface SidebarRemoteSessionService {
+  openWorkspacePath(request: { readonly path: string }): Promise<SidebarRemoteResult<{ readonly opened: true }>>
+}
+
+/** The generated client Remote namespace face used by this plugin. */
+export interface SidebarRemoteService {
+  readonly session: SidebarRemoteSessionService
 }
 
 /**
@@ -498,8 +502,8 @@ export interface SidebarContextShape {
   webRuntime: SidebarWebRuntime
   /** The client slot registry (register/inject). */
   slots: SidebarSlotsService
-  /** The client workspaces service face (file-open funnel). */
-  workspaces: SidebarWorkspacesService
+  /** Generated Remote namespaces (chat file-open funnel). */
+  remote: SidebarRemoteService
   /** The settings service face (prefs persistence + namespace reads). */
   settings: SidebarSettingsService
   /** The invariant registry face. */

--- a/src/prefs-shared.ts
+++ b/src/prefs-shared.ts
@@ -62,8 +62,8 @@ export interface SidebarPrefs {
   bottomPanelAutoTerminal: boolean
   /**
    * Whether chat-side file opens (tool-row path links, the produced-files
-   * row, prose file mentions — every path that funnels through the client
-   * runtime's `ctx.workspaces.openPath`) open in the sidebar editor instead
+   * row, prose file mentions — every path that funnels through
+   * `ctx.remote.session.openWorkspacePath`) open in the sidebar editor instead
    * of the Host OS's default application. On by default; the editor tab's
    * own enable switch gates it too (both must be on for the takeover).
    */

--- a/tests/openpath-intercept.spec.ts
+++ b/tests/openpath-intercept.spec.ts
@@ -1,148 +1,191 @@
 import { describe, expect, it } from 'vitest'
 import { registerOpenPathInterception } from '../src/client/intercept.tsx'
-import { wrapOpenPath, type OpenPathInterceptDeps, type OpenPathService } from '../src/client/openpath-intercept.ts'
+import {
+  wrapOpenWorkspacePath,
+  type OpenPathInterceptDeps,
+  type OpenWorkspacePathRequest,
+  type OpenWorkspacePathResult,
+  type OpenWorkspacePathService,
+} from '../src/client/openpath-intercept.ts'
 import { createSidebarStore } from '../src/client/state.ts'
 import type { Context } from '../src/context-types.ts'
 
 describe('open-path interception', () => {
-  /** A minimal fake of the workspaces.openPath service method. */
-  const service = (): OpenPathService & { calls: string[]; opened: string[] } => {
-    const fake = {
-      calls: [] as string[],
-      opened: [] as string[],
-      async openPath(path: string): Promise<void> {
-        this.calls.push(path)
-        this.opened.push(path)
+  /** A minimal fake of the generated remote.session namespace. */
+  const service = (
+    result: OpenWorkspacePathResult = { ok: true, value: { opened: true } },
+  ): OpenWorkspacePathService & { calls: OpenWorkspacePathRequest[] } => {
+    const calls: OpenWorkspacePathRequest[] = []
+    return {
+      calls,
+      async openWorkspacePath(request) {
+        calls.push(request)
+        return result
       },
     }
-    return fake
   }
 
   const deps = (overrides: Partial<OpenPathInterceptDeps> = {}): OpenPathInterceptDeps & {
     sidebar: string[]
+    revealed: string[]
   } => {
     const sidebar: string[] = []
+    const revealed: string[] = []
     return {
       sidebar,
+      revealed,
       takeoverEnabled: () => true,
       currentSessionId: () => 's1',
       openInSidebar: (path, sessionId) => { sidebar.push(`${sessionId}:${path}`) },
-      revealInExplorer: () => {},
+      revealInExplorer: (path, sessionId) => { revealed.push(`${sessionId}:${path}`) },
       ...overrides,
     }
   }
 
-  it('routes an intercepted open into the sidebar and resolves without the original call', async () => {
-    const ws = service()
+  it('routes an intercepted Remote open into the sidebar and returns a valid success envelope', async () => {
+    const remote = service()
     const d = deps()
-    const restore = wrapOpenPath(ws, d)
-    await expect(ws.openPath('/abs/a.ts')).resolves.toBeUndefined()
-    expect(ws.calls).toEqual([])
+    const restore = wrapOpenWorkspacePath(remote, d)
+    await expect(remote.openWorkspacePath({ path: '/abs/a.ts' }))
+      .resolves.toEqual({ ok: true, value: { opened: true } })
+    expect(remote.calls).toEqual([])
     expect(d.sidebar).toEqual(['s1:/abs/a.ts'])
     restore()
   })
 
-  it('falls through to the original when the takeover is disabled', async () => {
-    const ws = service()
+  it('falls through with the exact request when the takeover is disabled', async () => {
+    const remote = service()
     const d = deps({ takeoverEnabled: () => false })
-    const restore = wrapOpenPath(ws, d)
-    await ws.openPath('/abs/a.ts')
-    expect(ws.opened).toEqual(['/abs/a.ts'])
+    const restore = wrapOpenWorkspacePath(remote, d)
+    const request = { path: '/abs/a.ts' }
+    await expect(remote.openWorkspacePath(request))
+      .resolves.toEqual({ ok: true, value: { opened: true } })
+    expect(remote.calls).toHaveLength(1)
+    expect(remote.calls[0]).toBe(request)
     expect(d.sidebar).toEqual([])
     restore()
   })
 
   it('falls through when no session is current (nothing to scope the editor load to)', async () => {
-    const ws = service()
+    const remote = service()
     const d = deps({ currentSessionId: () => undefined })
-    const restore = wrapOpenPath(ws, d)
-    await ws.openPath('/abs/a.ts')
-    expect(ws.opened).toEqual(['/abs/a.ts'])
+    const restore = wrapOpenWorkspacePath(remote, d)
+    await remote.openWorkspacePath({ path: '/abs/a.ts' })
+    expect(remote.calls).toEqual([{ path: '/abs/a.ts' }])
     expect(d.sidebar).toEqual([])
     restore()
   })
 
-  it('passes the current session into the sidebar opener', async () => {
-    const ws = service()
+  it('reads the current session for every call', async () => {
+    const remote = service()
     let current = 's1'
     const d = deps({ currentSessionId: () => current })
-    const restore = wrapOpenPath(ws, d)
-    await ws.openPath('/abs/a.ts')
+    const restore = wrapOpenWorkspacePath(remote, d)
+    await remote.openWorkspacePath({ path: '/abs/a.ts' })
     current = 's2'
-    await ws.openPath('/abs/b.ts')
+    await remote.openWorkspacePath({ path: '/abs/b.ts' })
     expect(d.sidebar).toEqual(['s1:/abs/a.ts', 's2:/abs/b.ts'])
     restore()
   })
 
-  it('restores the original method on dispose (HMR-safe)', async () => {
-    const ws = service()
+  it('routes the show-in-folder gesture to the explorer and still returns Remote success', async () => {
+    const remote = service()
     const d = deps()
-    const original = ws.openPath
-    const restore = wrapOpenPath(ws, d)
-    expect(ws.openPath).not.toBe(original)
+    const restore = wrapOpenWorkspacePath(remote, d)
+    await expect(remote.openWorkspacePath({ path: '/workspace/.' }))
+      .resolves.toEqual({ ok: true, value: { opened: true } })
+    expect(d.sidebar).toEqual([])
+    expect(d.revealed).toEqual(['s1:/workspace/.'])
+    expect(remote.calls).toEqual([])
     restore()
-    expect(ws.openPath).toBe(original)
-    await ws.openPath('/abs/a.ts')
-    expect(ws.opened).toEqual(['/abs/a.ts'])
   })
 
-  it('treats a rejected promise like the original would (no swallowing)', async () => {
-    const failing: OpenPathService = {
-      async openPath() { throw new Error('host refused') },
+  it('restores the original Remote method on dispose (HMR-safe)', async () => {
+    const remote = service()
+    const d = deps()
+    const original = remote.openWorkspacePath
+    const restore = wrapOpenWorkspacePath(remote, d)
+    expect(remote.openWorkspacePath).not.toBe(original)
+    restore()
+    expect(remote.openWorkspacePath).toBe(original)
+    await remote.openWorkspacePath({ path: '/abs/a.ts' })
+    expect(remote.calls).toEqual([{ path: '/abs/a.ts' }])
+  })
+
+  it('preserves the original Remote failure envelope when interception declines', async () => {
+    const failure: OpenWorkspacePathResult = {
+      ok: false,
+      error: { code: 'gateway/internal', message: 'host refused', details: {} },
     }
+    const remote = service(failure)
     const d = deps({ takeoverEnabled: () => false })
-    const restore = wrapOpenPath(failing, d)
-    await expect(failing.openPath('/abs/a.ts')).rejects.toThrow('host refused')
+    const restore = wrapOpenWorkspacePath(remote, d)
+    await expect(remote.openWorkspacePath({ path: '/abs/a.ts' })).resolves.toBe(failure)
     restore()
   })
 })
 
 describe('open-path interception wiring', () => {
-  it('registerOpenPathInterception routes chat opens into the editor tab and restores on dispose', async () => {
-    // A realistic client-context fake: the sessions list feed (current + cwd),
-    // the workspaces funnel, and the sidebar service the editor goes through.
+  it('registerOpenPathInterception wraps the real alpha.3 Remote face and honors every gate', async () => {
     const opened: Array<Record<string, unknown>> = []
-    const funnel = { openPath: async (): Promise<void> => {} }
+    const calls: OpenWorkspacePathRequest[] = []
+    const sessionRemote: OpenWorkspacePathService = {
+      async openWorkspacePath(request) {
+        calls.push(request)
+        return { ok: true, value: { opened: true } }
+      },
+    }
+    let current: string | undefined = 's1'
     const ctx = {
       sessions: {
-        list: { getSnapshot: () => ({ current: 's1', byId: { s1: { cwd: '/w' } } }) },
+        list: { getSnapshot: () => ({ current, byId: { s1: { cwd: '/w' } } }) },
       },
-      workspaces: funnel,
-      betterSidebar: { openTab: (seed: unknown) => { opened.push(seed as Record<string, unknown>) } },
+      remote: { session: sessionRemote },
       get: (name: string) => name === 'betterSidebar'
         ? { openTab: (seed: unknown) => { opened.push(seed as Record<string, unknown>) } }
         : undefined,
     } as unknown as Context
     const store = createSidebarStore()
-    const original = ctx.workspaces.openPath
+    const original = ctx.remote.session.openWorkspacePath
     const restore = registerOpenPathInterception(ctx, store)
 
-    // Default prefs: the takeover routes the open into the sidebar editor
-    // with the session-scoped absolute path (chat already resolved it).
-    await ctx.workspaces.openPath('/w/src/a.ts')
+    // Default prefs: the takeover routes the already-resolved path into the
+    // editor and returns the Remote success envelope ui-chat reads.
+    await expect(ctx.remote.session.openWorkspacePath({ path: '/w/src/a.ts' }))
+      .resolves.toEqual({ ok: true, value: { opened: true } })
     expect(opened).toEqual([{
       type: 'editor',
       title: 'a.ts',
       path: '/w/src/a.ts',
       id: 'editor:/w/src/a.ts',
     }])
+    expect(calls).toEqual([])
 
-    // The interceptOpenPath pref off → the original funnel runs untouched.
+    // Preference off, editor disabled, external provider suspension, and no
+    // selected session all preserve the original Host RPC path.
     store.setPrefs({ ...store.getPrefs(), interceptOpenPath: false })
-    const calls: string[] = []
-    ctx.workspaces.openPath = async (path: string) => { calls.push(path) }
-    await ctx.workspaces.openPath('/w/src/b.ts')
-    expect(calls).toEqual(['/w/src/b.ts'])
+    await ctx.remote.session.openWorkspacePath({ path: '/w/src/b.ts' })
+
+    store.setPrefs({ ...store.getPrefs(), interceptOpenPath: true, tabsEnabled: { editor: false } })
+    await ctx.remote.session.openWorkspacePath({ path: '/w/src/c.ts' })
+
+    store.setPrefs({ ...store.getPrefs(), tabsEnabled: {} })
+    store.setSuspended(true)
+    await ctx.remote.session.openWorkspacePath({ path: '/w/src/d.ts' })
+
+    store.setSuspended(false)
+    current = undefined
+    await ctx.remote.session.openWorkspacePath({ path: '/w/src/e.ts' })
+
+    expect(calls).toEqual([
+      { path: '/w/src/b.ts' },
+      { path: '/w/src/c.ts' },
+      { path: '/w/src/d.ts' },
+      { path: '/w/src/e.ts' },
+    ])
     expect(opened).toHaveLength(1)
 
-    // The editor tab disabled → falls through too (an editor that cannot
-    // open must not swallow opens).
-    store.setPrefs({ ...store.getPrefs(), interceptOpenPath: true, tabsEnabled: { editor: false } })
-    await ctx.workspaces.openPath('/w/src/c.ts')
-    expect(calls).toEqual(['/w/src/b.ts', '/w/src/c.ts'])
-
-    // Disposal restores the raw original method (HMR-safe).
     restore()
-    expect(ctx.workspaces.openPath).toBe(original)
+    expect(ctx.remote.session.openWorkspacePath).toBe(original)
   })
 })


### PR DESCRIPTION
## Summary

- intercept DSH 0.1.2-alpha.3 chat file opens at `ctx.remote.session.openWorkspacePath` instead of the removed `ctx.workspaces.openPath` path
- preserve the generated Remote `{ ok, value/error }` contract for intercepted opens and keep native fallthrough unchanged
- declare the required `remote` / `remote.session` injections and replace the old fake-green regression coverage

## Validation

- `pnpm build`
- `pnpm typecheck`
- targeted Vitest regression group: 59/59 passed
- full `pnpm test`: 1126 passed, 12 skipped; 9 unrelated Windows environment failures (ConPTY, symlink/file locking, and CRLF assertions)
- `pnpm test:mount` could not start because local WSL returned `E_ACCESSDENIED` before the script ran

Fixes #500