### PR TITLE
fix: preserve Windows Explorer reveal selection

### DIFF
--- a/src/open-external.ts
+++ b/src/open-external.ts
@@ -28,11 +28,10 @@ export function revealCommand(path: string, platform: NodeJS.Platform = process.
   switch (platform) {
     case 'darwin':
       return { command: 'open', args: ['-R', path] }
-    // `explorer /select,<path>` — the classic "show in folder" incantation.
-    // Passed as separate argv entries (no shell); verify on Windows, with
-    // `cmd /c start "" explorer.exe "/select,<path>"` as the fallback.
+    // Explorer expects `/select,<path>` as one argument. Keep the spawn
+    // shell-free: a command shell would reinterpret valid path characters.
     case 'win32':
-      return { command: 'explorer.exe', args: ['/select,', path] }
+      return { command: 'explorer.exe', args: [`/select,${path}`] }
     default: {
       const parent = parentOf(path)
       return { command: 'xdg-open', args: [parent ?? path] }

--- a/tests/open-external.spec.ts
+++ b/tests/open-external.spec.ts
@@ -13,8 +13,11 @@ describe('revealCommand', () => {
     expect(revealCommand('/a/b.txt', 'darwin')).toEqual({ command: 'open', args: ['-R', '/a/b.txt'] })
   })
 
-  it('win32: `explorer /select,<path>` selects the file', () => {
-    expect(revealCommand('C:\\a\\b.txt', 'win32')).toEqual({ command: 'explorer.exe', args: ['/select,', 'C:\\a\\b.txt'] })
+  it('win32: passes /select,<path> as one shell-free Explorer argument', () => {
+    expect(revealCommand('C:\\work\\two words\\a.txt', 'win32')).toEqual({
+      command: 'explorer.exe',
+      args: ['/select,C:\\work\\two words\\a.txt'],
+    })
   })
 
   it('linux: `xdg-open` opens the containing directory (no common select protocol)', () => {


### PR DESCRIPTION
## Summary

- Pass the Windows Explorer select switch and target path as one `/select,<path>` argument.
- Preserve the shell-free process launch path so file names containing command-shell metacharacters remain data.
- Add a regression test using a path with spaces.

Closes #504

## Test plan

- `pnpm exec vitest run tests/open-external.spec.ts tests/market-manifest.spec.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` *(106 files pass; one pre-existing cleanup failure remains in `tests/fs-operations.spec.ts`)*
