### PR TITLE
feat(client): 收敛重复实现（api envelope/extOf/lineage/错误归一化）并删除死代码

### DIFF
--- a/src/client/SubagentView.tsx
+++ b/src/client/SubagentView.tsx
@@ -715,7 +715,7 @@ export function SubagentView(props: {
     try {
       sessions.openSubagent?.(address)
     } catch (error) {
-      console.warn('[dsh-better-sidebar] openSubagent failed:', error)
+      console.error('[dsh-better-sidebar] openSubagent failed:', error)
     }
   }, [sessions, onOpenChild])
 
@@ -725,7 +725,7 @@ export function SubagentView(props: {
     try {
       sessions.open?.(rootId)
     } catch (error) {
-      console.warn('[dsh-better-sidebar] open session failed:', error)
+      console.error('[dsh-better-sidebar] open session failed:', error)
     }
   }, [sessions, rootId])
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -129,6 +129,25 @@ export type TerminalDepsStatus =
     note?: string
   }
 
+/**
+ * Parse one `/sidebar` JSON response envelope into its value. A non-ok
+ * status, an unparseable body, or any shape other than `{ok: true, value}`
+ * surfaces as {@link SidebarApiError} carrying the wire code (falling back
+ * to the HTTP status). Shared by the JSON api route and the raw upload
+ * route, whose envelopes are identical.
+ */
+async function readEnvelope<T>(response: Response): Promise<T> {
+  const parsed: { ok?: boolean; value?: unknown; error?: { code?: string; message?: string } } | null
+    = await response.json().catch(() => null)
+  if (!response.ok || parsed === null || parsed.ok !== true || parsed.value === undefined) {
+    throw new SidebarApiError(
+      parsed?.error?.code ?? 'http',
+      parsed?.error?.message ?? `HTTP ${response.status}`,
+    )
+  }
+  return parsed.value as T
+}
+
 async function call<T>(method: string, payload: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
   let response: Response
   try {
@@ -141,15 +160,7 @@ async function call<T>(method: string, payload: Record<string, unknown>, signal?
   } catch (error) {
     throw new SidebarApiError('network', error instanceof Error ? error.message : String(error))
   }
-  const parsed: { ok?: boolean; value?: unknown; error?: { code?: string; message?: string } } | null
-    = await response.json().catch(() => null)
-  if (!response.ok || parsed === null || parsed.ok !== true || parsed.value === undefined) {
-    throw new SidebarApiError(
-      parsed?.error?.code ?? 'http',
-      parsed?.error?.message ?? `HTTP ${response.status}`,
-    )
-  }
-  return parsed.value as T
+  return readEnvelope<T>(response)
 }
 
 /**
@@ -180,15 +191,7 @@ async function fetchUpload<T>(
     if (error instanceof DOMException && error.name === 'AbortError') throw error
     throw new SidebarApiError('network', error instanceof Error ? error.message : String(error))
   }
-  const parsed: { ok?: boolean; value?: unknown; error?: { code?: string; message?: string } } | null
-    = await response.json().catch(() => null)
-  if (!response.ok || parsed === null || parsed.ok !== true || parsed.value === undefined) {
-    throw new SidebarApiError(
-      parsed?.error?.code ?? 'http',
-      parsed?.error?.message ?? `HTTP ${response.status}`,
-    )
-  }
-  return parsed.value as T
+  return readEnvelope<T>(response)
 }
 
 /** One request's session scope: the conversation id plus its cwd when known. */

--- a/src/client/changes/GitLens.tsx
+++ b/src/client/changes/GitLens.tsx
@@ -64,6 +64,12 @@ function refNames(refs: string): string[] {
   )]
 }
 
+/** One thrown value as display text (every error banner/row here normalizes
+ *  through this so non-Error rejections never render as '[object Object]'). */
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason)
+}
+
 /** The pending destructive action (discard / revert / cherry-pick), gated by a confirm modal. */
 interface ConfirmState {
   title: string
@@ -157,7 +163,7 @@ export function GitLens(props: GitLensProps) {
       setLogEnded(logResult.length < LOG_BATCH)
     } catch (reason) {
       if (options.generation === refreshGeneration.current) {
-        setError(reason instanceof Error ? reason.message : String(reason))
+        setError(errorMessage(reason))
       }
     } finally {
       if (options.loading && options.generation === refreshGeneration.current) setLoading(false)
@@ -219,7 +225,7 @@ export function GitLens(props: GitLensProps) {
       await refreshTarget(target, { loading: !silent, generation })
     } catch (reason) {
       if (generation === refreshGeneration.current) {
-        setError(reason instanceof Error ? reason.message : String(reason))
+        setError(errorMessage(reason))
         if (!silent) setLoading(false)
       }
     } finally {
@@ -289,7 +295,7 @@ export function GitLens(props: GitLensProps) {
       if (next.length < LOG_BATCH) setLogEnded(true)
     } catch (reason) {
       if (generation === refreshGeneration.current && target === chosenPathRef.current) {
-        setCommitError(`${t('historyLoadError')}: ${reason instanceof Error ? reason.message : String(reason)}`)
+        setCommitError(`${t('historyLoadError')}: ${errorMessage(reason)}`)
       }
     } finally {
       if (generation === refreshGeneration.current && target === chosenPathRef.current) setLogLoadingMore(false)
@@ -355,7 +361,7 @@ export function GitLens(props: GitLensProps) {
       setCommitMsg('')
       await refresh()
     } catch (reason) {
-      setCommitError(reason instanceof Error ? reason.message : String(reason))
+      setCommitError(errorMessage(reason))
     } finally {
       setBusy(false)
     }
@@ -369,7 +375,7 @@ export function GitLens(props: GitLensProps) {
       await api.gitCheckout(gitScope, branch, selectedWorktree)
       await refresh()
     } catch (reason) {
-      setCommitError(`${t('checkoutError')}: ${reason instanceof Error ? reason.message : String(reason)}`)
+      setCommitError(`${t('checkoutError')}: ${errorMessage(reason)}`)
     } finally {
       setBusy(false)
     }
@@ -384,7 +390,7 @@ export function GitLens(props: GitLensProps) {
         await confirmState.onConfirm()
         await refresh()
       } catch (reason) {
-        setCommitError(reason instanceof Error ? reason.message : String(reason))
+        setCommitError(errorMessage(reason))
       } finally {
         setBusy(false)
       }

--- a/src/client/lang.ts
+++ b/src/client/lang.ts
@@ -48,14 +48,12 @@ import { pascal } from '@codemirror/legacy-modes/mode/pascal'
 import { vb } from '@codemirror/legacy-modes/mode/vb'
 import { vhdl } from '@codemirror/legacy-modes/mode/vhdl'
 import { stex } from '@codemirror/legacy-modes/mode/stex'
+import { extOf } from './paths.ts'
 
-/** The lowercased file extension of a path ('' when none). */
-export function extOf(path: string): string {
-  const at = path.lastIndexOf('.')
-  if (at === -1) return ''
-  const base = path.slice(at + 1).toLowerCase()
-  return base.includes('/') || base.includes('\\') ? '' : base
-}
+// Re-exported for the established import surface (tests import extOf from
+// this module); the implementation lives in the dependency-free paths.ts so
+// core-bundle modules can share it without pulling the CodeMirror packages.
+export { extOf }
 
 /** Language key for an extension, or null for plain text. Pure (tested). */
 export function languageKeyForExt(ext: string): string | null {

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -70,3 +70,16 @@ export function baseName(path: string): string {
   const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
   return at === -1 ? path : path.slice(at + 1)
 }
+
+/**
+ * The lowercased file extension of a path ('' when none). The dot must sit
+ * inside the last segment — a dot in a directory name is not an extension.
+ * Shared by the editor language mapping (lang.ts) and the viewer registry's
+ * extension matching (service.ts), which both live in the core bundle.
+ */
+export function extOf(path: string): string {
+  const at = path.lastIndexOf('.')
+  if (at === -1) return ''
+  const base = path.slice(at + 1).toLowerCase()
+  return base.includes('/') || base.includes('\\') ? '' : base
+}

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -27,6 +27,7 @@ import {
   type SidebarSnapshot, type SidebarState, type SidebarStore, type SidebarTab,
 } from './state.ts'
 import { isNarrowWidth } from './breakpoints.ts'
+import { extOf } from './paths.ts'
 import type { SessionScope } from './api.ts'
 import type { SidebarPrefs } from '../prefs-shared.ts'
 
@@ -427,14 +428,6 @@ export interface BetterSidebarService {
   openFile(scope: SessionScope, path: string, title?: string): void
 }
 
-/** Extract the lowercase extension without leading dot from a path. */
-function extOfPath(path: string): string {
-  const at = path.lastIndexOf('.')
-  if (at === -1) return ''
-  const base = path.slice(at + 1).toLowerCase()
-  return base.includes('/') || base.includes('\\') ? '' : base
-}
-
 /** The file name of a path (both separators). */
 function baseNameOf(path: string): string {
   const at = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
@@ -571,7 +564,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
   const isViewerEnabled = (id: string): boolean => store.getPrefs().viewersEnabled[id] !== false
 
   const matchFileViewer = (path: string, head?: Uint8Array): FileViewerDescriptor | undefined => {
-    const ext = extOfPath(path)
+    const ext = extOf(path)
     // Single pass in priority order (descending; stable for equal
     // priorities — insertion order). Each descriptor gets first refusal in
     // its own turn: `detect` (when head bytes are available) beats its own

--- a/src/client/subagent-detect.ts
+++ b/src/client/subagent-detect.ts
@@ -9,23 +9,20 @@
  * - {@link countSubagentDescendants}: uninterrupted subagent-origin lineage
  *   totals (mirror of the official `indexSubagentDescendants` over the
  *   plugin's own summary rows).
+ *
+ * The lineage walks themselves ({@link isSideThreadSummary}, {@link
+ * rootAncestor}, {@link countSubagentDescendants}) live in
+ * ./subagent-lineage.ts — the single shared walk implementation — and are
+ * re-exported below for their established import sites.
  */
 import type {
   SidebarSessionList,
-  SidebarSessionSummary,
   SidebarSubagentCatalog,
 } from '../context-types.ts'
-import { SIDE_LABEL_PREFIX } from '../sidechat-core.ts'
+import { countSubagentDescendants, isSideThreadSummary, rootAncestor } from './subagent-lineage.ts'
 
-/**
- * Side Chat threads ride the subagent origin (main-list hiding + the RPC
- * ownership fence) but they are NOT subagent topology: they carry the
- * durable 'Side: ' label and live as sidebar tabs. Excluding them here
- * keeps the auto-open trigger and the Subagent page counts clean.
- */
-export function isSideThreadSummary(summary: SidebarSessionSummary): boolean {
-  return summary.origin === 'subagent' && summary.displayTitle.startsWith(SIDE_LABEL_PREFIX)
-}
+export { countSubagentDescendants, isSideThreadSummary, rootAncestor }
+export type { SubagentDescendantTotals } from './subagent-lineage.ts'
 
 /** Count the direct subagent children of one session (durable `origin` rows). */
 export function directSubagentCount(
@@ -38,28 +35,6 @@ export function directSubagentCount(
       && !isSideThreadSummary(summary)) count += 1
   }
   return count
-}
-
-/**
- * The main agent of the current session's tree: walk the durable parent
- * chain upward until the first non-subagent session. The Subagent page shows
- * THIS root's full topology regardless of how deep the current selection is
- * (a session whose row is still hydrating, or a broken chain, degrades to
- * the session itself).
- */
-export function rootAncestor(
-  byId: SidebarSessionList['byId'],
-  sessionId: string | undefined,
-): string | undefined {
-  if (sessionId === undefined) return undefined
-  const seen = new Set<string>()
-  let current: SidebarSessionSummary | undefined = byId[sessionId]
-  while (current !== undefined && current.origin === 'subagent'
-    && current.parentId !== undefined && !seen.has(current.id)) {
-    seen.add(current.id)
-    current = byId[current.parentId]
-  }
-  return current?.id ?? sessionId
 }
 
 /**
@@ -100,38 +75,4 @@ export function detectNewDirectSubagent(
 ): boolean {
   return directSubagentCount(prev.byId, sessionId) === 0
     && directSubagentCount(next.byId, sessionId) > 0
-}
-
-/** Descendant totals of one session through an uninterrupted subagent-origin chain. */
-export interface SubagentDescendantTotals {
-  count: number
-  runningCount: number
-}
-
-/**
- * Index every subagent descendant under each ancestor it reaches through an
- * uninterrupted subagent-origin chain (same semantics as the official
- * `indexSubagentDescendants`; cycles fail soft).
- */
-export function countSubagentDescendants(
-  byId: SidebarSessionList['byId'],
-  sessionId: string,
-): SubagentDescendantTotals {
-  const totals: SubagentDescendantTotals = { count: 0, runningCount: 0 }
-  for (const descendant of Object.values(byId)) {
-    if (descendant.origin !== 'subagent' || isSideThreadSummary(descendant)) continue
-    const seen = new Set<string>()
-    let current: SidebarSessionSummary | undefined = descendant
-    while (current?.origin === 'subagent' && current.parentId !== undefined
-      && !seen.has(current.id)) {
-      seen.add(current.id)
-      if (current.parentId === sessionId) {
-        totals.count += 1
-        if (descendant.running === true) totals.runningCount += 1
-        break
-      }
-      current = byId[current.parentId]
-    }
-  }
-  return totals
 }

--- a/src/client/subagent-jobs.ts
+++ b/src/client/subagent-jobs.ts
@@ -8,11 +8,11 @@
  */
 import type {
   SidebarSessionList,
-  SidebarSessionSummary,
   SidebarJobStatus,
   SidebarJobView,
 } from '../context-types.ts'
 import type { CopyKey } from './locales.ts'
+import { treeSessionIds } from './subagent-lineage.ts'
 
 /** One row of the jobs section: the job plus its owning session's title. */
 export interface TreeJob {
@@ -26,36 +26,10 @@ export function isJobLive(job: SidebarJobView): boolean {
   return job.status === 'running' || job.status === 'stopping'
 }
 
-/**
- * Every session id of the topology tree rooted at `rootId` (the root plus
- * each session whose uninterrupted subagent-origin chain reaches it — same
- * lineage semantics as {@link countSubagentDescendants}; cycles fail soft).
- * Sessions outside the tree (orphans, other trees) are excluded, so the
- * jobs section never shows foreign work.
- */
-export function treeSessionIds(
-  byId: SidebarSessionList['byId'],
-  rootId: string | undefined,
-): Set<string> {
-  const ids = new Set<string>()
-  if (rootId === undefined) return ids
-  for (const summary of Object.values(byId)) {
-    const seen = new Set<string>()
-    let current: SidebarSessionSummary | undefined = summary
-    let reachesRoot = false
-    while (current !== undefined && !seen.has(current.id)) {
-      seen.add(current.id)
-      if (current.id === rootId) {
-        reachesRoot = true
-        break
-      }
-      if (current.origin !== 'subagent' || current.parentId === undefined) break
-      current = byId[current.parentId]
-    }
-    if (reachesRoot) ids.add(summary.id)
-  }
-  return ids
-}
+// The lineage walk itself lives in ./subagent-lineage.ts (the single shared
+// subagent-origin chain implementation); re-exported for the established
+// import sites of this module.
+export { treeSessionIds }
 
 /**
  * Whether a NEW background job appeared for one session between two

--- a/src/client/subagent-lineage.ts
+++ b/src/client/subagent-lineage.ts
@@ -1,0 +1,131 @@
+/**
+ * The shared subagent-lineage walks over the sessions list feed (structural
+ * mirror world — no runtime imports). Every public walk here answers a
+ * topology question by following the DURABLE subagent-origin chain upward
+ * (child → parent → …); one private generator ({@link subagentOriginChain})
+ * is the single implementation of that walk, seen-set guarded so cycles fail
+ * soft (the walk just stops; nothing throws).
+ *
+ * subagent-detect.ts and subagent-jobs.ts re-export these for their
+ * established import sites — the auto-activation triggers and the Subagent
+ * page both consume them through the original module paths.
+ */
+import type { SidebarSessionList, SidebarSessionSummary } from '../context-types.ts'
+import { SIDE_LABEL_PREFIX } from '../sidechat-core.ts'
+
+/**
+ * Side Chat threads ride the subagent origin (main-list hiding + the RPC
+ * ownership fence) but they are NOT subagent topology: they carry the
+ * durable 'Side: ' label and live as sidebar tabs. Excluding them here
+ * keeps the auto-open trigger and the Subagent page counts clean.
+ */
+export function isSideThreadSummary(summary: SidebarSessionSummary): boolean {
+  return summary.origin === 'subagent' && summary.displayTitle.startsWith(SIDE_LABEL_PREFIX)
+}
+
+/**
+ * Yield `start`'s uninterrupted subagent-origin chain upward: each summary
+ * while it is a subagent with a known parent, then its parent row, and so
+ * on. A revisited id ends the walk (cycles fail soft); the row that BREAKS
+ * the chain — the first non-subagent ancestor, or a parent id with no row —
+ * is deliberately NOT yielded: callers observe it through where the walk
+ * stopped (the row after the last yielded one is `byId[last.parentId]`).
+ */
+function* subagentOriginChain(
+  byId: SidebarSessionList['byId'],
+  start: SidebarSessionSummary,
+): Generator<SidebarSessionSummary> {
+  const seen = new Set<string>()
+  let current: SidebarSessionSummary | undefined = start
+  while (current?.origin === 'subagent' && current.parentId !== undefined && !seen.has(current.id)) {
+    seen.add(current.id)
+    yield current
+    current = byId[current.parentId]
+  }
+}
+
+/**
+ * The main agent of the current session's tree: walk the durable parent
+ * chain upward until the first non-subagent session. The Subagent page shows
+ * THIS root's full topology regardless of how deep the current selection is
+ * (a session whose row is still hydrating, or a broken chain, degrades to
+ * the session itself).
+ */
+export function rootAncestor(
+  byId: SidebarSessionList['byId'],
+  sessionId: string | undefined,
+): string | undefined {
+  if (sessionId === undefined) return undefined
+  const start = byId[sessionId]
+  // A hydrating (or unknown) row degrades to the session itself.
+  if (start === undefined) return sessionId
+  let last: SidebarSessionSummary | undefined
+  for (const node of subagentOriginChain(byId, start)) last = node
+  if (last === undefined) return start.id
+  // The walk stopped one row past the last chain node: that parent row is
+  // the root (still missing from the feed → the session itself). Every
+  // yielded node carries a parent id (the generator's walk condition).
+  return byId[last.parentId!]?.id ?? sessionId
+}
+
+/** Descendant totals of one session through an uninterrupted subagent-origin chain. */
+export interface SubagentDescendantTotals {
+  count: number
+  runningCount: number
+}
+
+/**
+ * Index every subagent descendant under each ancestor it reaches through an
+ * uninterrupted subagent-origin chain (same semantics as the official
+ * `indexSubagentDescendants`; cycles fail soft).
+ */
+export function countSubagentDescendants(
+  byId: SidebarSessionList['byId'],
+  sessionId: string,
+): SubagentDescendantTotals {
+  const totals: SubagentDescendantTotals = { count: 0, runningCount: 0 }
+  for (const descendant of Object.values(byId)) {
+    if (descendant.origin !== 'subagent' || isSideThreadSummary(descendant)) continue
+    for (const node of subagentOriginChain(byId, descendant)) {
+      if (node.parentId === sessionId) {
+        totals.count += 1
+        if (descendant.running === true) totals.runningCount += 1
+        break
+      }
+    }
+  }
+  return totals
+}
+
+/**
+ * Every session id of the topology tree rooted at `rootId` (the root plus
+ * each session whose uninterrupted subagent-origin chain reaches it — same
+ * lineage semantics as {@link countSubagentDescendants}; cycles fail soft).
+ * Sessions outside the tree (orphans, other trees) are excluded, so the
+ * jobs section never shows foreign work.
+ */
+export function treeSessionIds(
+  byId: SidebarSessionList['byId'],
+  rootId: string | undefined,
+): Set<string> {
+  const ids = new Set<string>()
+  // A root with no row in the feed cannot be reached by walking: only real
+  // rows anchor tree membership (a parent pointer naming a hydrating root
+  // does not pull the orphaned branch into the tree).
+  if (rootId === undefined || byId[rootId] === undefined) return ids
+  for (const summary of Object.values(byId)) {
+    // The root row itself belongs to its own tree even though it is not a
+    // subagent (it is usually the main agent).
+    if (summary.id === rootId) {
+      ids.add(summary.id)
+      continue
+    }
+    for (const node of subagentOriginChain(byId, summary)) {
+      if (node.parentId === rootId) {
+        ids.add(summary.id)
+        break
+      }
+    }
+  }
+  return ids
+}

--- a/src/sidechat-core.ts
+++ b/src/sidechat-core.ts
@@ -245,11 +245,6 @@ export function buildSidechatInheritance(events: readonly SidechatLogEvent[]): S
   return { seed, snapshot: null }
 }
 
-/** The seed half of {@link buildSidechatInheritance} (test convenience). */
-export function sidechatSeed(events: readonly SidechatLogEvent[]): SeedEvent[] {
-  return buildSidechatInheritance(events).seed
-}
-
 /**
  * Structured text snapshot of the parent's OPEN turn (from its `turn/start`
  * to the log tail): the accumulated assistant/reasoning output verbatim


### PR DESCRIPTION
## 概述

行为不变的纯重构流（仅 SubagentView 两处日志级别按计划 warn→error 对齐）：六项去重中的四项落地为 4 个 commit，收敛五处重复实现并删除一处死代码。**tests/ 零改动**（无断言修改），既有测试全部原样通过。

## 各项 before/after

### 1. api envelope 解析收敛（`857646e`）
- **before**：`src/client/api.ts` 的 `call()` 与 `fetchUpload()` 各持一份逐字相同的 envelope 解析（`response.json().catch(() => null)` + `!ok || parsed === null || parsed.ok !== true || parsed.value === undefined` 判断 + 同款 `SidebarApiError` 构造）。
- **after**：私有 `readEnvelope<T>(response)` 一份实现，两处 `return readEnvelope<T>(response)`。判断顺序、`parsed?.error?.code ?? 'http'` / `HTTP <status>` 回退逐字保留。

### 2. 取扩展名双实现收敛（`857646e`）
- **before**：`lang.ts` 的 `extOf` 与 `service.ts` 模块私有的 `extOfPath` 函数体相同。
- **after**：实现迁至零依赖的 `paths.ts`；`lang.ts` re-export `extOf` 保持既有导入面（`tests/file-types.spec.ts` 从 lang.ts 导入）；`service.ts` 删除 `extOfPath`，`matchFileViewer` 改用 `extOf`。
- **方向论证**：`service.ts → lang.ts` 不可行——lang.ts 携带全部 `@codemirror/*` 依赖且只经 editor 懒加载 chunk 进入浏览器，core bundle 静态引用会把 CodeMirror 拉进核心包（违反懒加载 chunk 约束）；反向（lang→service）会把整个 service 内联进 editor chunk。故落位基础模块 `paths.ts`。**构建产物已验证**：`client.js` / `client-registry.js` 中 codemirror 引用为 0，`client-editor.js` 不变。

### 3. lineage 遍历收敛（`69cc801`）
- **before**：`rootAncestor` / `countSubagentDescendants`（subagent-detect.ts）与 `treeSessionIds`（subagent-jobs.ts）三份「沿 subagent-origin 链上行 + seen 防环 fail-soft」walk。
- **after**：新模块 `src/client/subagent-lineage.ts` 持有唯一核心生成器 `subagentOriginChain()`（seen 防环，仅在节点为 subagent 且有 parent 时前行）；三函数迁入并基于它重写；`isSideThreadSummary` 一并迁入（`countSubagentDescendants` 依赖它，避免 detect↔lineage 循环依赖）；subagent-detect.ts / subagent-jobs.ts re-export 全部迁出符号——**既有 import 调用点零变化**。
- **语义等价性论证**（逐函数，含 fail-soft 边界）：
  - `rootAncestor`：链为空 → `start.id`（原循环条件不满足时返回 `current?.id`，同一行）；链非空 → `byId[末节点.parentId]?.id ?? sessionId`（原循环退出时 `current` 恰为该行；断链/父行缺失回退 `sessionId` 不变；环路径下两者同在 seen 处截止，返回同一行）。
  - `countSubagentDescendants`：生成器在 `seen.add` 后 yield，消费方判 `parentId === sessionId` 即 break——与原循环体判断顺序一致；`descendant.running` 判定与 side-thread 过滤位置不变。
  - `treeSessionIds`：原实现的成员判定是「上行 walk 访问到的某行 id === rootId」，访问集恒为 byId 中真实存在的行，故根行缺失时提前返回空集等价；根行自身（通常非 subagent）经 `summary.id === rootId` 特判入集（对应原首轮访问判定）；其余行经「链节点 parentId === rootId」判定，与「上行走到 id === rootId 的行」指向同一行（链节点斜上一步的 next 行）。
- **与背景描述的偏差（按实际证据处置）**：`directSubagentCount` 是直接子行的单层过滤，**没有**上行 walk，无共享逻辑，不迁移；`collectBranchIds` 遍历 catalog 结构而非 session 链，不动。

### 4. GitLens 错误归一化 + SubagentView 日志分级（`4002f3c`）
- **before**：GitLens.tsx 六处 `catch (reason) { … reason instanceof Error ? reason.message : String(reason) … }`（refreshTarget / refresh / loadMoreLog / commit / checkout / runConfirmed）；SubagentView.tsx 两处同严重度失败用 `console.warn`。
- **after**：模块级 `errorMessage(reason)` 一份，六处复用（含两处 `t('historyLoadError')/t('checkoutError')` 前缀的模板插值）；`console.warn → console.error`，与 Sidebar.tsx（tab badge）、TerminalView.tsx（xterm open）、service.ts（urlTarget / plugin callback）对齐。前缀 `[dsh-better-sidebar]` 与消息文本不变；tests/ 无钉 console.warn 的断言（已核实）。

### 5. 死代码删除（`bc1984b`）
- `src/sidechat-core.ts` 的 `sidechatSeed()`：src+tests 全仓零引用（含 re-export 面核查，仓库无 `export *` barrel），删除。`SeedEvent` / `copyEvents` 仍被 `SidechatInheritance` 使用，保留。

## 测试证据

| 检查 | 结果 |
|---|---|
| `pnpm typecheck` | ✅ 通过 |
| `pnpm build`（tsc + tsdown 全产物） | ✅ 通过；core bundle 无 codemirror 泄漏 |
| `pnpm test`（vitest 全量） | ✅ 118 files / 1241 passed / 9 skipped（既有 skip），exit 0 |
| 指定套件单独复跑（subagent-detect / subagent-jobs / subagent-jobs-view / git / git-view-worktree / api-surface / sidechat-core / sidechat-seed-validation + file-types） | ✅ 9 files / 73 tests 全绿，断言零改动 |
| `pnpm check:consumer-types` | ✅ 通过（service.ts 有改动故按规则执行） |

tests/ 目录零文件改动（`git diff --name-only | grep ^tests/` 为空）。