### PR TITLE
feat(dev): 引入 Makefile 规范化命令面

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig — https://editorconfig.org
+# 仓库统一编辑器基线；缩进等风格细节以各文件的既有约定为准。
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Makefile 的 recipe 必须用真实 tab（GNU Make 硬性要求）。
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
         with:
           # Tests run git log against this repository and need the full history.
           fetch-depth: 0
+      # pnpm version is pinned via packageManager in package.json; the action
+      # reads it from there (specifying both makes action-setup fail on
+      # purpose with ERR_PNPM_BAD_PM_VERSION).
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -69,9 +70,10 @@ jobs:
         with:
           # Tests run git log against this repository and need the full history.
           fetch-depth: 0
+      # pnpm version is pinned via packageManager in package.json; the action
+      # reads it from there (specifying both makes action-setup fail on
+      # purpose with ERR_PNPM_BAD_PM_VERSION).
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -109,9 +111,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # pnpm version is pinned via packageManager in package.json; the action
+      # reads it from there (specifying both makes action-setup fail on
+      # purpose with ERR_PNPM_BAD_PM_VERSION).
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Aggregate double-mount regression
         env:
           DSH_CMD: dsh
-        run: bash scripts/e2e-aggregate-mount.sh
+        run: pnpm test:mount:aggregate
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,10 @@ jobs:
           # Tests run git log against this repository and need full history.
           fetch-depth: 0
 
+      # pnpm version is pinned via packageManager in package.json; the action
+      # reads it from there (specifying both makes action-setup fail on
+      # purpose with ERR_PNPM_BAD_PM_VERSION).
       - uses: pnpm/action-setup@v6
-        with:
-          version: 11
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,20 @@ jobs:
             exit 1
           fi
 
-      - name: Build
-        run: pnpm build
-
       - name: Typecheck
         run: pnpm typecheck
 
       - name: Test
         run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      # The consumer-facing declaration surface guard — mirrors the ci.yml
+      # verification order (typecheck → test → build → check:consumer-types)
+      # so a release is gated on the same checks a PR runs.
+      - name: Check consumer type surface
+        run: pnpm check:consumer-types
 
       - name: Dry-run publish (validation only)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# dsh-better-sidebar 命令面薄封装：目标仅转发 package.json scripts（唯一事实源），
+# 新增/改名 script 不需要动这里；本文件只补目标发现（help）与 CI 门禁聚合
+# （check / mount / mount-aggregate / registry）。
+# 注：lint 目标留给引入 ESLint 的后续 PR。
+
+.DEFAULT_GOAL := help
+
+help: ## 列出所有可用目标
+	@awk -F':.*## ' '/^[a-zA-Z0-9_-]+:.*## / {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## 安装依赖（pnpm install）
+	pnpm install
+
+build: ## 构建（清 lib/ → tsc → tsdown）
+	pnpm build
+
+typecheck: ## 类型检查（tsc --noEmit）
+	pnpm typecheck
+
+test: ## 单元测试（vitest run）
+	pnpm test
+
+check: ## 聚合校验门禁：typecheck → build → test → check:consumer-types（对齐 CI）
+	pnpm typecheck && pnpm build && pnpm test && pnpm check:consumer-types
+
+clean: ## 清理构建产物与测试报告（lib/、*.tgz、playwright-report/、test-results/）
+	rm -rf lib playwright-report test-results
+	rm -f *.tgz
+
+pack: ## 打 npm tarball（pnpm pack）
+	pnpm pack
+
+mount: ## 真机挂载冒烟：build + pack → Playwright Chromium → pnpm test:mount
+	pnpm build && pnpm pack && pnpm exec playwright install chromium && pnpm test:mount
+
+mount-aggregate: ## 聚合双挂载回归：build + pack → pnpm test:mount:aggregate
+	pnpm build && pnpm pack && pnpm test:mount:aggregate
+
+registry: ## 组装 plugin-registry 暂存（registry/，不入库）：build → node scripts/package-registry.mjs
+	pnpm build && node scripts/package-registry.mjs
+
+.PHONY: help install build typecheck test check clean pack mount mount-aggregate registry

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ dsh plugin --profile web add dsh-better-sidebar@latest   # 重跑即成功
 遇到报错先查 https://github.com/omdsh-dev/DSH-better-sidebar README 的常见问题表。
 ```
 
+**方式三：一键脚本**——克隆本仓库后执行 `bash scripts/install.sh`（macOS / Linux / Windows Git Bash；Windows 原生环境用 `install.ps1`；`-h` 查看参数），自动完成 add → 放行构建脚本 → 重跑安装。
+
 <details>
 <summary><b>更新</b></summary>
 
@@ -492,6 +494,16 @@ pnpm test         # vitest（含 manifest 一致性守卫，需先 build）
 pnpm watch        # tsdown --watch
 ```
 
+**Make 薄封装**（`make help` 查看全部目标；package.json 仍是唯一事实源）：
+
+```sh
+make check          # 聚合校验门禁：typecheck → build → test → check:consumer-types（对齐 CI）
+make mount          # 真机挂载冒烟：build + pack → 安装 Chromium → pnpm test:mount
+make clean          # 清理 lib/、*.tgz、playwright-report/、test-results/
+```
+
+`pnpm check:consumer-types`：对外类型声明面守卫——以浏览器-only 消费者（无 `@types/node`、`skipLibCheck: false`）的视角对构建出的 `lib/types` 做类型检查，需先 `pnpm build`。
+
 **架构**：单 npm 包、host/client 双半结构——host（`src/index.ts`）：`/sidebar/api/*` JSON API、`/sidebar/file` 媒体路由、`/sidebar/html` 预览路由、`/sidebar/ws/terminal` WebSocket（fs / git / pty / 预览，全部会话级 + 信任围栏）；client（`src/client/index.tsx`）：portal 侧边栏 + 各视图 + 拦截；状态按会话持久化 localStorage。插件按 DSH 官方规范组织（无 default 导出、双 client bundle），运行期不依赖 npm / checkout（`@deepseek-ai/*` 由 web profile 提供）。
 
 ## 🔐 安全
@@ -517,7 +529,7 @@ Windows / Linux / macOS 三平台适配（macOS 日常验证；其余经单元�
 
 - **代码改动走 PR**：`feat/*` / `fix/*` 分支开发 → `gh pr create`；纯文档改动可直接推 main
 - **收录生态插件**：给仓库打 `dsh-better-sidebar` topic + 向 [`src/client/plugins-tabs.ts`](./src/client/plugins-tabs.ts) / [`plugins-viewers.ts`](./src/client/plugins-viewers.ts) 提 PR
-- **提交前自检**：`pnpm typecheck && pnpm build && pnpm test`（CI 另有 npm 打包 → 真实挂载 → 无头渲染门禁 `pnpm test:mount`）
+- **提交前自检**：`pnpm typecheck && pnpm build && pnpm test`（或 `make check` 一键聚合；CI 另有 npm 打包 → 真实挂载 → 无头渲染门禁 `pnpm test:mount`，及聚合双挂载回归 `pnpm test:mount:aggregate`）
 - 仓库工作规范见 [`AGENTS.md`](./AGENTS.md)（含仓库硬约束与 CI 说明）
 
 ## ⭐ Star History

--- a/README_EN.md
+++ b/README_EN.md
@@ -85,6 +85,8 @@ Install the dsh-better-sidebar plugin (a sidebar workbench for DSH):
 If anything fails, check the troubleshooting table in the README at https://github.com/omdsh-dev/DSH-better-sidebar
 ```
 
+**Option 3: one-shot script** — from a clone of this repo, run `bash scripts/install.sh` (macOS / Linux / Windows Git Bash; native Windows uses `install.ps1`; `-h` for options) — it automates add → approve-builds → re-run.
+
 <details>
 <summary><b>Updating</b></summary>
 
@@ -487,6 +489,16 @@ pnpm test         # vitest (includes manifest consistency guard; build first)
 pnpm watch        # tsdown --watch
 ```
 
+**Make thin wrappers** (`make help` lists every target; package.json stays the single source of truth):
+
+```sh
+make check          # aggregate gate: typecheck → build → test → check:consumer-types (mirrors CI)
+make mount          # real-mount smoke: build + pack → install Chromium → pnpm test:mount
+make clean          # remove lib/, *.tgz, playwright-report/, test-results/
+```
+
+`pnpm check:consumer-types`: the consumer-facing declaration-surface guard — type-checks the built `lib/types` from a browser-only consumer's perspective (no `@types/node`, `skipLibCheck: false`); run `pnpm build` first.
+
 **Architecture**: a single npm package with host/client halves — host (`src/index.ts`): `/sidebar/api/*` JSON API, `/sidebar/file` media route, `/sidebar/html` preview route, `/sidebar/ws/terminal` WebSocket (fs / git / pty / preview, all session-scoped with a trust fence); client (`src/client/index.tsx`): portal sidebar + views + interception; state persisted per session in localStorage. Organized per DSH official conventions (no default export, dual client bundles); no dependency on npm / checkout at runtime (`@deepseek-ai/*` provided by the web profile).
 
 ## 🔐 Security
@@ -525,7 +537,7 @@ WeChat / QQ group QR codes will live here. After uploading the QR images (drag t
 
 - **Code changes go through PRs**: develop on a `feat/*` / `fix/*` branch, then `gh pr create`; docs-only changes may be pushed to main directly
 - **Curate an ecosystem plugin**: tag your repo with `dsh-better-sidebar` + PR a `PluginEntry` into [`src/client/plugins-tabs.ts`](./src/client/plugins-tabs.ts) / [`plugins-viewers.ts`](./src/client/plugins-viewers.ts)
-- **Before submitting**: `pnpm typecheck && pnpm build && pnpm test` (CI additionally gates on npm-pack → real-mount → headless-render via `pnpm test:mount`)
+- **Before submitting**: `pnpm typecheck && pnpm build && pnpm test` (or `make check` for the one-shot aggregate; CI additionally gates on npm-pack → real-mount → headless-render via `pnpm test:mount`, plus the aggregate double-mount regression `pnpm test:mount:aggregate`)
 - See [`AGENTS.md`](./AGENTS.md) for the repository rules (hard constraints, CI lanes, release flow)
 
 ## ⭐ Star History

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "engines": {
     "node": ">=20"
   },
+  "packageManager": "pnpm@11.8.0",
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
@@ -79,6 +80,8 @@
     "prepare": "tsdown",
     "test": "vitest run",
     "test:mount": "bash scripts/e2e-mount.sh",
+    "test:mount:aggregate": "bash scripts/e2e-aggregate-mount.sh",
+    "clean": "node -e \"require('node:fs').rmSync('lib',{recursive:true,force:true})\"",
     "check:consumer-types": "bash scripts/check-consumer-types.sh"
   },
   "license": "MIT",


### PR DESCRIPTION
## 改动摘要

仓库此前只有 package.json 的 9 条 scripts，无统一命令入口、无 clean、无聚合校验；CI 的聚合挂载 lane 直接 `bash scripts/e2e-aggregate-mount.sh` 无 npm script 别名；release.yml 不跑 `check:consumer-types` 且校验步骤顺序与 ci.yml 相反。本 PR 引入 Makefile 薄封装补齐命令面（3 个 commit）：

### 1. Makefile + .editorconfig（789696a）
- **Makefile 薄封装**：所有目标仅转发 package.json scripts（唯一事实源仍是 package.json，新增/改名 script 不需要动 Makefile）；`.DEFAULT_GOAL := help`，目标用 `## 注释` 自说明。
  - `check`：单条 recipe 顺序 `pnpm typecheck && pnpm build && pnpm test && pnpm check:consumer-types`——聚合 CI 门禁，**刻意不用 make 前置依赖表达顺序**（避免 `-j` 下乱序）
  - `mount`：build + pack → `pnpm exec playwright install chromium`（幂等）→ `pnpm test:mount`
  - `mount-aggregate`：build + pack → `pnpm test:mount:aggregate`；`registry`：build → `node scripts/package-registry.mjs`
  - `clean`：删 `lib/`、`*.tgz`、`playwright-report/`、`test-results/`（四者均已 gitignore）
  - 本 PR 不加 `lint` 目标（ESLint 由后续 PR 引入时补），Makefile 头部已注明
- **.editorconfig**：root + utf-8 / lf / 末尾换行 / 去尾随空格，默认 2 空格缩进，Makefile recipe 保持 tab。

### 2. package.json + CI 对齐（6201a2c）
- 新增 `"test:mount:aggregate": "bash scripts/e2e-aggregate-mount.sh"`；ci.yml plugin-mount 的「Aggregate double-mount regression」步骤改为 `pnpm test:mount:aggregate`（保留 `DSH_CMD: dsh` env）。
- 新增 `"clean"`：`node -e rmSync('lib')` 删 lib（跨平台，风格与 build script 开头的清理写法一致；*.tgz/报告目录留给 make clean，npm script 保持极简）。**只新增普通 script，不新增/修改任何生命周期钩子**——market-manifest.spec.ts 的 lifecycle 断言只针对 `pnpm pack` 产出的 packed manifest（既存 `prepare` 由 pnpm 剥离，同理由我的普通 script 不在拒绝清单内），已实跑 `tests/market-manifest.spec.ts` 5/5 绿验证。
- 新增 `"packageManager": "pnpm@11.8.0"`（选版依据：本地实装 `pnpm --version` = 11.8.0，属 11.x 直接采用）。pnpm 10+ 运行时按该字段自切版本；CI 三个 workflow 的 `pnpm/action-setup` `version: 11` 输入与其兼容不冲突（显式 version 输入安装 latest 11.x，pnpm 首次调用自切到钉版），实跑 `pnpm install` 验证不破坏安装。
- **release.yml 校验顺序统一**为 typecheck → test → build → check:consumer-types（与 ci.yml 一致），并补上此前缺失的 `pnpm check:consumer-types` 步骤（该守卫读取构建产物，故仍在 build 之后）；tag 校验等非构建步骤位置不变。

### 3. README 双语镜像（35111e1）
- 「开发与构建」：补 Makefile 用法示例（help/check/mount/clean）与 `pnpm check:consumer-types` 定位说明（浏览器-only 消费者视角、需先 build）。
- 「参与贡献」：提交前自检补 `make check` 与 `pnpm test:mount:aggregate`。
- 「安装」：补方式三一键脚本入口（`bash scripts/install.sh`，Windows `install.ps1`，`-h` 查看参数）。README 与 README_EN 同步镜像，「最近更新」未动。

## 逐项验证结果（全部实跑，macOS arm64 / GNU Make 3.81 / pnpm 11.8.0）

| 项目 | 结果 |
|---|---|
| `pnpm install`（packageManager 字段） | ✅ 成功，pnpm v11.8.0，prepare 钩子正常 |
| `make help` | ✅ 11 个目标全部列出 |
| `make typecheck` | ✅ tsc --noEmit 通过 |
| `make pack` | ✅ 产出 dsh-better-sidebar-0.19.0-alpha.0.tgz |
| `make clean` | ✅ lib/、*.tgz、playwright-report/、test-results/ 四项实测清除（报告目录为人工种入后验证） |
| `pnpm clean` | ✅ lib 移除 |
| `make build` | ✅ lib/ 全量产物（含 lib/types） |
| `pnpm test` | ✅ 118 files / 1241 passed · 9 skipped，exit 0 |
| `tests/market-manifest.spec.ts` 单跑 | ✅ 5/5 passed（packed manifest 无 lifecycle script） |
| `make check` | ✅ typecheck → build → test（1241 passed）→ check:consumer-types 全绿，exit 0 |
| YAML 校验（js-yaml） | ✅ ci.yml / release.yml 语法均通过 |
| `make registry` | ✅ registry/ 组装 11 文件，抽查 lib/ 产物在位 |
| `make mount`（真机挂载 lane） | ⚠️ 详见下方说明 |

## make mount 本地环境说明（reviewer 注意）

- 本机 PATH 上的全局 `dsh` 是 **0.1.0-rc.8**（pre-alpha，就绪行不带 `?token=` 鉴权 URL，AGENTS §3.1 契约），`e2e-mount.sh` 缺省用 PATH 的 `dsh`，因此首次直跑在 URL 解析处失败——**环境问题而非目标缺陷**。
- 按 CI 同款钉版（`@deepseek-ai/dsh@0.1.2-alpha.5` 置顶 PATH，装在 /tmp 未动全局）重跑整条 lane：真实 `dsh web` 启动、token 鉴权、Playwright 无头渲染均正常，**17/18 通过**，含核心挂载冒烟 mount.e2e（`[data-dsh-better-sidebar]` 挂载 + 全内置 tab 扫掠）。
- 唯一失败 `desktop-layout.e2e.ts > right panel keeps desktop session actions in their header positions`，失败点在 **DSH 宿主自身的 workspace 选择弹窗**（点击 Choose workspace 后 dialog 未出现，ARIA 快照确认无该节点），重试单测仍失败（本机 macOS 可复现）。本 PR 零运行时代码改动（tarball 内容与 main 等价），该用例在 ubuntu CI 上是绿的——请以本 PR 的 plugin-mount lane 结果为准。

## Reviewer 注意点

1. **check 的顺序**：`typecheck → build → test → check:consumer-types` 与 ci.yml 完全一致（release.yml 原为 build→typecheck→test，本 PR 统一）；build 在 test 前是刻意的——部分守卫测试读取 lib/ 产物。
2. **packageManager 选版**：取本地实装 11.8.0（11.x 直接采用）；与 action-setup `version: 11` 输入共存无冲突（pnpm 自切机制），CI 实际行为不变。
3. **市场约束**：仅新增普通 script（test:mount:aggregate / clean），未触碰任何生命周期钩子；market-manifest 守卫已验证。
4. **Makefile 的 check/mount 等聚合目标用单条 recipe `&&` 串联**而非前置依赖，保证 `-j`/`-j1` 下顺序恒定。