### PR TITLE
refactor(theme): One Dark/Light 语法色板单源化

### DIFF
--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -37,6 +37,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
 import '@xterm/xterm/css/xterm.css'
 import { t } from './locales.ts'
+import { ONE_DARK, ONE_LIGHT } from './one-dark-palette.ts'
 import { openWhenSized } from './open-when-sized.ts'
 import { api, type SessionScope, type TerminalDepsStatus } from './api.ts'
 import { agentUuidOf, isAgentTabId, type SidebarStore } from './state.ts'
@@ -67,24 +68,24 @@ type TerminalDepsInfo = Extract<TerminalDepsStatus, { ok: false }>
  * Curated ANSI palettes for the terminal. The surface colors (background,
  * foreground, cursor, selection) ride the theme tokens so the terminal
  * blends with the panel in both schemes; the 16 ANSI colors are the same
- * designed palettes the app's code surfaces use (one-dark family for dark,
- * one-light family for light), read live so a scheme flip re-themes in
- * place.
+ * designed syntax families the app's code surfaces use — one-dark for
+ * dark, one-light for light (one-dark-palette.ts, shared with the
+ * CodeMirror themes) — read live so a scheme flip re-themes in place.
  */
 const ANSI_DARK: Record<string, string> = {
-  black: '#282c34', red: '#e06c75', green: '#98c379', yellow: '#e5c07b',
-  blue: '#61afef', magenta: '#c678dd', cyan: '#56b6c2', white: '#abb2bf',
-  brightBlack: '#5c6370', brightRed: '#e06c75', brightGreen: '#98c379',
-  brightYellow: '#e5c07b', brightBlue: '#61afef', brightMagenta: '#c678dd',
-  brightCyan: '#56b6c2', brightWhite: '#ffffff',
+  black: ONE_DARK.black, red: ONE_DARK.red, green: ONE_DARK.green, yellow: ONE_DARK.yellow,
+  blue: ONE_DARK.blue, magenta: ONE_DARK.magenta, cyan: ONE_DARK.cyan, white: ONE_DARK.gray,
+  brightBlack: ONE_DARK.faintGray, brightRed: ONE_DARK.red, brightGreen: ONE_DARK.green,
+  brightYellow: ONE_DARK.yellow, brightBlue: ONE_DARK.blue, brightMagenta: ONE_DARK.magenta,
+  brightCyan: ONE_DARK.cyan, brightWhite: ONE_DARK.white,
 }
 
 const ANSI_LIGHT: Record<string, string> = {
-  black: '#383a42', red: '#e45649', green: '#50a14f', yellow: '#c18401',
-  blue: '#0184bc', magenta: '#a626a4', cyan: '#0997b3', white: '#a0a1a7',
-  brightBlack: '#4f525e', brightRed: '#e45649', brightGreen: '#50a14f',
-  brightYellow: '#c18401', brightBlue: '#0184bc', brightMagenta: '#a626a4',
-  brightCyan: '#0997b3', brightWhite: '#fafafa',
+  black: ONE_LIGHT.black, red: ONE_LIGHT.red, green: ONE_LIGHT.green, yellow: ONE_LIGHT.yellow,
+  blue: ONE_LIGHT.blue, magenta: ONE_LIGHT.magenta, cyan: ONE_LIGHT.cyan, white: ONE_LIGHT.gray,
+  brightBlack: ONE_LIGHT.faintGray, brightRed: ONE_LIGHT.red, brightGreen: ONE_LIGHT.green,
+  brightYellow: ONE_LIGHT.yellow, brightBlue: ONE_LIGHT.blue, brightMagenta: ONE_LIGHT.magenta,
+  brightCyan: ONE_LIGHT.cyan, brightWhite: ONE_LIGHT.offWhite,
 }
 
 /** The xterm theme for the current scheme (surface from tokens, ANSI curated). */

--- a/src/client/cm-themes.ts
+++ b/src/client/cm-themes.ts
@@ -2,15 +2,17 @@
  * CodeMirror 6 theme pieces for the sidebar editor. The editor surface
  * (background, caret, gutter) rides the DSH theme tokens so it blends with
  * the panel in both schemes; only the syntax token colors need concrete
- * values, and those come from the same designed palettes the app's code
- * surfaces use — the one-dark family for dark, the one-light family for
- * light. The scheme flip reconfigures these via a compartment (see
- * TextEditor), so the document, undo history and scroll survive re-theming.
+ * values, and those come from the same designed syntax families the app's
+ * code surfaces use — one-dark for dark, one-light for light
+ * (one-dark-palette.ts, shared with the terminal's ANSI palette). The
+ * scheme flip reconfigures these via a compartment (see TextEditor), so
+ * the document, undo history and scroll survive re-theming.
  */
 import { Compartment } from '@codemirror/state'
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { tags, type Tag } from '@lezer/highlight'
 import { EditorView } from '@codemirror/view'
+import { ONE_DARK, ONE_LIGHT } from './one-dark-palette.ts'
 
 /** Token-driven surface shared by both schemes (pure CSS values). */
 export const cmSurfaceTheme = EditorView.theme({
@@ -53,52 +55,52 @@ interface HighlightRule {
   fontStyle?: string
 }
 
-/** one-dark syntax palette (mirrors @codemirror/theme-one-dark). */
+/** one-dark syntax rules (mirrors @codemirror/theme-one-dark; hues from one-dark-palette.ts). */
 const HIGHLIGHTS_DARK: HighlightRule[] = [
-  { tag: tags.comment, color: '#5c6370', fontStyle: 'italic' },
-  { tag: tags.keyword, color: '#c678dd' },
-  { tag: tags.string, color: '#98c379' },
-  { tag: tags.number, color: '#d19a66' },
-  { tag: tags.bool, color: '#d19a66' },
-  { tag: tags.atom, color: '#d19a66' },
-  { tag: tags.typeName, color: '#e5c07b' },
-  { tag: tags.className, color: '#e5c07b' },
-  { tag: tags.propertyName, color: '#e06c75' },
-  { tag: tags.function(tags.variableName), color: '#61afef' },
-  { tag: tags.variableName, color: '#e06c75' },
-  { tag: tags.operator, color: '#56b6c2' },
-  { tag: tags.tagName, color: '#e06c75' },
-  { tag: tags.attributeName, color: '#d19a66' },
-  { tag: tags.heading, color: '#e06c75', fontStyle: 'bold' },
+  { tag: tags.comment, color: ONE_DARK.faintGray, fontStyle: 'italic' },
+  { tag: tags.keyword, color: ONE_DARK.magenta },
+  { tag: tags.string, color: ONE_DARK.green },
+  { tag: tags.number, color: ONE_DARK.orange },
+  { tag: tags.bool, color: ONE_DARK.orange },
+  { tag: tags.atom, color: ONE_DARK.orange },
+  { tag: tags.typeName, color: ONE_DARK.yellow },
+  { tag: tags.className, color: ONE_DARK.yellow },
+  { tag: tags.propertyName, color: ONE_DARK.red },
+  { tag: tags.function(tags.variableName), color: ONE_DARK.blue },
+  { tag: tags.variableName, color: ONE_DARK.red },
+  { tag: tags.operator, color: ONE_DARK.cyan },
+  { tag: tags.tagName, color: ONE_DARK.red },
+  { tag: tags.attributeName, color: ONE_DARK.orange },
+  { tag: tags.heading, color: ONE_DARK.red, fontStyle: 'bold' },
   { tag: tags.emphasis, fontStyle: 'italic' },
   { tag: tags.strong, fontStyle: 'bold' },
-  { tag: tags.link, color: '#61afef', fontStyle: 'underline' },
-  { tag: tags.meta, color: '#e5c07b' },
-  { tag: tags.invalid, color: '#ffffff', fontStyle: 'bold' },
+  { tag: tags.link, color: ONE_DARK.blue, fontStyle: 'underline' },
+  { tag: tags.meta, color: ONE_DARK.yellow },
+  { tag: tags.invalid, color: ONE_DARK.white, fontStyle: 'bold' },
 ]
 
-/** one-light syntax palette (the light counterpart of one-dark). */
+/** one-light syntax rules (the light counterpart; hues from one-dark-palette.ts). */
 const HIGHLIGHTS_LIGHT: HighlightRule[] = [
-  { tag: tags.comment, color: '#a0a1a7', fontStyle: 'italic' },
-  { tag: tags.keyword, color: '#a626a4' },
-  { tag: tags.string, color: '#50a14f' },
-  { tag: tags.number, color: '#986801' },
-  { tag: tags.bool, color: '#0184bc' },
-  { tag: tags.atom, color: '#0184bc' },
-  { tag: tags.typeName, color: '#c18401' },
-  { tag: tags.className, color: '#c18401' },
-  { tag: tags.propertyName, color: '#e45649' },
-  { tag: tags.function(tags.variableName), color: '#c18401' },
-  { tag: tags.variableName, color: '#e45649' },
-  { tag: tags.operator, color: '#383a42' },
-  { tag: tags.tagName, color: '#e45649' },
-  { tag: tags.attributeName, color: '#986801' },
-  { tag: tags.heading, color: '#e45649', fontStyle: 'bold' },
+  { tag: tags.comment, color: ONE_LIGHT.gray, fontStyle: 'italic' },
+  { tag: tags.keyword, color: ONE_LIGHT.magenta },
+  { tag: tags.string, color: ONE_LIGHT.green },
+  { tag: tags.number, color: ONE_LIGHT.orange },
+  { tag: tags.bool, color: ONE_LIGHT.blue },
+  { tag: tags.atom, color: ONE_LIGHT.blue },
+  { tag: tags.typeName, color: ONE_LIGHT.yellow },
+  { tag: tags.className, color: ONE_LIGHT.yellow },
+  { tag: tags.propertyName, color: ONE_LIGHT.red },
+  { tag: tags.function(tags.variableName), color: ONE_LIGHT.yellow },
+  { tag: tags.variableName, color: ONE_LIGHT.red },
+  { tag: tags.operator, color: ONE_LIGHT.black },
+  { tag: tags.tagName, color: ONE_LIGHT.red },
+  { tag: tags.attributeName, color: ONE_LIGHT.orange },
+  { tag: tags.heading, color: ONE_LIGHT.red, fontStyle: 'bold' },
   { tag: tags.emphasis, fontStyle: 'italic' },
   { tag: tags.strong, fontStyle: 'bold' },
-  { tag: tags.link, color: '#4078f2', fontStyle: 'underline' },
-  { tag: tags.meta, color: '#c18401' },
-  { tag: tags.invalid, color: '#ffffff', fontStyle: 'bold' },
+  { tag: tags.link, color: ONE_LIGHT.link, fontStyle: 'underline' },
+  { tag: tags.meta, color: ONE_LIGHT.yellow },
+  { tag: tags.invalid, color: ONE_LIGHT.white, fontStyle: 'bold' },
 ]
 
 /** The scheme-dependent extension pair (surface tint + syntax highlight). */

--- a/src/client/one-dark-palette.ts
+++ b/src/client/one-dark-palette.ts
@@ -1,0 +1,62 @@
+/**
+ * The single source for the syntax color families the app's code surfaces
+ * use: one-dark for the dark scheme, one-light for the light scheme. Two
+ * lazy-chunk consumers assemble their theme objects from these constants —
+ * the terminal's curated ANSI 16 (TerminalView.tsx) and CodeMirror's
+ * highlight rules (cm-themes.ts) — so a family color is defined exactly
+ * once and the two views can never drift apart.
+ *
+ * The palette holds only the syntax hues; surface colors (background,
+ * foreground, caret, gutter) are theme-token driven and selection tints /
+ * token-fallback colors stay with their consumers (they are not part of
+ * the designed syntax families).
+ *
+ * Chunk boundary: this module is inlined into BOTH lazy chunks that import
+ * it (terminal and editor) — the constants are plain strings, the per-chunk
+ * copy is a few hundred bytes, and no cross-chunk import is introduced. The
+ * core bundle does not (and must not) import this module.
+ */
+
+/** one-dark family (dark scheme) syntax hues. */
+export const ONE_DARK = {
+  /** Editor-background tone; ANSI black. */
+  black: '#282c34',
+  /** Default foreground gray; ANSI white. */
+  gray: '#abb2bf',
+  /** Comment gray; ANSI bright black. */
+  faintGray: '#5c6370',
+  /** Pure white; ANSI bright white and the invalid-token color. */
+  white: '#ffffff',
+  red: '#e06c75',
+  green: '#98c379',
+  yellow: '#e5c07b',
+  blue: '#61afef',
+  magenta: '#c678dd',
+  cyan: '#56b6c2',
+  /** Numbers, bools, atoms, attribute names. */
+  orange: '#d19a66',
+} as const
+
+/** one-light family (light scheme) syntax hues. */
+export const ONE_LIGHT = {
+  /** Foreground dark; ANSI black and the operator color. */
+  black: '#383a42',
+  /** Comment gray; ANSI white. */
+  gray: '#a0a1a7',
+  /** ANSI bright black. */
+  faintGray: '#4f525e',
+  /** Pure white; the invalid-token color (stays white in light for contrast). */
+  white: '#ffffff',
+  /** Off-white; ANSI bright white. */
+  offWhite: '#fafafa',
+  red: '#e45649',
+  green: '#50a14f',
+  yellow: '#c18401',
+  blue: '#0184bc',
+  magenta: '#a626a4',
+  cyan: '#0997b3',
+  /** Numbers and attribute names. */
+  orange: '#986801',
+  /** Markdown links — the light family's dedicated link blue (dark rides blue). */
+  link: '#4078f2',
+} as const

--- a/tests/one-dark-palette.spec.ts
+++ b/tests/one-dark-palette.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Byte-level guard for the shared syntax color families
+ * (src/client/one-dark-palette.ts). The terminal's ANSI 16
+ * (TerminalView.tsx) and CodeMirror's highlight rules (cm-themes.ts) both
+ * assemble from these constants, so an accidental value edit here silently
+ * re-themes every code surface in both views. The expected hexes are the
+ * exact pre-single-sourcing literals from the two consumers — changing one
+ * must be a deliberate, reviewable act.
+ */
+import { describe, expect, it } from 'vitest'
+import { ONE_DARK, ONE_LIGHT } from '../src/client/one-dark-palette.ts'
+
+describe('one-dark-palette', () => {
+  it('pins the one-dark family (dark scheme) hues', () => {
+    expect(ONE_DARK).toEqual({
+      black: '#282c34',
+      gray: '#abb2bf',
+      faintGray: '#5c6370',
+      white: '#ffffff',
+      red: '#e06c75',
+      green: '#98c379',
+      yellow: '#e5c07b',
+      blue: '#61afef',
+      magenta: '#c678dd',
+      cyan: '#56b6c2',
+      orange: '#d19a66',
+    })
+  })
+
+  it('pins the one-light family (light scheme) hues', () => {
+    expect(ONE_LIGHT).toEqual({
+      black: '#383a42',
+      gray: '#a0a1a7',
+      faintGray: '#4f525e',
+      white: '#ffffff',
+      offWhite: '#fafafa',
+      red: '#e45649',
+      green: '#50a14f',
+      yellow: '#c18401',
+      blue: '#0184bc',
+      magenta: '#a626a4',
+      cyan: '#0997b3',
+      orange: '#986801',
+      link: '#4078f2',
+    })
+  })
+})


### PR DESCRIPTION
## 动机

同一套 One Dark / One Light 语法色在两个模块各写一遍——`TerminalView.tsx` 的 xterm ANSI 16（暗/亮 ~20 色/套）与 `cm-themes.ts` 的 CodeMirror 高亮规则（~40 色值/套）。任何色值调整都要改两处且容易漂移。本 PR 把色系抽成单一来源，**行为不变**（色值逐字节一致）。

## 模块设计

- 新增 `src/client/one-dark-palette.ts`：导出 `ONE_DARK` / `ONE_LIGHT` 两个常量对象，按色相命名（`black / gray / faintGray / white / offWhite / red / green / yellow / blue / magenta / cyan / orange / link`）。暗色系 11 个不同 hex、亮色系 13 个，正是两消费方原值的并集，每个字面量全仓库只出现一次。
- **角色映射留在消费方**：ANSI 槽位（`brightWhite` → 暗系 `white`、亮系 `offWhite`）与 lezer tag 映射（如 comment：暗系 `faintGray`、亮系 `gray`；bool/atom：暗系 `orange`、亮系 `blue`）本就两侧不对称，是各视图自己的设计决策，不适合塞进色板。
- 按任务边界**不合并无关值**：`TerminalView` 的 token 兜底色（`#111114/#ffffff/#e6e6e6/#1a1a1a`）与 `cm-themes` 的 selection/activeLine rgba 留在原处。
- 新增 `tests/one-dark-palette.spec.ts` 钉住色板字面量（新测试，未改任何既有断言）：今后改任何色相必须显式触碰该 spec。

## 逐字节等价的验证方法（全实跑）

1. **映射机器证明**：一次性脚本从 `git show HEAD:` 提取迁移前的 `HIGHLIGHTS_DARK/LIGHT` 与 `ANSI_DARK/LIGHT` 字面量片段、从工作树提取迁移后引用色板的片段，在桩 `tags` proxy 下分别求值并深度比对——**逐字节相等**（cm 规则 JSON 2389 字节、ANSI 记录 837 字节，含全部 color/fontStyle 与槽位值）。产物 grep 只能证明"值还在"，这步证明"tag→色 映射没换"。
2. **产物 hex 清单对比**（迁移前后 `lib/client-terminal.js` / `lib/client-editor.js` 各自 `grep -oE '#hex{6}' | sort | uniq -c`）：
   - **零删除**：基线出现过的每个 hex 迁移后仍存在（含 `e06c75`、`61afef` 等特征值抽查）；
   - **非色板 hex（依赖自带 + 兜底色）计数零变化**；
   - 色板 hex 计数全部收敛为每 chunk 1 次（去重生效）；`rgba(255,255,255,0.22)` / `rgba(0,0,0,0.12)` / 兜底 hex 在产物中原样存活。
   - 预期内的"新增"：色板对象整体内联进两个 chunk，未消费的家族成员（如 terminal chunk 里的 `#4078f2`）作为惰性数据随行，每 chunk 约 200B 字面量。

## chunk 边界论证

- `TerminalView.tsx` 只被 terminal 懒加载 chunk（`src/client/chunks/terminal.tsx`）引入，`cm-themes.ts` 只被 editor 侧（`TextEditor.tsx` ← `chunks/editor.tsx`）消费；色板是纯常量模块，被两个 chunk **各自内联**——不存在也不需要跨 chunk import（chunk 间本就只能经 `globalThis.__dshChunks__` 工厂交换，不适用纯常量共享）。
- 核心产物证据：`grep -c one-dark-palette lib/client.js lib/client-registry.js` → **0 / 0**；该字符串只出现在 `lib/client-terminal.js` / `lib/client-editor.js`（及其 sourcemap）内。
- 既有守护未动：`tests/chunk-artifact.spec.ts`（产物工厂形状）、`tests/chunk-loader.spec.ts`、`tests/manifest-consistency.spec.ts` 全绿。

## 测试证据

- `pnpm typecheck` ✅、`pnpm build` ✅
- `pnpm test` 全量：**119 files / 1243 passed | 9 skipped**（含新增 `tests/one-dark-palette.spec.ts` 2 例；零断言修改）
- 真机挂载 lane（`pnpm pack` → `scripts/e2e-mount.sh`，钉版 `@deepseek-ai/dsh@0.1.2-alpha.5`）：**17 passed, 1 failed**。唯一失败为 `desktop-layout.e2e.ts › right panel keeps desktop session actions…`，现象是宿主 workspace 选择对话框 5s 未现（`getByRole('dialog', {name: /Select Workspace Directory/})` 超时）——与本分支改动无关的已知本机环境问题（本机全局 dsh 为旧版 rc.8，lane 用 /tmp 钉版 alpha.5 复跑）。关键的 `mount.e2e.ts` 全部 5 例通过，含 14.9s 的「built-in tab sweep」（逐个打开内置 tab 走真实 xterm 终端懒加载 chunk，再经文件树打开 seed 文件强制加载 editor chunk），perf lane 亦绿。