### PR TITLE
feat(client): 收敛四处轮询习语到共享 use-polling 原语

### DIFF
--- a/src/client/SideChatView.tsx
+++ b/src/client/SideChatView.tsx
@@ -69,6 +69,7 @@ import {
   type SidechatTranscriptRow,
 } from './sidechat-transcript.ts'
 import { api } from './api.ts'
+import { usePolling } from './use-polling.ts'
 import { t } from './locales.ts'
 import type { SessionScope } from './api.ts'
 import type { SidebarTab } from './state.ts'
@@ -493,17 +494,25 @@ export function SideChatView(props: {
     }
   }, [threadId, fetchInfo])
 
-  // Poll while the tab is visible and the thread runs.
+  // One transcript pull on every input change (attach, visibility flip,
+  // run-state flip — the last one catches a thread's terminal state once it
+  // stops running).
   useEffect(() => {
     if (!visible || threadId === undefined) return
     void fetchThread(threadId)
-    if (!running) return
-    const timer = window.setInterval(() => {
-      void fetchThread(threadId)
-      void fetchInfo(threadId)
-    }, POLL_MS)
-    return () => { window.clearInterval(timer) }
-  }, [visible, threadId, running, fetchThread, fetchInfo])
+    // `running` is not read here, but re-triggering this pull on run-state
+    // flips is load-bearing (see above); the badge fetch rides the ticks.
+  }, [visible, threadId, running, fetchThread])
+
+  // Poll while the tab is visible and the thread runs: transcript deltas +
+  // badge refresh on a fixed cadence. Each pull self-guards (fetchThread
+  // aborts its predecessor; a late settle keeps the last rows).
+  const pollTick = useCallback(async (): Promise<void> => {
+    if (threadId === undefined) return
+    void fetchThread(threadId)
+    void fetchInfo(threadId)
+  }, [threadId, fetchThread, fetchInfo])
+  usePolling(visible && running && threadId !== undefined, pollTick, { intervalMs: POLL_MS })
 
   useEffect(() => () => { controllerRef.current?.abort() }, [])
 

--- a/src/client/SubagentView.tsx
+++ b/src/client/SubagentView.tsx
@@ -53,6 +53,7 @@ import {
   type TreeJob,
 } from './subagent-jobs.ts'
 import { api, type JobOutputResult } from './api.ts'
+import { usePolling } from './use-polling.ts'
 import { IconStopOutline16 } from './icons.tsx'
 import { t } from './locales.ts'
 import css from './SubagentView.module.css'
@@ -180,52 +181,30 @@ function SubagentLiveLines(props: { live: LastActivity | undefined }) {
 /**
  * One shared live-preview poller for the whole Subagent tree. Unlike the old
  * per-card `subagents.history` timers, this sends at most ONE `subagents.live`
- * request at a time: a recursive timeout starts only after the previous
- * request settles, so a slow host never sees abort/restart storms.
+ * request at a time (the shared poller's self-scheduling mode arms the next
+ * tick only after the previous request settles, so a slow host never sees
+ * abort/restart storms); a response settling after the poller stopped (page
+ * hidden, tree re-rooted) is dropped via the aborted signal.
  */
 function useSubagentLive(
   rootId: string | undefined,
   active: boolean,
 ): Readonly<Record<string, LastActivity>> {
   const [live, setLive] = useState<Record<string, LastActivity>>({})
-  const controllerRef = useRef<AbortController | undefined>(undefined)
 
   // A new tree must never inherit another root's live previews.
   useEffect(() => { setLive({}) }, [rootId])
 
-  useEffect(() => {
-    if (rootId === undefined || !active) return
-    const targetRootId = rootId
-    let disposed = false
-    let timer: number | undefined
-
-    const schedule = (): void => {
-      if (disposed) return
-      timer = window.setTimeout(() => { void load() }, POLL_MS)
-    }
-    async function load(): Promise<void> {
-      if (disposed) return
-      const controller = new AbortController()
-      controllerRef.current = controller
-      try {
-        const result = await api.subagentsLive(targetRootId, controller.signal)
-        if (!disposed) setLive(result.live)
-      } catch {
-        // Keep the last known live map; the next scheduled poll retries.
-      } finally {
-        if (controllerRef.current === controller) controllerRef.current = undefined
-        if (!disposed) schedule()
-      }
-    }
-
-    void load()
-    return () => {
-      disposed = true
-      if (timer !== undefined) window.clearTimeout(timer)
-      controllerRef.current?.abort()
-      controllerRef.current = undefined
-    }
-  }, [rootId, active])
+  const poll = useCallback(async (signal: AbortSignal): Promise<void> => {
+    if (rootId === undefined) return
+    const result = await api.subagentsLive(rootId, signal)
+    if (!signal.aborted) setLive(result.live)
+  }, [rootId])
+  usePolling(rootId !== undefined && active, poll, {
+    intervalMs: POLL_MS,
+    mode: 'self-scheduling',
+    immediate: true,
+  })
 
   return live
 }

--- a/src/client/changes/ChangesTab.tsx
+++ b/src/client/changes/ChangesTab.tsx
@@ -18,6 +18,7 @@ import type { SidebarSessionEvent } from '../../context-types.ts'
 import type { TabComponentProps } from '../service.ts'
 import { t } from '../locales.ts'
 import { api } from '../api.ts'
+import { usePolling } from '../use-polling.ts'
 import { floatTab, type SidebarDiffRef } from '../state.ts'
 import { GitLens } from './GitLens.tsx'
 import { SessionLens } from './SessionLens.tsx'
@@ -104,12 +105,11 @@ export function ChangesTab({ ctx, store, scope, tab, visible, onOpenFile, onOpen
     seqRef.current = 0
     setOpsError(false)
   }, [scope.sessionId])
-  useEffect(() => {
-    void pull()
-    if (!visible) return
-    const timer = window.setInterval(() => { void pull() }, 2_500)
-    return () => { window.clearInterval(timer) }
-  }, [visible, pull])
+  // One pull on every input change — mount, scope change, and visibility
+  // flip all re-pull (a hidden tab still catches up on the flip); only the
+  // poll CADENCE below is gated by visibility.
+  useEffect(() => { void pull() }, [visible, pull])
+  usePolling(visible, pull, { intervalMs: 2_500 })
   // tick only forces the re-render; the fold reads the ref directly.
   void tick
   const ops = opsRef.current

--- a/src/client/changes/GitLens.tsx
+++ b/src/client/changes/GitLens.tsx
@@ -17,6 +17,7 @@ import {
 } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { GitLogEntry, GitStatusEntry, GitStatusResult, GitWorktree, SessionScope } from '../api.ts'
 import { api } from '../api.ts'
+import { usePolling } from '../use-polling.ts'
 import { baseName, isWithinWorkspace, relativeTo } from '../paths.ts'
 import { resolveSidebarPath } from '../produced-files.ts'
 import { relativeTime, t } from '../locales.ts'
@@ -280,11 +281,11 @@ export function GitLens(props: GitLensProps) {
     const generation = refreshGeneration.current += 1
     void refreshTarget(chosenPathRef.current ?? '', { loading: true, generation })
   }
-  useEffect(() => {
-    if (!visible) return
-    const timer = window.setInterval(() => { void refresh(true) }, 2_000)
-    return () => { window.clearInterval(timer) }
-  }, [visible, refresh])
+  /** The silent poll tick (the status-only fast path between worktree
+   *  re-lists, see refresh) — fixed 2s cadence while visible, no initial
+   *  burst (mount and scope changes already refresh above). */
+  const pollTick = useCallback((): Promise<void> => refresh(true), [refresh])
+  usePolling(visible, pollTick, { intervalMs: 2_000 })
 
   /** Append the next history page (lazy: only when the user asks for more). */
   const loadMoreLog = async (): Promise<void> => {

--- a/src/client/use-polling.ts
+++ b/src/client/use-polling.ts
@@ -1,0 +1,83 @@
+/**
+ * The sidebar's ONE polling loop: every timed client fetch — subagent live
+ * previews, side-chat transcript deltas, git status, session ops — funnels
+ * here so the cancellation-safety rules are written once instead of four
+ * times. The contract every poller gets:
+ *
+ * - While `enabled`, the task runs on the chosen cadence; the loop restarts
+ *   (and the old one is torn down) whenever `enabled`, the task identity, or
+ *   any option primitive changes — callers express "scope changed" through
+ *   the task's `useCallback` deps, exactly like an effect's dep array.
+ * - Each enabled run owns ONE AbortSignal for its whole lifetime; teardown
+ *   (unmount, `enabled` flip, identity change) aborts it AND stops all
+ *   scheduling. A task whose fetch settles late must check the signal
+ *   before writing state: an aborted fetch is NOT guaranteed to reject
+ *   (the transport may deliver the response anyway), so the signal is the
+ *   only reliable staleness guard.
+ * - A rejected task never breaks the loop — the scheduler swallows it and
+ *   the next tick retries. Sites that surface errors (setError banners and
+ *   friends) do so inside the task body; the scheduler always stays silent.
+ */
+import { useEffect } from 'react'
+
+/** One poll tick. See the module doc for the signal contract. */
+export type PollingTask = (signal: AbortSignal) => Promise<void>
+
+export interface UsePollingOptions {
+  /** Tick cadence in milliseconds. */
+  intervalMs: number
+  /**
+   * Scheduling mode. `'fixed-interval'` (default) fires ticks on a plain
+   * `setInterval` cadence — an in-flight task never delays the next tick,
+   * overlapping tasks guard their own writes (abort controllers or
+   * generation counters inside the task). `'self-scheduling'` arms the next
+   * tick only after the previous task settles: at most ONE request in
+   * flight, ever, so a slow host never sees request storms.
+   */
+  mode?: 'fixed-interval' | 'self-scheduling'
+  /** Run one task immediately when the poller (re)starts, before the first
+   * scheduled tick. */
+  immediate?: boolean
+}
+
+export function usePolling(
+  enabled: boolean,
+  task: PollingTask,
+  { intervalMs, mode = 'fixed-interval', immediate = false }: UsePollingOptions,
+): void {
+  useEffect(() => {
+    if (!enabled) return
+    const controller = new AbortController()
+    if (mode === 'self-scheduling') {
+      let disposed = false
+      let timer: number | undefined
+      const tick = async (): Promise<void> => {
+        if (disposed) return
+        try {
+          await task(controller.signal)
+        } catch {
+          // A failed poll keeps the last view; the next tick retries.
+        }
+        if (!disposed) timer = window.setTimeout(() => { void tick() }, intervalMs)
+      }
+      if (immediate) void tick()
+      else timer = window.setTimeout(() => { void tick() }, intervalMs)
+      return () => {
+        disposed = true
+        if (timer !== undefined) window.clearTimeout(timer)
+        controller.abort()
+      }
+    }
+    const run = (): void => {
+      // A failed tick keeps the last view; the next tick retries.
+      task(controller.signal).catch(() => {})
+    }
+    if (immediate) run()
+    const timer = window.setInterval(run, intervalMs)
+    return () => {
+      window.clearInterval(timer)
+      controller.abort()
+    }
+    // Option primitives only: a churned options object must not restart the loop.
+  }, [enabled, task, intervalMs, mode, immediate])
+}


### PR DESCRIPTION
## 动机

四个站点为同一目标（取消安全 + 代际失效）各自手写轮询，机制各异：自排程 setTimeout、setInterval + AbortController、setInterval + generation 计数器。本 PR 落地一个 ~80 行的共享原语 `src/client/use-polling.ts`，四处全部迁入，**所有守护 spec 断言零改动**。

## 原语 API

```ts
export type PollingTask = (signal: AbortSignal) => Promise<void>

export interface UsePollingOptions {
  intervalMs: number
  mode?: 'fixed-interval' | 'self-scheduling'   // 默认 fixed-interval
  immediate?: boolean                             // (重)启动时立即跑一次，默认 false
}

export function usePolling(enabled: boolean, task: PollingTask, options: UsePollingOptions): void
```

契约（模块 doc 全文写在文件头）：

- **调度模式**：`fixed-interval` = setInterval 固定节拍（在飞任务不推迟下一 tick，重叠任务自守写入）；`self-scheduling` = 上一任务 settle 后才排下一次（**至多一个在飞请求**，慢宿主不会见到请求风暴）。
- **取消安全 + 代际失效**：每个 enabled 周期持有**一个** AbortSignal；teardown（卸载、`enabled` 翻转、task/间隔身份变化）同步 abort 并停止一切调度。任务在写 state 前检查 `signal.aborted`——**不信任 abort 必然让 fetch reject**（传输层可能照常送达响应，信号是唯一可靠的过期判定；这正是 `subagent-live-polling.spec.tsx`「stale resolve 不得渲染也不得重排」用例锁定的语义）。
- **错误策略**：任务 reject 不打断循环——调度层静默吞掉，下一 tick 重试；需要 surface 错误的站点（setError 横幅等）在任务体内自行处理，四站点现状即如此，故调度层无需 onError 注入点（不引入当前无人使用的参数）。
- 重启语义：task 身份（useCallback deps）即「作用域变化」的表达，与 effect 依赖数组等价。

## 逐站点语义保留论证

| 站点 | 模式（前 → 后） | 间隔（前 → 后） | 失效策略（前 → 后） | 错误策略（前 → 后） |
|---|---|---|---|---|
| `SubagentView.tsx` `useSubagentLive` | 自排程 setTimeout（settle 后才排下一次，不重叠）→ `mode:'self-scheduling'` | 3000ms → 3000ms | disposed 标志 + controllerRef.abort + clearTimeout → 原语 disposed + 每代单一 AbortSignal（teardown 同步置位，`!disposed` ≡ `!signal.aborted`） | catch 静默保留旧 live map，下一轮重试 → 任务体不再 catch，调度层吞掉等价 |
| `SideChatView.tsx` 转录轮询 | setInterval 固定节拍 → `mode:'fixed-interval'`（默认） | 2000ms → 2000ms | fetchThread 内部逐次 abort 前任 + 独立卸载 abort effect（均保留不动）；间隔清理由原语接管 | fetchThread/fetchInfo 各自静默 catch（保留在任务体内） |
| `changes/GitLens.tsx` | setInterval 固定节拍 → `mode:'fixed-interval'` | 2000ms → 2000ms | generation 计数器在 refresh/refreshTarget 内部（不动），间隔清理由原语接管 | refresh 内部 setError（不动） |
| `changes/ChangesTab.tsx` | setInterval 固定节拍 → `mode:'fixed-interval'` | 2500ms → 2500ms | pollGen 代际在 pull 内部（不动），间隔清理由原语接管 | pull 内部 setOpsError（不动） |

SideChatView / ChangesTab 的「立即拉取」拆为紧邻的普通 effect（依赖数组与原 effect 一致），保证每次输入变化（含 `running` 翻转、可见性翻转、隐藏态挂载）仍先拉一次，且声明顺序在 usePolling 之前、与原单 effect 内的执行顺序一致；GitLens 无初始突发（mount/scope 的完整刷新本就在别处）。

## 迁移 / 未迁移清单

**已迁移（4/4）**：上表四站点，全部守护 spec 原断言通过，无一处回退。

**识别但未迁移**：`SubagentView.tsx` `JobOutputPane` 的 2s 输出轮询（`JOB_POLL_MS`）——不在本次任务列定的四站点内；它是「load 回调身份进依赖 + isJobLive 部分求值」的第五种形状，且其守护用例（`subagent-jobs-view.spec.tsx`「hidden 不轮询」）已在本 PR 验证范围内保持绿。留作后续独立小改动。

**顺带修复（main 存量断裂，独立 commit `65bd495`）**：`tests/add-plugin-modal.spec.tsx` 用了 `builtinTabPlugins` 却缺 import——main 上 tsc 报 TS2304、vitest 加载即 ReferenceError（该文件 0 用例），与本分支无关；不补则本 PR 无法给出绿 typecheck / 基线测试数。补上后全量恢复 1243 passed / 9 skipped 基线。

## 验证证据

- 逐站迁移即时验证：`subagent-live-polling` + `subagent-jobs-view` 13/13；`sidechat-view` + `sidechat-transcript` 29/29；`git-view-worktree` + `changes-tab` + `changes-ops` 13/13。
- `pnpm lint`：零告警（新门禁；期间发现并清除 2 处孤儿 eslint-disable——本仓库 exhaustive-deps 版本不报多余依赖）。
- `pnpm typecheck`：绿（stash 对照证实上述 add-plugin-modal 报错为 main 存量，非本分支引入）。
- `pnpm build`：绿。
- `pnpm test` 全量：**119 files，1243 passed / 9 skipped**，与基线一致（main 存量断裂下仅 1236，import 修复找回 7 个）。
- 真机挂载 lane（钉版 `@deepseek-ai/dsh@0.1.2-rc.1`，`PATH=/tmp/dsh-rc1-bin/... pnpm test:mount`）：**17 passed / 1 failed**——唯一失败为 `desktop-layout.e2e.ts`「right panel keeps desktop session actions in their header positions」：宿主 onboarding 浮层（"Configure the official DeepSeek provider to start…"）拦截「选择工作区」按钮点击，workspace 对话框无法到达，属任务预告的已知本机环境问题；`mount.e2e.ts` 全部通过，并对其核心用例（内置 tab 逐个深扫，覆盖 Subagent/SideChat/Changes 轮询视图）单独重跑复核 ✓。