### PR TITLE
feat: list dsh-turn-outline in the plugin ecosystem (README + catalog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ GitHub topic [`dsh-better-sidebar`](https://github.com/topics/dsh-better-sidebar
 ### 📑 Tab 插件（注册侧边栏页面）
 
 <details>
-<summary><b>24 个插件（点击展开）</b></summary>
+<summary><b>26 个插件（点击展开）</b></summary>
 
 | 插件 | ⭐ | 简介 |
 |---|---|---|
@@ -227,6 +227,7 @@ GitHub topic [`dsh-better-sidebar`](https://github.com/topics/dsh-better-sidebar
 | [dong-victor/dsh-better-sidebar-starter](https://github.com/dong-victor/dsh-better-sidebar-starter) | <img alt="stars" src="https://img.shields.io/github/stars/dong-victor/dsh-better-sidebar-starter?style=flat&color=4d6bfe" /> | 运行配置页：IDEA 式 Run/Debug 配置（npm / springboot / python / custom）——一键启动、历史保存、WebSocket 实时日志（ANSI 彩色）、多实例并行、进程树跨平台杀死 |
 | [baosfeng/my-dsh-plugins](https://github.com/baosfeng/my-dsh-plugins) | <img alt="stars" src="https://img.shields.io/github/stars/baosfeng/my-dsh-plugins?style=flat&color=4d6bfe" /> | 个人多插件合集（`dsh-file-activity`）：侧边栏文件活动页——记录文件读取 / 新增 / 修改历史与统计，按文件夹平铺，点击用原生预览打开 |
 | [Hoemr/dsh-better-overleaf](https://github.com/Hoemr/dsh-better-overleaf) | <img alt="stars" src="https://img.shields.io/github/stars/Hoemr/dsh-better-overleaf?style=flat&color=4d6bfe" /> | Overleaf 标签页：直连 CDP 浏览器登录（支持第三方 Chromium）、项目切换、工作区下 overleaf/ 目录本地 git 镜像与双向同步 |
+| [Andor-Z/dsh-turn-outline](https://github.com/Andor-Z/dsh-turn-outline) | <img alt="stars" src="https://img.shields.io/github/stars/Andor-Z/dsh-turn-outline?style=flat&color=4d6bfe" /> | 轮次轨迹页：按用户轮次折叠会话（输入 + 工具步骤 + 输出），点击任意步骤一键跳回对话原位；零 LLM、只读 |
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -198,7 +198,7 @@ The GitHub topic [`dsh-better-sidebar`](https://github.com/topics/dsh-better-sid
 ### 📑 Tab Plugins (sidebar pages)
 
 <details>
-<summary><b>24 plugins (click to expand)</b></summary>
+<summary><b>26 plugins (click to expand)</b></summary>
 
 | Plugin | ⭐ | Description |
 |---|---|---|
@@ -227,6 +227,7 @@ The GitHub topic [`dsh-better-sidebar`](https://github.com/topics/dsh-better-sid
 | [dong-victor/dsh-better-sidebar-starter](https://github.com/dong-victor/dsh-better-sidebar-starter) | <img alt="stars" src="https://img.shields.io/github/stars/dong-victor/dsh-better-sidebar-starter?style=flat&color=4d6bfe" /> | Run-configurations tab: IDEA-style Run/Debug configs (npm / springboot / python / custom) — one-click launch, history, WebSocket live logs (ANSI colors), parallel instances, cross-platform process-tree kill |
 | [baosfeng/my-dsh-plugins](https://github.com/baosfeng/my-dsh-plugins) | <img alt="stars" src="https://img.shields.io/github/stars/baosfeng/my-dsh-plugins?style=flat&color=4d6bfe" /> | Personal multi-plugin collection (`dsh-file-activity`): a sidebar file-activity tab recording read / added / modified history and stats, flat-browsed by folder, opened with the native preview |
 | [Hoemr/dsh-better-overleaf](https://github.com/Hoemr/dsh-better-overleaf) | <img alt="stars" src="https://img.shields.io/github/stars/Hoemr/dsh-better-overleaf?style=flat&color=4d6bfe" /> | Overleaf tab: direct-CDP browser login (third-party Chromium supported), project switching, local git mirrors under the workspace with two-way sync |
+| [Andor-Z/dsh-turn-outline](https://github.com/Andor-Z/dsh-turn-outline) | <img alt="stars" src="https://img.shields.io/github/stars/Andor-Z/dsh-turn-outline?style=flat&color=4d6bfe" /> | Turn-outline tab: folds the session by user turns (input + tool steps + output) with one-click jump-back to the exact spot in the conversation; zero-LLM, read-only |
 
 </details>
 

--- a/src/client/locales-ar.ts
+++ b/src/client/locales-ar.ts
@@ -448,5 +448,7 @@ export const ar: Record<string, string> = {
   pluginMdExportName: 'تصدير Markdown',
   pluginCodeNavName: 'مستكشف معاينة الكود',
   pluginVideoPreviewName: 'معاينة الفيديو',
+  pluginTurnOutlineName: "dsh-turn-outline مخطط الجولات",
+  pluginTurnOutlineDesc: "يطوي الجلسة إلى جولات المستخدم (الإدخال + خطوات الأدوات + المخرجات)؛ انقر على أي خطوة للانتقال إلى موضعها الدقيق في المحادثة — بدون استدعاء LLM، للقراءة فقط",
   presetDshDesktopDesc: 'وضع Electron المتقدم (بلا إطار): يحجز macOS شريطًا علويًا بمقدار 20px، ويحجز Windows بمقدار 32px لشريط العنوان عند غياب WCO',
 }

--- a/src/client/locales-de.ts
+++ b/src/client/locales-de.ts
@@ -433,5 +433,7 @@ export const de: Record<string, string> = {
   pluginMdExportName: 'Markdown-Export',
   pluginCodeNavName: 'Code-Vorschau-Navigation',
   pluginVideoPreviewName: 'Video-Vorschau',
+  pluginTurnOutlineName: "dsh-turn-outline Runden-Gliederung",
+  pluginTurnOutlineDesc: "Faltet die Sitzung in Benutzerrunden (Eingabe + Tool-Schritte + Ausgabe); Klick auf einen Schritt springt an die genaue Stelle im Gespräch — ohne LLM, nur lesend",
   presetDshDesktopDesc: 'Elektronischer Erweiterte-Modus (rahmenlos): macOS reserviert oben 20px; Windows reserviert ohne WCO 32px für die Titelleiste',
 }

--- a/src/client/locales-fr.ts
+++ b/src/client/locales-fr.ts
@@ -440,5 +440,7 @@ export const fr: Record<string, string> = {
   pluginMdExportName: 'Exportation Markdown',
   pluginCodeNavName: 'Navigateur d’aperçu de code',
   pluginVideoPreviewName: 'Aperçu vidéo',
+  pluginTurnOutlineName: "dsh-turn-outline Plan des tours",
+  pluginTurnOutlineDesc: "Plie la session en tours utilisateur (entrée + étapes d'outil + sortie) ; un clic sur une étape ramène à l'endroit exact de la conversation — sans LLM, en lecture seule",
   presetDshDesktopDesc: 'Mode avancé Electron (sans bordure) : macOS réserve 20px en haut ; Windows réserve 32px pour la barre de titre sans WCO',
 }

--- a/src/client/locales-hi.ts
+++ b/src/client/locales-hi.ts
@@ -447,5 +447,7 @@ export const hi: Record<string, string> = {
   pluginMdExportName: 'Markdown एक्सपोर्ट',
   pluginCodeNavName: 'कोड प्रीव्यू नेविगेटर',
   pluginVideoPreviewName: 'वीडियो प्रीव्यू',
+  pluginTurnOutlineName: "dsh-turn-outline टर्न रूपरेखा",
+  pluginTurnOutlineDesc: "सत्र को उपयोगकर्ता टर्न (इनपुट + टूल चरण + आउटपुट) में मोड़ें; किसी भी चरण पर क्लिक करें और बातचीत के सटीक स्थान पर जाएँ — कोई LLM कॉल नहीं, केवल पढ़ना",
   presetDshDesktopDesc: 'Electron एडवांस्ड (फ्रेमलेस) मोड: macOS ऊपर 20px सुरक्षित रखता है; Windows WCO अनुपलब्ध होने पर टाइटल बार के लिए 32px रखता है',
 }

--- a/src/client/locales-id.ts
+++ b/src/client/locales-id.ts
@@ -445,5 +445,7 @@ export const id: Record<string, string> = {
   pluginMdExportName: 'Ekspor Markdown',
   pluginCodeNavName: 'Navigator pratinjau kode',
   pluginVideoPreviewName: 'Pratinjau video',
+  pluginTurnOutlineName: "dsh-turn-outline Garis besar giliran",
+  pluginTurnOutlineDesc: "Melipat sesi menjadi giliran pengguna (input + langkah alat + output); klik langkah mana pun untuk melompat ke posisi persisnya dalam percakapan — tanpa panggilan LLM, hanya baca",
   presetDshDesktopDesc: 'Mode Electron lanjutan (tanpa bingkai): macOS mencadangkan 20px di atas; Windows mencadangkan 32px untuk bilah judul saat WCO tidak tersedia',
 }

--- a/src/client/locales-it.ts
+++ b/src/client/locales-it.ts
@@ -438,5 +438,7 @@ export const it: Record<string, string> = {
   pluginMdExportName: 'Esportazione Markdown',
   pluginCodeNavName: 'Navigatore anteprima codice',
   pluginVideoPreviewName: 'Anteprima video',
+  pluginTurnOutlineName: "dsh-turn-outline Schema dei turni",
+  pluginTurnOutlineDesc: "Ripiega la sessione in turni utente (input + passaggi strumento + output); clic su un passaggio per tornare al punto esatto della conversazione — nessuna chiamata LLM, sola lettura",
   presetDshDesktopDesc: 'Modalità avanzata Electron (senza bordi): macOS riserva 20px in alto; Windows riserva 32px per la barra del titolo quando WCO non è disponibile',
 }

--- a/src/client/locales-ja.ts
+++ b/src/client/locales-ja.ts
@@ -447,5 +447,7 @@ export const ja: Record<string, string> = {
   pluginMdExportName: 'Markdown エクスポート',
   pluginCodeNavName: 'コードプレビューナビゲーター',
   pluginVideoPreviewName: '動画プレビュー',
+  pluginTurnOutlineName: "dsh-turn-outline ターンアウトライン",
+  pluginTurnOutlineDesc: "セッションをユーザーターン（入力＋ツール手順＋出力）ごとに折りたたみ、任意のステップをクリックすると会話の該当箇所へワンクリックでジャンプ。LLM 呼び出しなし・読み取り専用",
   presetDshDesktopDesc: 'Electron 高度モード（枠なし）：macOS は上部 20px、Windows は WCO 未提供時に 32px のタイトルバー分を確保',
 }

--- a/src/client/locales-ko.ts
+++ b/src/client/locales-ko.ts
@@ -439,5 +439,7 @@ export const ko: Record<string, string> = {
   pluginMdExportName: 'Markdown 내보내기',
   pluginCodeNavName: '코드 미리보기 내비게이터',
   pluginVideoPreviewName: '동영상 미리보기',
+  pluginTurnOutlineName: "dsh-turn-outline 턴 아웃라인",
+  pluginTurnOutlineDesc: "세션을 사용자 턴(입력 + 도구 단계 + 출력)으로 접어 요약하고, 아무 단계나 클릭하면 대화의 정확한 위치로 한 번에 점프합니다. LLM 호출 없음, 읽기 전용",
   presetDshDesktopDesc: 'Electron 고급 모드(테두리 없음): macOS는 상단에 20px, Windows는 WCO가 없을 때 타이틀 바에 32px를 확보',
 }

--- a/src/client/locales-nl.ts
+++ b/src/client/locales-nl.ts
@@ -445,5 +445,7 @@ export const nl: Record<string, string> = {
   pluginMdExportName: 'Markdown-export',
   pluginCodeNavName: 'Codevoorvertoning-navigator',
   pluginVideoPreviewName: 'Videovoorvertoning',
+  pluginTurnOutlineName: "dsh-turn-outline Beurtoverzicht",
+  pluginTurnOutlineDesc: "Vouwt de sessie op in gebruikersbeurten (invoer + toolstappen + uitvoer); klik op een stap om terug te springen naar de exacte plek in het gesprek — zonder LLM-aanroepen, alleen-lezen",
   presetDshDesktopDesc: 'Geavanceerde Electronmodus (zonder rand): macOS reserveert 20px bovenaan; Windows reserveert 32px voor de titelbalk wanneer WCO niet beschikbaar is',
 }

--- a/src/client/locales-pl.ts
+++ b/src/client/locales-pl.ts
@@ -449,5 +449,7 @@ export const pl: Record<string, string> = {
   pluginMdExportName: 'Eksport Markdown',
   pluginCodeNavName: 'Nawigator podglądu kodu',
   pluginVideoPreviewName: 'Podgląd wideo',
+  pluginTurnOutlineName: "dsh-turn-outline Zarys tury",
+  pluginTurnOutlineDesc: "Składa sesję w tury użytkownika (wejście + kroki narzędzi + wyjście); kliknij dowolny krok, aby przeskoczyć do dokładnego miejsca w rozmowie — bez wywołań LLM, tylko do odczytu",
   presetDshDesktopDesc: 'Tryb zaawansowany Electron (bez ramki): macOS rezerwuje 20px u góry; Windows bez WCO rezerwuje 32px na pasek tytułu',
 }

--- a/src/client/locales-pt.ts
+++ b/src/client/locales-pt.ts
@@ -430,5 +430,7 @@ export const pt: Record<string, string> = {
   pluginMdExportName: 'Exportação Markdown',
   pluginCodeNavName: 'Navegador de pré-visualização de código',
   pluginVideoPreviewName: 'Pré-visualização de vídeo',
+  pluginTurnOutlineName: "dsh-turn-outline Esboço do turno",
+  pluginTurnOutlineDesc: "Dobra a sessão em turnos do usuário (entrada + etapas de ferramenta + saída); clique em qualquer etapa para voltar ao ponto exato da conversa — sem chamadas de LLM, somente leitura",
   presetDshDesktopDesc: 'Modo avançado Electron (sem moldura): o macOS reserva 20px no topo; o Windows reserva 32px para a barra de título sem WCO',
 }

--- a/src/client/locales-ru.ts
+++ b/src/client/locales-ru.ts
@@ -445,5 +445,7 @@ export const ru: Record<string, string> = {
   pluginMdExportName: 'Экспорт Markdown',
   pluginCodeNavName: 'Навигатор предпросмотра кода',
   pluginVideoPreviewName: 'Предпросмотр видео',
+  pluginTurnOutlineName: "dsh-turn-outline План раундов",
+  pluginTurnOutlineDesc: "Сворачивает сессию в раунды пользователя (ввод + шаги инструментов + вывод); клик по любому шагу возвращает к точному месту в диалоге — без вызовов LLM, только чтение",
   presetDshDesktopDesc: 'Расширенный режим Electron (без рамки): macOS резервирует 20px сверху; Windows без WCO резервирует 32px под строку заголовка',
 }

--- a/src/client/locales-sv.ts
+++ b/src/client/locales-sv.ts
@@ -430,5 +430,7 @@ export const sv: Record<string, string> = {
   pluginMdExportName: 'Markdown-export',
   pluginCodeNavName: 'Kodförhandsvisningsnavigatör',
   pluginVideoPreviewName: 'Videoförhandsvisning',
+  pluginTurnOutlineName: "dsh-turn-outline Varvöversikt",
+  pluginTurnOutlineDesc: "Viker sessionen i användarvarv (indata + verktygssteg + utdata); klicka på ett steg för att hoppa till exakt plats i samtalet — utan LLM-anrop, skrivskyddad",
   presetDshDesktopDesc: 'Electrons avancerade läge (ramlöst): macOS reserverar 20px högst upp; Windows reserverar 32px för namnlisten när WCO inte är tillgängligt',
 }

--- a/src/client/locales-th.ts
+++ b/src/client/locales-th.ts
@@ -447,5 +447,7 @@ export const th: Record<string, string> = {
   pluginMdExportName: 'ส่งออก Markdown',
   pluginCodeNavName: 'ตัวนำทางพรีวิวโค้ด',
   pluginVideoPreviewName: 'พรีวิววิดีโอ',
+  pluginTurnOutlineName: "dsh-turn-outline โครงร่างรอบ",
+  pluginTurnOutlineDesc: "พับเซสชันเป็นรอบของผู้ใช้ (อินพุต + ขั้นตอนเครื่องมือ + เอาต์พุต) คลิกขั้นตอนใดก็ได้เพื่อข้ามไปยังตำแหน่งที่แน่นอนในบทสนทนา — ไม่มีการเรียก LLM อ่านอย่างเดียว",
   presetDshDesktopDesc: 'โหมดขั้นสูงของ Electron (ไร้กรอบ): macOS จองแถบด้านบน 20px; Windows จอง 32px ให้แถบหัวเรื่องเมื่อไม่มี WCO',
 }

--- a/src/client/locales-tr.ts
+++ b/src/client/locales-tr.ts
@@ -447,5 +447,7 @@ export const tr: Record<string, string> = {
   pluginMdExportName: 'Markdown dışa aktarma',
   pluginCodeNavName: 'Kod önizleme gezgini',
   pluginVideoPreviewName: 'Video önizlemesi',
+  pluginTurnOutlineName: "dsh-turn-outline Tur özeti",
+  pluginTurnOutlineDesc: "Oturumu kullanıcı turlarına (girdi + araç adımları + çıktı) katlar; herhangi bir adıma tıklayarak sohbette tam konumuna atlayın — LLM çağrısı yok, yalnızca okunur",
   presetDshDesktopDesc: 'Electron gelişmiş (çerçevesiz) mod: macOS üstte 20px ayırır; Windows, WCO yokken başlık çubuğu için 32px ayırır',
 }

--- a/src/client/locales-vi.ts
+++ b/src/client/locales-vi.ts
@@ -447,5 +447,7 @@ export const vi: Record<string, string> = {
   pluginMdExportName: 'Xuất Markdown',
   pluginCodeNavName: 'Trình điều hướng xem trước mã',
   pluginVideoPreviewName: 'Xem trước video',
+  pluginTurnOutlineName: "dsh-turn-outline Dàn ý theo vòng",
+  pluginTurnOutlineDesc: "Gấp phiên thành các vòng của người dùng (đầu vào + bước công cụ + đầu ra); nhấp vào bất kỳ bước nào để nhảy về đúng vị trí trong hội thoại — không gọi LLM, chỉ đọc",
   presetDshDesktopDesc: 'Chế độ Electron nâng cao (không viền): macOS dành 20px ở trên cùng; Windows dành 32px cho thanh tiêu đề khi không có WCO',
 }

--- a/src/client/locales-zh-HK.ts
+++ b/src/client/locales-zh-HK.ts
@@ -462,5 +462,7 @@ export const zhHK: Record<string, string> = {
   pluginMdExportName: 'Markdown 匯出插件',
   pluginCodeNavName: '程式碼預覽導航',
   pluginVideoPreviewName: '影片預覽插件',
+  pluginTurnOutlineName: "dsh-turn-outline 輪次軌跡",
+  pluginTurnOutlineDesc: "把會話按用戶輪次摺疊成「輸入 + 工具步驟 + 輸出」摘要，點擊任意步驟一鍵跳回對話原位；零 LLM 調用、唯讀",
   presetDshDesktopDesc: 'Electron 進階模式（無邊框）：macOS 頂欄 20px、Windows 無 WCO 時 32px 標題欄讓位',
 }

--- a/src/client/locales-zh-MO.ts
+++ b/src/client/locales-zh-MO.ts
@@ -462,5 +462,7 @@ export const zhMO: Record<string, string> = {
   pluginMdExportName: 'Markdown 匯出插件',
   pluginCodeNavName: '代碼預覽導航',
   pluginVideoPreviewName: '影片預覽插件',
+  pluginTurnOutlineName: "dsh-turn-outline 輪次軌跡",
+  pluginTurnOutlineDesc: "把會話按用戶輪次摺疊成「輸入 + 工具步驟 + 輸出」摘要，點擊任意步驟一鍵跳回對話原位；零 LLM 調用、唯讀",
   presetDshDesktopDesc: 'Electron 進階模式（無邊框）：macOS 頂欄 20px、Windows 無 WCO 時 32px 標題欄讓位',
 }

--- a/src/client/locales-zh-TW.ts
+++ b/src/client/locales-zh-TW.ts
@@ -462,5 +462,7 @@ export const zhTW: Record<string, string> = {
   pluginMdExportName: 'Markdown 匯出插件',
   pluginCodeNavName: '程式碼預覽導覽',
   pluginVideoPreviewName: '影片預覽插件',
+  pluginTurnOutlineName: "dsh-turn-outline 輪次軌跡",
+  pluginTurnOutlineDesc: "把會話按用戶輪次摺疊成「輸入 + 工具步驟 + 輸出」摘要，點擊任意步驟一鍵跳回對話原位；零 LLM 調用、唯讀",
   presetDshDesktopDesc: 'Electron 進階模式（無邊框）：macOS 頂欄 20px、Windows 無 WCO 時 32px 標題列讓位',
 }

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -454,6 +454,8 @@ export const zh = {
   pluginMdExportName: 'Markdown 导出插件',
   pluginCodeNavName: '代码预览导航',
   pluginVideoPreviewName: '视频预览插件',
+  pluginTurnOutlineName: 'dsh-turn-outline 轮次轨迹',
+  pluginTurnOutlineDesc: '把会话按用户轮次折叠成「输入 + 工具步骤 + 输出」摘要，点击任意步骤一键跳回对话原位；零 LLM 调用、只读',
   presetDshDesktopDesc: 'Electron 高级模式（无边框）：macOS 顶栏 20px、Windows 无 WCO 时 32px 标题栏让位',
 }
 
@@ -890,6 +892,8 @@ export const en: Record<keyof typeof zh, string> = {
   pluginMdExportName: 'Markdown Export',
   pluginCodeNavName: 'Code Preview Navigator',
   pluginVideoPreviewName: 'Video Preview',
+  pluginTurnOutlineName: 'dsh-turn-outline Turn Outline',
+  pluginTurnOutlineDesc: 'Fold the session into user turns (input + tool steps + output) and click any step to jump back to its exact spot in the conversation — no LLM calls, read-only',
   presetDshDesktopDesc: 'Electron advanced (frameless) mode: macOS reserves a 20px top strip; Windows reserves a 32px title bar when WCO is unavailable',
 }
 

--- a/src/client/plugins-tabs.ts
+++ b/src/client/plugins-tabs.ts
@@ -157,10 +157,10 @@ export const builtinTabPlugins: readonly PluginEntry[] = [
     description: () => t('pluginTurnOutlineDesc'),
     // Turn-outline tab: folds the session by user turns (input + tool steps
     // + output) with one-click jump-back into the conversation. Optional
-    // peer of better-sidebar, published on npm. Stable-line policy: the
-    // plugin validates against better-sidebar 0.17.x + DSH 0.1.1-rc.x; npm
-    // latest (0.18.0) targets DSH 0.1.2-rc.1+ and is not co-tested yet, so
-    // the prerequisite is pinned to 0.17.1.
-    install: 'cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar@0.17.1 && dsh plugin --profile web add dsh-turn-outline',
+    // peer of better-sidebar, published on npm. The plugin declares
+    // `dsh-better-sidebar@^0.17.0 || ^0.18.0` and is co-tested on both
+    // lines: better-sidebar 0.18.0 + DSH 0.1.2-rc.1 (since plugin 0.2.7)
+    // and better-sidebar 0.17.1 + DSH 0.1.1-rc.x (stable).
+    install: 'cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar && dsh plugin --profile web add dsh-turn-outline',
   },
 ]

--- a/src/client/plugins-tabs.ts
+++ b/src/client/plugins-tabs.ts
@@ -150,4 +150,17 @@ export const builtinTabPlugins: readonly PluginEntry[] = [
     // better-sidebar tab service, so install the prerequisite first.
     install: 'cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar && dsh plugin --profile web add github:Johnblur/dsh-bilingual-reader',
   },
+  {
+    id: 'dsh-turn-outline',
+    name: () => t('pluginTurnOutlineName'),
+    url: 'https://github.com/Andor-Z/dsh-turn-outline',
+    description: () => t('pluginTurnOutlineDesc'),
+    // Turn-outline tab: folds the session by user turns (input + tool steps
+    // + output) with one-click jump-back into the conversation. Optional
+    // peer of better-sidebar, published on npm. Stable-line policy: the
+    // plugin validates against better-sidebar 0.17.x + DSH 0.1.1-rc.x; npm
+    // latest (0.18.0) targets DSH 0.1.2-rc.1+ and is not co-tested yet, so
+    // the prerequisite is pinned to 0.17.1.
+    install: 'cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar@0.17.1 && dsh plugin --profile web add dsh-turn-outline',
+  },
 ]


### PR DESCRIPTION
## 收录申请：dsh-turn-outline（轮次轨迹 tab）

> **Update 2026-09-04**：插件已发布 **0.2.7**，适配 better-sidebar 0.18.0（DSH 0.1.2-rc.1 正式线）——peer 放宽为 `^0.17.0 || ^0.18.0` 并在双线真机联调，目录安装行随之**去 pin**（与本目录其余条目的惯例一致）；分支已 rebase 到最新 main。

### 插件信息

| 项 | 值 |
|---|---|
| npm 包名（目录 id） | `dsh-turn-outline`（已发布，`latest` = 0.2.7） |
| 仓库 | https://github.com/Andor-Z/dsh-turn-outline （已打 `dsh-better-sidebar` / `dsh-plugin` / `dsh` / `deepseek-harness` / `sidebar` topics） |
| 类型 | Tab 注册插件（`registerTab`，single） |
| 依赖 | `dsh-better-sidebar` 可选 peer（`^0.17.0 || ^0.18.0`，未装则 inert）；零 LLM 调用、只读 |

**功能一句话**：按用户轮次把会话折叠成「输入 + 工具步骤 + 输出」摘要，点击任意步骤一键跳回对话原位（聊天 / 轨迹视图双支持）。

### 变更内容

1. **README.md / README_EN.md**「🌐 插件生态 → 📑 Tab 插件」表格各加一行（zh/en），表头计数 24 → 26。
   - 注：表头此前已落后实际行数（表中本有 25 行），本次一并修正为与行数一致。
2. **src/client/plugins-tabs.ts**：追加 `dsh-turn-outline` 推荐目录条目：
   ```sh
   cd ~/.dsh && dsh plugin --profile web add dsh-better-sidebar && dsh plugin --profile web add dsh-turn-outline
   ```
   **版本线说明**：插件 peer 声明 `dsh-better-sidebar@^0.17.0 || ^0.18.0`，双线均已联调——**better-sidebar 0.18.0 + DSH 0.1.2-rc.1**（0.2.7 起）与 **better-sidebar 0.17.1 + DSH 0.1.1-rc.x（stable）**。0.18.0 对插件面 API 为零变化（[#537](https://github.com/omdsh-dev/DSH-better-sidebar/pull/537) 纯版本升级，`registerTab` 契约原样），故前置依赖不做钉版，与目录其余条目一致。
3. **i18n**：`pluginTurnOutlineName` / `pluginTurnOutlineDesc` 补全全部 20 本词典（`locales.ts` 的 zh/en + 19 个 locale chunk），保持 `tests/locales.spec.ts` 键位对齐；文案为 best-effort 初稿（词风参照 turn-review / bilingual-reader 既有条目），欢迎维护者润色。

### 自检

- [x] `npm view dsh-turn-outline` → 0.2.7 已在 registry（`latest`；peer `^0.17.0 || ^0.18.0`），目录安装行可实际执行
- [x] 仓库 topics 含 `dsh-better-sidebar`
- [x] 条目满足 `tests/plugin-list.spec.ts`（id = npm 包名 / url 以 github.com 开头 / install 以 `cd ~/.dsh` 开头且含 `dsh plugin`）
- [x] 20 本词典键位对齐（`tests/locales.spec.ts` 口径）
- [x] 插件自身套件 80/80 通过（含 host 路由 / client tab / 折叠与跳回），发布走 GitHub Release → npm trusted publishing（dry_run 预检 + 正式发布均绿）

> 仓库全量套件请以 CI 为准；如个别语言措辞需要调整，我随时跟进修改。
