### PR TITLE
fix: Align node-pty version with DSH v0.1.2-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "clsx": "^2.1.1",
     "dompurify": "^3.4.14",
     "mermaid": "^11.16.1",
-    "node-pty": "^1.1.0",
+    "node-pty": "1.2.0-beta.15",
     "react-icons": "5.7.0",
     "rxjs": "^7.8.2",
     "schemastery": "^3.18.0",

--- a/src/pty-deps.ts
+++ b/src/pty-deps.ts
@@ -39,7 +39,7 @@ export type NodePtyModule = typeof nodePtyNs
  * range DSH core declares (`@deepseek-ai/dsh-subprocess-local`): the same
  * range keeps pnpm resolving both to one physical package.
  */
-export const DSH_NODE_PTY_RANGE = '^1.1.0'
+export const DSH_NODE_PTY_RANGE = '1.2.0-beta.15'
 
 /**
  * The WebSocket close-code-1011 reason the host sends when node-pty is


### PR DESCRIPTION
Align `node-pty` with DSH `dsh-v0.1.2-rc.1`

Update the `node-pty` dependency and `DSH_NODE_PTY_RANGE` from `^1.1.0` to `1.2.0-beta.15`, matching `@deepseek-ai/dsh-subprocess-local` in DSH tag `dsh-v0.1.2-rc.1`. The stale range resolves to `node-pty@1.1.0` and adds a redundant installation