### PR TITLE
fix: open Zed on Windows by direct spawn instead of zed:// URL

### DIFF
--- a/src/client/open-with.ts
+++ b/src/client/open-with.ts
@@ -200,9 +200,12 @@ function schemeOf(template: string): string | undefined {
   return /^[a-z][a-z0-9+.-]*$/i.test(scheme) ? scheme : undefined
 }
 
-/** Normalize a filesystem path for embedding in a URL (backslashes → '/'). */
+/** Normalize a filesystem path for embedding in a URL: convert backslashes to
+ *  forward slashes, then percent-encode characters that are invalid in a URL
+ *  path (spaces, Unicode, #, etc.). The colon after a drive letter and the
+ *  forward slashes are kept as-is — they are valid URL path characters. */
 export function normalizeUrlPath(path: string): string {
-  return path.replace(/\\/g, '/')
+  return encodeURI(path.replace(/\\/g, '/'))
 }
 
 /** A fresh custom-editor id (uuid when available, time-based fallback). */

--- a/src/open-external.ts
+++ b/src/open-external.ts
@@ -6,24 +6,24 @@
  * The client runs in a browser / DSH Desktop renderer where a raw `vscode://`
  * navigation is unreliable, so both actions fan out through this host route
  * and spawn the platform opener with an argv array (no shell interpolation).
- * The command builders are pure — the platform is injectable — so every
+ * The command builders are pure 鈥?the platform is injectable 鈥?so every
  * per-platform branch is unit-testable without spawning anything.
  */
-import { spawn } from 'node:child_process'
+import { spawn, execSync } from 'node:child_process'
 import { parentOf, requireAbsolute } from './fs-tree.ts'
 import { SidebarError } from './wire.ts'
 
 /** The two external open actions the route accepts. */
 export type OpenExternalAction = 'reveal' | 'url'
 
-/** One platform opener invocation (argv array — never a shell string). */
+/** One platform opener invocation (argv array 鈥?never a shell string). */
 export interface ExternalCommand {
   command: string
   args: string[]
 }
 
 /** Reveal/select a path in the OS file manager. On Linux there is no common
- *  select protocol — the containing directory is opened instead (KISS). */
+ *  select protocol 鈥?the containing directory is opened instead (KISS). */
 export function revealCommand(path: string, platform: NodeJS.Platform = process.platform): ExternalCommand {
   switch (platform) {
     case 'darwin':
@@ -39,8 +39,59 @@ export function revealCommand(path: string, platform: NodeJS.Platform = process.
   }
 }
 
+/** Cache the Zed executable path after first registry lookup. */
+let zedPathMemo: string | null | undefined
+
+/** Read the Zed executable path from the Windows registry (HKCU then HKLM). */
+function findZedPath(): string | null {
+  if (zedPathMemo !== undefined) return zedPathMemo
+  try {
+    const out = execSync(
+      'powershell -NoProfile -Command "& {get-itemproperty \'HKCU:\\Software\\Classes\\zed\\shell\\open\\command\' \'(default)\' 2>$null} | select -expand \'(default)\' -first 1"',
+      { encoding: 'utf-8', timeout: 3000, windowsHide: true },
+    ).trim()
+    // The value is something like: "D:\soft\Zed\Zed.exe" "%1"
+    const m = out.match(/^"([^"]+\.exe)"/)
+    if (m) { zedPathMemo = m[1]; return m[1] }
+  } catch { /* fall through */ }
+  try {
+    const out = execSync(
+      'powershell -NoProfile -Command "& {get-itemproperty \'HKLM:\\SOFTWARE\\Classes\\zed\\shell\\open\\command\' \'(default)\' 2>$null} | select -expand \'(default)\' -first 1"',
+      { encoding: 'utf-8', timeout: 3000, windowsHide: true },
+    ).trim()
+    const m = out.match(/^"([^"]+\.exe)"/)
+    if (m) { zedPathMemo = m[1]; return m[1] }
+  } catch { /* fall through */ }
+  zedPathMemo = null
+  return null
+}
+
+/** Extract a Windows file path from a `zed://file/C:/path` URL. */
+function zedUrlToPath(url: string): string | null {
+  // url = zed://file/C:/dsh-ecosystem/plugins/pnpm-lock.yaml
+  const prefix = 'zed://file/'
+  if (!url.startsWith(prefix)) return null
+  const encoded = url.slice(prefix.length)  // C:/dsh-ecosystem/plugins/pnpm-lock.yaml
+  try {
+    return decodeURI(encoded)
+  } catch {
+    return encoded
+  }
+}
+
 /** Hand a custom-scheme URL to the OS protocol handler. */
 export function urlCommand(url: string, platform: NodeJS.Platform = process.platform): ExternalCommand {
+  // Zed on Windows does not correctly parse zed://file/C:/path URLs.
+  // Read the Zed install path from the registry and launch it directly
+  // with the file path as a command-line argument.
+  if (platform === 'win32' && url.startsWith('zed://')) {
+    const zedPath = findZedPath()
+    const filePath = zedUrlToPath(url)
+    if (zedPath && filePath) {
+      return { command: zedPath, args: [filePath] }
+    }
+    // Fall through to rundll32 if registry lookup failed
+  }
   switch (platform) {
     case 'darwin':
       return { command: 'open', args: [url] }
@@ -54,7 +105,7 @@ export function urlCommand(url: string, platform: NodeJS.Platform = process.plat
 }
 
 /** Validate a URL-scheme open target: a parseable custom-scheme URL (never
- *  http/https — those would only dump the URL into a browser tab). */
+ *  http/https 鈥?those would only dump the URL into a browser tab). */
 export function validateExternalUrl(raw: string): string {
   if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
     throw new SidebarError('bad-request', 'url must be a custom-scheme URL')
@@ -73,8 +124,7 @@ export function validateExternalUrl(raw: string): string {
 
 /**
  * Launch one external open action and return immediately (detached, no
- * stdio). Spawn failures are reported through the child's 'error' event —
- * by then the route already returned, so the event is swallowed (the OS
+ * stdio). Spawn failures are reported through the child's 'error' event 鈥? * by then the route already returned, so the event is swallowed (the OS
  * dialog about a missing handler is the user-visible outcome either way).
  */
 export function launchExternal(action: OpenExternalAction, value: string): { started: true } {


### PR DESCRIPTION
## Problem

On Windows, "Open in Zed" from the file tree context menu launches Zed but does not open the selected file. VSCode and Cursor work correctly.

Zed's URL parser does not correctly convert `zed://file/C:/path` URLs to Windows file paths, so it launches with an empty window.

## Changes

### `src/open-external.ts`
- Read the Zed executable path from the Windows registry
- Extract the file path from the `zed://file/…` URL
- Spawn Zed directly with the file path, bypassing the broken URL handler
- Falls back to `rundll32` if the registry lookup fails

### `src/client/open-with.ts`
- `normalizeUrlPath` now uses `encodeURI()` to percent-encode special characters