### PR TITLE
fix(config): share the host Schemastery runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@deepseek-ai/dsh-settings": "^0.1.2-rc.1",
     "@deepseek-ai/dsh-subagent": "^0.1.2-rc.1",
     "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
+    "@deepseek-ai/schemastery": "^3.18.2",
     "@huanlin/dsh-plugin-better-locale": "^0.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -139,7 +140,6 @@
     "node-pty": "^1.1.0",
     "react-icons": "5.7.0",
     "rxjs": "^7.8.2",
-    "schemastery": "^3.18.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
@@ -164,6 +164,7 @@
     "@deepseek-ai/dsh-tools": "0.1.2-rc.1",
     "@deepseek-ai/dsh-user-approval": "0.1.2-rc.1",
     "@deepseek-ai/dsh-util-time": "0.1.2-rc.1",
+    "@deepseek-ai/schemastery": "3.18.2",
     "@huanlin/dsh-plugin-better-locale": "^0.1.0",
     "@playwright/test": "^1.62.1",
     "@types/node": "^24.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
       ws:
         specifier: ^8.18.0
         version: 8.21.3
@@ -165,6 +162,9 @@ importers:
       '@deepseek-ai/dsh-util-time':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/schemastery':
+        specifier: 3.18.2
+        version: 3.18.2
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.9.1)
@@ -2755,9 +2755,6 @@ packages:
 
   scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
-
-  schemastery@3.18.0:
-    resolution: {integrity: sha512-Jw2uxjoyyqc/yeurmChUEc/jbi8GsrdXV/KmqRUDZXJAXAmrJiPsz8vKa17l/VckyzljHZ9oGaul443CQiXxtA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5928,11 +5925,6 @@ snapshots:
   scheduler@0.23.0:
     dependencies:
       loose-envify: 1.4.0
-
-  schemastery@3.18.0:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      cosmokit: 1.8.1
 
   semver@6.3.1: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@
  * @module dsh-better-sidebar/config
  */
 
-import z from 'schemastery'
+import z from '@deepseek-ai/schemastery'
 import {
   TERMINAL_FONT_SIZE_DEFAULT,
   TERMINAL_FONT_SIZE_MAX,

--- a/tests/agent-pty.spec.ts
+++ b/tests/agent-pty.spec.ts
@@ -85,7 +85,7 @@ describe('AgentPtyRegistry', () => {
     } finally {
       registry.disposeAll()
     }
-  })
+  }, 15_000)
 
   it('spawns a bare shell when command is empty', () => {
     const registry = new AgentPtyRegistry(testShell())
@@ -118,7 +118,7 @@ describe('AgentPtyRegistry', () => {
     } finally {
       registry.disposeAll()
     }
-  })
+  }, 15_000)
 
   it('reads a bounded page of the transcript', async () => {
     const registry = new AgentPtyRegistry(testShell())
@@ -136,7 +136,7 @@ describe('AgentPtyRegistry', () => {
     } finally {
       registry.disposeAll()
     }
-  })
+  }, 15_000)
 
   it('resizes without throwing', () => {
     const registry = new AgentPtyRegistry(testShell())

--- a/tests/e2e/drag-layout.e2e.ts
+++ b/tests/e2e/drag-layout.e2e.ts
@@ -725,7 +725,7 @@ test('dragging the bottom strip while the right panel is closed keeps the host l
       return probe === null ? Number.NaN : probe
     }, { timeout: 30_000 })
     .toBeLessThanOrEqual(8)
-  const stripBox = await page.evaluate(() => {
+  const readStripBox = (): Promise<{ x: number; y: number } | null> => page.evaluate(() => {
     const bottom = document.querySelector('[data-dsh-better-sidebar] [data-dsh-bottom-panel]')
     if (bottom === null) return null
     const strip = [...bottom.querySelectorAll<HTMLElement>('*')].find(el => getComputedStyle(el).cursor === 'row-resize')
@@ -733,11 +733,31 @@ test('dragging the bottom strip while the right panel is closed keeps the host l
     const r = strip.getBoundingClientRect()
     return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
   })
-  expect(stripBox, 'the bottom drag strip must be present (cursor: row-resize)').not.toBeNull()
+
+  // The compositor can finish the slide a frame after the geometry poll.
+  // Re-acquire the moving strip and retry pointerdown if that boundary frame
+  // missed it; once the body marker appears, the real drag is live.
+  let stripBox: { x: number; y: number } | null = null
+  let dragStarted = false
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    stripBox = await readStripBox()
+    expect(stripBox, 'the bottom drag strip must be present (cursor: row-resize)').not.toBeNull()
+    await page.mouse.move(stripBox!.x, stripBox!.y)
+    await page.mouse.down()
+    try {
+      await expect
+        .poll(async () => page.evaluate(() => document.body.hasAttribute('data-dsh-sidebar-dragging')), { timeout: 1_000 })
+        .toBe(true)
+      dragStarted = true
+      break
+    } catch {
+      await page.mouse.up()
+      await page.waitForTimeout(150)
+    }
+  }
+  expect(dragStarted, 'pointerdown must engage the bottom drag strip').toBe(true)
 
   // Drag the strip UP (grow the bottom panel) in steps, like a real resize.
-  await page.mouse.move(stripBox!.x, stripBox!.y)
-  await page.mouse.down()
   for (let i = 1; i <= 12; i++) {
     await page.mouse.move(stripBox!.x, stripBox!.y - i * 8, { steps: 2 })
     await page.waitForTimeout(40)

--- a/tests/manifest-consistency.spec.ts
+++ b/tests/manifest-consistency.spec.ts
@@ -103,6 +103,12 @@ describe.skipIf(!libBuilt)('registry manifest consistency (dsh.plugin.json)', ()
     expect(registryId).not.toBe(pkg.name)
   })
 
+  it('the host bundle keeps the shared scoped Schemastery runtime external', () => {
+    const source = readFileSync(resolve(ROOT, manifest.main), 'utf8')
+    expect(source).toContain('from "@deepseek-ai/schemastery"')
+    expect(source).not.toMatch(/from ["']schemastery["']/)
+  })
+
   it('the lazy chunk bundles exist and assign their global registry slots (served by /sidebar/bundle)', () => {
     for (const file of CHUNK_FILES) {
       expect(existsSync(resolve(ROOT, file)), file).toBe(true)

--- a/tests/market-manifest.spec.ts
+++ b/tests/market-manifest.spec.ts
@@ -76,6 +76,11 @@ describe('DSH community-market manifest compatibility', () => {
     }
   })
 
+  it('shares the host Schemastery runtime instead of installing the legacy bare package', () => {
+    expect(pkg.dependencies).not.toHaveProperty('schemastery')
+    expect(pkg.peerDependencies).toHaveProperty('@deepseek-ai/schemastery', '^3.18.2')
+  })
+
   it('declares no install lifecycle scripts in the PACKED manifest (the published surface)', () => {
     const packed = packedManifest()
     const scripts = (packed.scripts as Record<string, string> | undefined) ?? {}

--- a/tests/plugin-shape.spec.ts
+++ b/tests/plugin-shape.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import Loader from '@cordisjs/plugin-loader'
+import Schema from '@deepseek-ai/schemastery'
 import * as sidebar from '../src/index.ts'
 
 /**
@@ -25,6 +26,10 @@ describe('dsh-better-sidebar plugin export shape', () => {
   it('exports the schemastery Config with the documented tunable fields', () => {
     const schema = sidebar.Config
     expect(schema).toBeDefined()
+    // The loader/settings stack and this plugin must share the scoped DSH
+    // Schemastery constructor; a bundled legacy `schemastery` copy breaks
+    // runtime identity even when its schema objects look structurally alike.
+    expect(schema).toBeInstanceOf(Schema)
     // The resolved defaults mirror the pre-config constants.
     const resolved = (schema as unknown as {
       (input: Record<string, unknown> | undefined): Record<string, unknown>


### PR DESCRIPTION
## Summary

- replace the legacy bare schemastery import with @deepseek-ai/schemastery
- declare the host-provided scoped package as a peer dependency and pin 3.18.2 for development
- guard the published manifest, runtime Schema identity, and host bundle externalization
- give the real Windows PTY integration cases enough time for ConPTY cleanup
- retry the bottom-resize pointerdown when the compositor finishes its slide on the boundary frame

## Verification

- pnpm peers check
- pnpm typecheck
- ESLint on changed source and tests
- pnpm exec vitest run tests/manifest-consistency.spec.ts tests/plugin-shape.spec.ts tests/market-manifest.spec.ts
- pnpm exec vitest run tests/agent-pty.spec.ts
- pnpm build

Closes #546