### PR TITLE
fix: preview absolute Markdown links in sidebar

### DIFF
--- a/docs/external-plugin-guide.md
+++ b/docs/external-plugin-guide.md
@@ -419,6 +419,7 @@ interface FileViewerProps {
   mediaUrl?: string        // fetchStrategy='mediaUrl' 时
   customData?: unknown     // fetchStrategy='custom' 时（load() 的返回值）
   // 以下为内置文本编辑器与 EditorHost 内部协作字段，外部 viewer 忽略：
+  readOnly?: boolean       // 会话外 Markdown 的显式点击预览：只读、不可保存
   toolbar?: 'self' | 'host'
   onToolbarState?: (state: EditorToolbarState) => void
   onToolbarControls?: (controls: EditorToolbarControls | null) => void
@@ -731,6 +732,7 @@ ctx.effect(() =>
 | **第三语言覆盖（ja 等）** | 可选 peer `@huanlin/dsh-plugin-better-locale`（optional）提供 ja/ko 覆盖，**借用 DSH 英文槽位**（仅 DSH=en 时生效，zh 下惰性）。经 `ctx.get('betterLocale')` 注入 `t()`；未安装整段 no-op |
 | **懒加载 chunk** | 重依赖（xterm/CodeMirror）在独立 bundle（`lib/client-<name>.js`），经 `/sidebar/bundle` 按需下发；factory 赋到 `globalThis.__dshChunks__[<name>]`，由 `src/client/chunk-loader.ts` 物化，**不经** `__ModuleLoader__`。对消费插件透明 |
 | **聊天文件打开漏斗（alpha 宿主）** | 聊天里一切文件打开（工具行 / 产物行 / 正文提及 / 行内代码路径）汇入 `ctx.remote.session.openWorkspacePath`（Typert remote 命名空间，cordis 服务 key `remote.session`，方法为 **accessor 属性**、异步挂载）。better-sidebar 的「聊天区文件在侧边栏打开」即在 `ctx.inject(['remote.session'], …)` 内以 defineProperty 遮蔽该方法（`src/client/openpath-intercept.ts`）。你的插件若要观测/旁路聊天文件打开，走同一服务；不要假设 pre-alpha 的 `ctx.workspaces.openPath` 存在（alpha 的 `IWorkspaces` 已无此方法） |
+| **会话结果中的绝对 Markdown 路径** | stock `chatFileMentions` 先解析当轮产物；better-sidebar 仅对完整的 POSIX / Windows 绝对 `.md` / `.markdown` 行内代码补链接，并继续走聊天文件打开漏斗。工作区外文件需由 loopback TCP 客户端显式点击后取得随机、会话绑定、精确路径的内存读授权；该 tab 强制只读，`fs.write` 与其它路径仍按 `workspaceFence` 规则处理 |
 
 ---
 

--- a/src/client/EditorHost.tsx
+++ b/src/client/EditorHost.tsx
@@ -110,7 +110,12 @@ export function EditorHost(props: {
   // directory as an editor tab carrying `meta.dir: true` with the directory
   // as its path. It renders the file tree rooted at that folder instead of
   // the viewer loading flow (a directory is not a file).
-  const isDir = metaOf(tab).dir === true
+  const tabMeta = metaOf(tab)
+  const isDir = tabMeta.dir === true
+  /** Exact-path read capability for a user-clicked Markdown document outside
+   *  the session workspace. Its tab is always preview-only. */
+  const previewGrant = typeof tabMeta.previewGrant === 'string' ? tabMeta.previewGrant : undefined
+  const readOnly = previewGrant !== undefined && tabMeta.readOnly === true
   const [load, setLoad] = useState<EditorLoad>({ status: 'loading' })
   // Manual refresh (issue #167): bumping the sequence re-runs the load effect
   // with the same path/scope — the only reload entry besides open/close.
@@ -160,7 +165,10 @@ export function EditorHost(props: {
    */
   const openFile = (absolute: string): void => {
     if (inPlace) {
-      ctx.get('betterSidebar')?.updateTab(tab.id, { path: absolute, title: baseName(absolute) })
+      // A preview grant is exact-path. Navigating this tab to another file
+      // must drop it (and the read-only marker) while preserving tree chrome.
+      const { previewGrant: _previewGrant, readOnly: _readOnly, ...nextMeta } = tabMeta
+      ctx.get('betterSidebar')?.updateTab(tab.id, { path: absolute, title: baseName(absolute), meta: nextMeta })
     } else {
       openSidebarFile(ctx, store, scope.sessionId, absolute)
     }
@@ -330,7 +338,7 @@ export function EditorHost(props: {
           })
           return
         case 'fetchFsRead':
-          api.fsRead(scope, path).then((result) => {
+          api.fsRead(scope, path, controller.signal, previewGrant).then((result) => {
             if (cancelled) return
             // Binary reads carry the head bytes for the detect re-match.
             const outcome = planFsReadOutcome(action.viewer, {
@@ -352,7 +360,7 @@ export function EditorHost(props: {
     // The deps are deliberately granular: the scope object's identity churns,
     // only its sessionId / cwd fields gate the (re)fetch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scope.sessionId, scope.cwd, path, ctx, showEmpty, isDir, reloadSeq])
+  }, [scope.sessionId, scope.cwd, path, ctx, showEmpty, isDir, reloadSeq, previewGrant])
 
   // Save-then-refresh in preview mode (issue #167 part C): the edge into
   // 'saved' (never a lingering 'saved' state) triggers exactly one reload, so
@@ -490,6 +498,7 @@ export function EditorHost(props: {
             truncated: load.truncated,
             mediaUrl: load.mediaUrl,
             customData: load.customData,
+            readOnly,
             // The viewer's toolbar always hoists into this host's header.
             toolbar: 'host',
             onToolbarState,

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -151,7 +151,10 @@ export function TextEditor(props: FileViewerProps) {
         history(),
         EditorState.tabSize.of(2),
         CodeMirrorView.contentAttributes.of({ spellcheck: 'false' }),
+        // editable=false protects the DOM; readOnly=true also blocks editing
+        // commands/transactions from the remaining navigation keymaps.
         CodeMirrorView.editable.of(!readOnly),
+        EditorState.readOnly.of(readOnly),
         cmSurfaceTheme,
         themeComp.of(dark),
         ...(language !== null ? [language] : []),

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -61,6 +61,7 @@ const previewScrollKey = (scope: { sessionId: string }, path: string): string =>
 
 export function TextEditor(props: FileViewerProps) {
   const { ctx, scope, path, viewerId, content, truncated } = props
+  const readOnly = props.readOnly === true
   const [mode, setMode] = useState<ViewMode>('preview')
   /** The editor's current text (null while clean); preview renders this. */
   const [draft, setDraft] = useState<string | null>(null)
@@ -150,6 +151,7 @@ export function TextEditor(props: FileViewerProps) {
         history(),
         EditorState.tabSize.of(2),
         CodeMirrorView.contentAttributes.of({ spellcheck: 'false' }),
+        CodeMirrorView.editable.of(!readOnly),
         cmSurfaceTheme,
         themeComp.of(dark),
         ...(language !== null ? [language] : []),
@@ -159,11 +161,11 @@ export function TextEditor(props: FileViewerProps) {
           }
         }),
         keymap.of([
-          {
+          ...(readOnly ? [] : [{
             key: 'Mod-s',
             preventDefault: true,
             run: () => { save(); return true },
-          },
+          }]),
           ...defaultKeymap,
           ...historyKeymap,
         ]),
@@ -223,7 +225,7 @@ export function TextEditor(props: FileViewerProps) {
     // tab's lifetime, and the dark flip is handled by the reconfigure
     // effect below (recreating the view here would drop the draft).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content, path])
+  }, [content, path, readOnly])
 
   // Scheme flip: re-theme in place (the compartment holds only the
   // scheme-dependent extensions; everything else is untouched).
@@ -297,7 +299,7 @@ export function TextEditor(props: FileViewerProps) {
 
   const save = (): void => {
     const view = viewRef.current
-    if (view === null || savingRef.current) return
+    if (readOnly || view === null || savingRef.current) return
     savingRef.current = true
     setSaveState('saving')
     api.fsWrite(scope, path, view.state.doc.toString()).then(() => {
@@ -403,7 +405,8 @@ export function TextEditor(props: FileViewerProps) {
       rect.top,
     )
   }
-  const editable = content !== undefined
+  const editable = content !== undefined && !readOnly
+  const modes = (markdown || html) && !readOnly
   const saveLabel = saveState === 'saving' ? t('loading') : saveState === 'saved' ? t('saved') : saveState === 'failed' ? t('saveFailed') : ''
   // Per-feature sandbox escape hatch: the global side card setting (warned)
   // plus a per-surface temporary unlock. The unlock state starts at the
@@ -422,7 +425,7 @@ export function TextEditor(props: FileViewerProps) {
   const lastToolbarRef = useRef('')
   useEffect(() => {
     if (!hostToolbar) return
-    const state: EditorToolbarState = { modes: markdown || html, mode, dirty, editable, saveState }
+    const state: EditorToolbarState = { modes, mode, dirty, editable, saveState }
     const key = JSON.stringify(state)
     if (lastToolbarRef.current === key) return
     lastToolbarRef.current = key
@@ -441,7 +444,7 @@ export function TextEditor(props: FileViewerProps) {
     <>
       {!hostToolbar && (
       <div className={css.editorHeader}>
-        {(markdown || html) && (
+        {modes && (
           <div className={css.editorModeToggle}>
             <button
               type="button"

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -96,6 +96,11 @@ export interface FsTextResult { kind: 'text'; content: string; truncated: boolea
  *  `head` carries the first bytes (base64) for viewer detect sniffing. */
 export interface FsBinaryResult { kind: 'binary'; size: number; truncated: boolean; head: string }
 
+/** Result of authorizing one explicitly clicked absolute Markdown path. */
+export type MarkdownPreviewGrant =
+  | { outside: false }
+  | { outside: true; grant: string }
+
 /**
  * One jobs.output response: the output the MODEL has read so far for the
  * job (replayed from the owner session's event log — the model's
@@ -274,8 +279,16 @@ export const api = {
    *  side panel's search box); matches are cwd-relative '/'-separated paths. */
   fsSearch: (scope: SessionScope, query: string, signal?: AbortSignal) =>
     call<{ matches: string[]; truncated: boolean }>('fs.search', scopePayload(scope, { query }), signal),
-  fsRead: (scope: SessionScope, path: string, signal?: AbortSignal) =>
-    call<FsTextResult | FsBinaryResult>('fs.read', scopePayload(scope, { path }), signal),
+  /** Ask the loopback host to authorize an explicitly clicked Markdown file.
+   *  In-workspace paths need no token; outside paths receive an exact-path,
+   *  session-bound read grant. */
+  markdownPreviewGrant: (scope: SessionScope, path: string, signal?: AbortSignal) =>
+    call<MarkdownPreviewGrant>('preview.markdown', scopePayload(scope, { path }), signal),
+  fsRead: (scope: SessionScope, path: string, signal?: AbortSignal, previewGrant?: string) =>
+    call<FsTextResult | FsBinaryResult>('fs.read', scopePayload(scope, {
+      path,
+      ...(previewGrant !== undefined && previewGrant !== '' ? { previewGrant } : {}),
+    }), signal),
   fsWrite: (scope: SessionScope, path: string, content: string) =>
     call<{ ok: true }>('fs.write', scopePayload(scope, { path, content })),
   /** Rename one tree row within its directory (single-segment name; the

--- a/src/client/intercept.tsx
+++ b/src/client/intercept.tsx
@@ -8,21 +8,82 @@
  */
 import { IconCodeOutline16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { Context } from '../context-types.ts'
-import { firstLeaf, revealPaths, togglePanel, type SidebarStore } from './state.ts'
+import { allLeaves, firstLeaf, revealPaths, togglePanel, type SidebarStore, type SidebarTab } from './state.ts'
+import { api, type SessionScope } from './api.ts'
 import { t } from './locales.ts'
 import { resolveSidebarPath, selectProducedFiles } from './produced-files.ts'
-import { wrapOpenWorkspacePath, type OpenWorkspacePathService } from './openpath-intercept.ts'
+import {
+  isAbsoluteMarkdownPath,
+  wrapAbsoluteMarkdownMentions,
+  wrapOpenWorkspacePath,
+  type ChatFileMentionsService,
+  type OpenWorkspacePathService,
+} from './openpath-intercept.ts'
 import css from './sidebar.module.css'
 
+/** Private metadata carried only by an explicitly authorized chat preview. */
+interface SidebarFileOpenOptions {
+  previewGrant?: string
+  readOnly?: boolean
+}
+
 /** Open a file in the sidebar's editor (used by the intercepted row and the explorer). */
-export function openSidebarFile(ctx: Context, store: SidebarStore, sessionId: string, path: string): void {
+export function openSidebarFile(
+  ctx: Context,
+  store: SidebarStore,
+  sessionId: string,
+  path: string,
+  options: SidebarFileOpenOptions = {},
+): void {
   const summary = ctx.sessions.list.getSnapshot().byId[sessionId]
   const absolute = resolveSidebarPath(summary?.cwd, path)
   const at = Math.max(absolute.lastIndexOf('/'), absolute.lastIndexOf('\\'))
   const title = at === -1 ? absolute : absolute.slice(at + 1)
+  const meta = options.previewGrant === undefined
+    ? undefined
+    : { previewGrant: options.previewGrant, readOnly: options.readOnly === true }
   // Route through the sidebar service so the editor descriptor's dedupeKey
   // (per-path) applies; the id is path-derived so multiple editors coexist.
-  ctx.get('betterSidebar')?.openTab({ type: 'editor', title, path: absolute, id: `editor:${absolute}` })
+  const service = ctx.get('betterSidebar')
+  if (meta !== undefined) {
+    // A previously opened tab for this path would otherwise win dedupe and
+    // retain a stale/missing grant. Refresh it without dropping tree chrome.
+    const state = service?.getSnapshot().state
+    const tabs: SidebarTab[] = state === undefined
+      ? []
+      : [
+          ...allLeaves(state.splits).flatMap(leaf => leaf.tabs),
+          ...allLeaves(state.bottomSplits).flatMap(leaf => leaf.tabs),
+          ...state.floats.map(item => item.tab),
+        ]
+    const existing = tabs.find(tab => tab.type === 'editor' && tab.path === absolute)
+    if (existing !== undefined) {
+      const currentMeta = existing.meta !== null && typeof existing.meta === 'object' && !Array.isArray(existing.meta)
+        ? existing.meta as Record<string, unknown>
+        : {}
+      service?.updateTab(existing.id, { meta: { ...currentMeta, ...meta } })
+    }
+  }
+  service?.openTab({ type: 'editor', title, path: absolute, id: `editor:${absolute}`, ...(meta === undefined ? {} : { meta }) })
+}
+
+/** Authorize a chat-clicked Markdown file, then open an outside file read-only. */
+function openChatFileInSidebar(ctx: Context, store: SidebarStore, sessionId: string, path: string): void {
+  if (!isAbsoluteMarkdownPath(path)) {
+    openSidebarFile(ctx, store, sessionId, path)
+    return
+  }
+  const summary = ctx.sessions.list.getSnapshot().byId[sessionId]
+  const scope: SessionScope = { sessionId, ...(summary?.cwd === undefined ? {} : { cwd: summary.cwd }) }
+  void api.markdownPreviewGrant(scope, path).then((result) => {
+    if (ctx.sessions.list.getSnapshot().current !== sessionId) return
+    if (result.outside) openSidebarFile(ctx, store, sessionId, path, { previewGrant: result.grant, readOnly: true })
+    else openSidebarFile(ctx, store, sessionId, path)
+  }).catch((error: unknown) => {
+    // Fail closed: opening without the capability would only create a broken
+    // tab (the normal fs.read route remains workspace-fenced).
+    console.error('[dsh-better-sidebar] Markdown preview authorization failed:', error)
+  })
 }
 
 /**
@@ -169,18 +230,36 @@ export function registerTurnTailInterception(ctx: Context, store: SidebarStore):
  * descriptor — HMR-safe).
  */
 export function registerOpenPathInterception(ctx: Context, store: SidebarStore): () => void {
+  const takeoverEnabled = (): boolean => !store.getSuspended()
+    && store.getPrefs().interceptOpenPath !== false
+    && store.getPrefs().tabsEnabled['editor'] !== false
+
   const fiber = ctx.inject(['remote.session'], (fctx) => {
     fctx.effect(() => {
       const service = fctx.get('remote.session') as OpenWorkspacePathService
       return wrapOpenWorkspacePath(service, {
-        takeoverEnabled: () => !store.getSuspended()
-          && store.getPrefs().interceptOpenPath !== false
-          && store.getPrefs().tabsEnabled['editor'] !== false,
+        takeoverEnabled,
         currentSessionId: () => ctx.sessions.list.getSnapshot().current,
-        openInSidebar: (path, sessionId) => { openSidebarFile(ctx, store, sessionId, path) },
+        openInSidebar: (path, sessionId) => { openChatFileInSidebar(ctx, store, sessionId, path) },
         revealInExplorer: (_path, sessionId) => { revealInExplorer(ctx, store, sessionId, lastProduced) },
       })
     }, 'dsh-better-sidebar: open-path interception wrap')
   })
-  return () => { void fiber.dispose() }
+
+  // ui-deliverables only links inline-code names produced in the same turn.
+  // Extend (never replace) that vocabulary with complete absolute Markdown
+  // paths, then let owner.openFile flow into the remote wrapper above.
+  const mentions = (ctx as unknown as {
+    get(name: 'chatFileMentions'): ChatFileMentionsService | undefined
+  }).get('chatFileMentions')
+  const restoreMentions = mentions === undefined
+    ? () => {}
+    : wrapAbsoluteMarkdownMentions(mentions, {
+        enabled: takeoverEnabled,
+        label: (path) => `${t('producedOpen')}: ${path}`,
+      })
+  return () => {
+    restoreMentions()
+    void fiber.dispose()
+  }
 }

--- a/src/client/openpath-intercept.ts
+++ b/src/client/openpath-intercept.ts
@@ -25,7 +25,12 @@
  * on contribution remounts; the caller therefore enters through
  * `ctx.inject(['remote.session'], …)`, which re-fires on every remount.
  *
- * The wrapper is dependency-free by design (no React / ui-primitives), so
+ * DSH's stock inline-code vocabulary only recognizes files produced in the
+ * same turn. The second wrapper in this module preserves that resolver first,
+ * then adds a deliberately narrow fallback for complete ABSOLUTE Markdown
+ * paths so an existing report mentioned by the assistant is clickable too.
+ *
+ * The wrappers are dependency-free by design (no React / ui-primitives), so
  * the takeover logic is unit-testable and the file stays importable from
  * the test runtime.
  */
@@ -136,9 +141,83 @@ export function wrapOpenWorkspacePath(
     value: wrapped,
   })
   return () => {
-    // Restore the exact original property (the gateway's accessor) so a
-    // chain of wrappers keeps working across disposals in any order.
+    // Restore only when this wrapper still owns the property. An older HMR
+    // disposer must never clobber a newer wrapper installed after it.
+    if (service.openWorkspacePath !== wrapped) return
     if (descriptor !== undefined) Object.defineProperty(target, KEY, descriptor)
     else Reflect.deleteProperty(target, KEY)
+  }
+}
+
+/** One clickable inline-code file mention (mirror of MarkdownFileMentions). */
+export interface ResolvedFileMention {
+  open(): void
+  label: string
+  title: string
+}
+
+/** Resolver passed by the chat renderer to assistant Markdown. */
+export interface FileMentionResolver {
+  resolve(value: string): ResolvedFileMention | undefined
+}
+
+/** The closing-message owner face needed by a mention's click callback. */
+export interface FileMentionOwner {
+  openFile(path: string): void | Promise<void>
+}
+
+/** Structural mirror of DSH's optional `chatFileMentions` service. */
+export interface ChatFileMentionsService {
+  forClosing(owner: FileMentionOwner): FileMentionResolver | undefined
+}
+
+/** Live gates and accessible copy for the absolute-path fallback. */
+export interface AbsoluteMarkdownMentionDeps {
+  enabled(): boolean
+  label(path: string): string
+}
+
+/**
+ * Whether a whole inline-code token is an absolute Markdown file path.
+ * Supports the native forms of every DSH host platform (POSIX, drive-letter,
+ * and UNC) without treating relative paths, URLs, commands, or other code as
+ * file links.
+ */
+export function isAbsoluteMarkdownPath(value: string): boolean {
+  if (value === '' || value.includes('\u0000') || !/\.(?:md|markdown)$/i.test(value)) return false
+  return value.startsWith('/')
+    || /^[a-zA-Z]:[\\/]/.test(value)
+    || /^\\\\[^\\/]+[\\/][^\\/]+[\\/]/.test(value)
+}
+
+/**
+ * Preserve the stock produced-file resolver, then recognize complete absolute
+ * Markdown paths. The returned mention still calls the chat owner's `openFile`
+ * so every click flows through the same open-path interception as stock links.
+ */
+export function wrapAbsoluteMarkdownMentions(
+  service: ChatFileMentionsService,
+  deps: AbsoluteMarkdownMentionDeps,
+): () => void {
+  const original = service.forClosing
+  const wrapped = function (this: ChatFileMentionsService, owner: FileMentionOwner): FileMentionResolver | undefined {
+    const inherited = original.call(this, owner)
+    if (!deps.enabled()) return inherited
+    return {
+      resolve(value) {
+        const existing = inherited?.resolve(value)
+        if (existing !== undefined) return existing
+        if (!deps.enabled() || !isAbsoluteMarkdownPath(value)) return undefined
+        return {
+          open: () => { void owner.openFile(value) },
+          label: deps.label(value),
+          title: value,
+        }
+      },
+    }
+  }
+  service.forClosing = wrapped
+  return () => {
+    if (service.forClosing === wrapped) service.forClosing = original
   }
 }

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -266,6 +266,9 @@ export interface FileViewerProps {
   mediaUrl?: string
   /** custom load() return value (fetchStrategy='custom'). */
   customData?: unknown
+  /** Internal: an explicitly authorized out-of-workspace chat preview is
+   *  readable but must never expose editing/saving controls. */
+  readOnly?: boolean
   /** Internal (built-in text editor): 'host' asks the viewer to skip its own
    *  toolbar row — the editor host's merged-mode header renders it instead,
    *  fed through the two callbacks below. Viewers that ignore these fields

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -38,6 +38,8 @@ export interface SidebarHttpRequest {
   url?: string
   method?: string
   headers: Record<string, string | string[] | undefined>
+  /** TCP peer facts used by the loopback-only external-preview grant route. */
+  socket?: { remoteAddress?: string }
   [Symbol.asyncIterator](): AsyncIterator<string | Uint8Array>
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,11 @@ import {
 import { parentOf, requireAbsolute, listDirectory, rootLabel } from './fs-tree.ts'
 import { resolveSessionPath } from './session-path.ts'
 import { renameWorkspaceEntry, removeWorkspaceEntry, writeWorkspaceUpload } from './fs-operations.ts'
-import { ensureWorkspacePath, ensureWorkspaceWritePath } from './path-security.ts'
+import { ensureWorkspacePath, ensureWorkspaceWritePath, MarkdownPreviewGrants } from './path-security.ts'
 import { searchFiles } from './fs-search.ts'
 import { decodeHtmlUrl } from './html-route.ts'
 import { extractFrameAncestors } from './browser-probe.ts'
-import { isTrustedApiRequest, isLoopbackHostname } from './trust-fence.ts'
+import { isTrustedApiRequest, isLoopbackHostname, isLoopbackRemoteAddress } from './trust-fence.ts'
 import { registerBundleRoute } from './bundle-route.ts'
 import { launchExternal } from './open-external.ts'
 import * as git from './git.ts'
@@ -298,6 +298,7 @@ function buildApi(
   resolved: ResolvedSidebarConfig,
   terminalShell: string,
   getSettings: () => SidebarSettingsFace | undefined,
+  markdownPreviewGrants: MarkdownPreviewGrants,
 ): Record<string, ApiMethod> {
   const cwdOf = async (payload: unknown): Promise<{ sessionId: string; cwd: string }> => {
     const sessionId = requireString(payload, 'sessionId')
@@ -342,14 +343,22 @@ function buildApi(
       const query = requireString(payload, 'query')
       return searchFiles(cwd, query)
     },
+    'preview.markdown': async (payload) => {
+      const { sessionId, cwd } = await cwdOf(payload)
+      return markdownPreviewGrants.issue(sessionId, cwd, requireString(payload, 'path'))
+    },
     'fs.read': async (payload) => {
-      const { cwd } = await cwdOf(payload)
+      const { sessionId, cwd } = await cwdOf(payload)
       // Relative paths are git-derived (status/diff report repo-root-relative
       // names; the untracked diff view reads the file through this route). A
       // child-repo path is relative to the selected repoRoot, not the session
       // cwd; thread it so the path resolves inside the authorized workspace.
       const selected = selectedRepoOf(payload)
-      const path = await ensureWorkspacePath(cwd, await resolveGitPath(cwd, requireString(payload, 'path'), selected), fenceEnabledOf(getSettings))
+      const requested = await resolveGitPath(cwd, requireString(payload, 'path'), selected)
+      const rawGrant = (payload as { previewGrant?: unknown }).previewGrant
+      const path = typeof rawGrant === 'string' && rawGrant !== ''
+        ? await markdownPreviewGrants.authorize(rawGrant, sessionId, requested)
+        : await ensureWorkspacePath(cwd, requested, fenceEnabledOf(getSettings))
       const { content, truncated, binary, size, head } = await readText(path, resolved.readLimit)
       if (binary) return { kind: 'binary', size, truncated, head }
       return { kind: 'text', content, truncated }
@@ -739,6 +748,9 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   // `/sidebar/ws/agent-opens` socket. Unlike the pty registry it has no
   // native dependencies — the tool works even in node-pty degraded mode.
   const agentOpenRegistry = new AgentOpenRegistry()
+  // Exact-path, session-bound read capabilities minted only for explicit
+  // loopback chat clicks on absolute Markdown paths outside the workspace.
+  const markdownPreviewGrants = new MarkdownPreviewGrants()
 
   // ── User-facing "Side card" preferences ──────────────────────────────────
   // Register the namespace with the settings provider so the Settings page
@@ -850,7 +862,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
   })
 
   // ── JSON API ────────────────────────────────────────────────────────────
-  const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, terminalShell, () => settingsFace)
+  const api = buildApi(ctx, ptyManager, agentPtyRegistry, resolved, terminalShell, () => settingsFace, markdownPreviewGrants)
   ctx.effect(() => ctx.webServer.register({
     kind: 'prefix',
     path: '/sidebar/api',
@@ -870,6 +882,12 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
         return
       }
       try {
+        // Minting an out-of-workspace read capability is deliberately stricter
+        // than the ordinary trusted-host fence: the TCP peer itself must be
+        // loopback, so a LAN client cannot ask the host to expose local files.
+        if (method === 'preview.markdown' && !isLoopbackRemoteAddress(req.socket?.remoteAddress)) {
+          throw new SidebarError('forbidden', 'external Markdown preview grants require a loopback client', 403)
+        }
         const payload = await readJsonBody(req)
         const handler = api[method]
         if (handler === undefined) {
@@ -1106,6 +1124,7 @@ export function apply(ctx: Context, config?: SidebarConfig): void {
     ptyManager?.disposeAll()
     agentPtyRegistry?.disposeAll()
     agentOpenRegistry.dispose()
+    markdownPreviewGrants.dispose()
     wss.close()
     agentListWss.close()
     agentOpenWss.close()

--- a/src/path-security.ts
+++ b/src/path-security.ts
@@ -1,6 +1,7 @@
 /** Filesystem path guards shared by sidebar APIs that access a session workspace. */
-import { realpath } from 'node:fs/promises'
-import { basename, dirname, join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { realpath, stat } from 'node:fs/promises'
+import { basename, dirname, extname, join } from 'node:path'
 import { isWithin, requireAbsolute } from './fs-tree.ts'
 import { resolveSessionPath } from './session-path.ts'
 import { SidebarError } from './wire.ts'
@@ -78,5 +79,90 @@ export async function ensureWorkspaceWritePath(cwd: string, target: string, fenc
       missingSegments.unshift(basename(existingPath))
       existingPath = parent
     }
+  }
+}
+
+/** A client-visible decision for one explicitly clicked Markdown path. */
+export type MarkdownPreviewGrant =
+  | { outside: false }
+  | { outside: true; grant: string }
+
+/** One server-memory read capability. It is exact-path and session bound. */
+interface MarkdownPreviewCapability {
+  sessionId: string
+  path: string
+}
+
+/** Maximum live external-preview capabilities (oldest entries are evicted). */
+const MARKDOWN_PREVIEW_GRANT_LIMIT = 128
+
+/** Only Markdown documents get the out-of-workspace preview escape hatch. */
+function isMarkdownPath(path: string): boolean {
+  const extension = extname(path).toLowerCase()
+  return extension === '.md' || extension === '.markdown'
+}
+
+/** Resolve one existing path without granting it any workspace authority. */
+async function resolveExternalPreviewPath(target: string): Promise<string> {
+  const absolute = requireAbsolute(target)
+  return resolveRealPath(absolute, 'preview target')
+}
+
+/**
+ * Host-lifetime, unguessable read capabilities for Markdown documents that
+ * the user explicitly clicks in chat. The normal workspace fence remains the
+ * default for every route and every write: `issue` only grants one canonical
+ * document to one session, and `authorize` re-resolves the path so a replaced
+ * symlink cannot reuse an old grant.
+ */
+export class MarkdownPreviewGrants {
+  private readonly grants = new Map<string, MarkdownPreviewCapability>()
+
+  /** Decide whether a clicked document needs a grant, and mint one if so. */
+  async issue(sessionId: string, cwd: string, target: string): Promise<MarkdownPreviewGrant> {
+    const [workspace, path] = await Promise.all([
+      resolveRealPath(cwd, 'workspace'),
+      resolveExternalPreviewPath(target),
+    ])
+    if (isWithin(workspace, path)) return { outside: false }
+    if (!isMarkdownPath(path)) {
+      throw new SidebarError('bad-request', 'external preview only accepts Markdown files', 400)
+    }
+    let info
+    try {
+      info = await stat(path)
+    } catch (error) {
+      throw new SidebarError('fs-error', `cannot inspect preview target "${path}": ${error instanceof Error ? error.message : String(error)}`, 400)
+    }
+    if (!info.isFile()) throw new SidebarError('bad-request', 'external Markdown preview target is not a file', 400)
+
+    const grant = randomBytes(24).toString('base64url')
+    this.grants.set(grant, { sessionId, path })
+    while (this.grants.size > MARKDOWN_PREVIEW_GRANT_LIMIT) {
+      const oldest = this.grants.keys().next().value as string | undefined
+      if (oldest === undefined) break
+      this.grants.delete(oldest)
+    }
+    return { outside: true, grant }
+  }
+
+  /** Validate an exact path/session/token tuple and return its canonical path. */
+  async authorize(grant: string, sessionId: string, target: string): Promise<string> {
+    const capability = this.grants.get(grant)
+    if (capability === undefined || capability.sessionId !== sessionId) {
+      throw new SidebarError('forbidden', 'invalid external Markdown preview grant', 403)
+    }
+    const path = await resolveExternalPreviewPath(target)
+    if (path !== capability.path) {
+      throw new SidebarError('forbidden', 'external Markdown preview grant does not match this path', 403)
+    }
+    this.grants.delete(grant)
+    this.grants.set(grant, capability)
+    return path
+  }
+
+  /** Drop all capabilities when the host plugin is disposed. */
+  dispose(): void {
+    this.grants.clear()
   }
 }

--- a/src/trust-fence.ts
+++ b/src/trust-fence.ts
@@ -37,6 +37,21 @@ export function isLoopbackHostname(hostname: string): boolean {
     && parts.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255)
 }
 
+/**
+ * Whether the HTTP peer itself is loopback. Unlike the Host-header fence,
+ * this cannot be forged by a remote direct client and is therefore used for
+ * the narrowly privileged API that mints out-of-workspace preview grants.
+ */
+export function isLoopbackRemoteAddress(address: string | undefined): boolean {
+  if (address === undefined) return false
+  if (address === '::1') return true
+  const normalized = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
+  const parts = normalized.split('.')
+  return parts.length === 4
+    && parts[0] === '127'
+    && parts.every(part => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+}
+
 /** Canonical authority form: hostname, or hostname:port when a port was written. */
 function canonicalAuthority(entry: string, entryUrl: URL): string {
   const port = entryUrl.port !== '' ? entryUrl.port : new URL(`https://${entry}`).port

--- a/tests/editor-host.spec.tsx
+++ b/tests/editor-host.spec.tsx
@@ -9,7 +9,7 @@
  * only, no editor chrome); file tabs keep the full chrome in both modes.
  */
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createElement, useEffect, type ReactNode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { act } from 'react-dom/test-utils'
@@ -298,6 +298,47 @@ describe('EditorHost (files window)', () => {
       expect(calls).toEqual(['mode:edit', 'save'])
     } finally {
       unmount()
+    }
+  })
+
+  it('threads an external preview grant into fs.read and marks the viewer read-only', async () => {
+    const { store, ctx } = setup()
+    let viewerReadOnly: boolean | undefined
+    ctx.betterSidebar.registerFileViewer({
+      id: 'test:markdown',
+      exts: ['md'],
+      fetchStrategy: 'fsRead',
+      component: (props) => {
+        viewerReadOnly = props.readOnly
+        return createElement('div', null, props.content)
+      },
+    })
+    ctx.betterSidebar.openTab({
+      type: 'editor',
+      title: 'report.md',
+      path: '/outside/report.md',
+      id: 'editor:/outside/report.md',
+      meta: { previewGrant: 'grant-token', readOnly: true },
+    })
+    const fileTab = (): SidebarTab =>
+      allLeaves(store.getSnapshot().state!.splits).flatMap(leaf => leaf.tabs)
+        .find(tab => tab.path === '/outside/report.md')!
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
+      ok: true,
+      value: { kind: 'text', content: '# External', truncated: false },
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { container, unmount } = mountHost(ctx, store, fileTab)
+    try {
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const body = JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body)) as Record<string, unknown>
+      expect(body).toMatchObject({ sessionId: 'editor-home-session', path: '/outside/report.md', previewGrant: 'grant-token' })
+      expect(viewerReadOnly).toBe(true)
+      expect(container.textContent).toContain('# External')
+    } finally {
+      unmount()
+      vi.unstubAllGlobals()
     }
   })
 

--- a/tests/markdown-copy-labels.spec.tsx
+++ b/tests/markdown-copy-labels.spec.tsx
@@ -70,4 +70,17 @@ describe('markdown preview code-block copy labels (DSH i18n following)', () => {
     expect(html).toContain('Copy')
     expect(html).not.toContain('复制')
   })
+
+  it('renders an authorized external Markdown document without edit/save controls', () => {
+    const locale = new FakeLocale()
+    locale.active = 'en'
+    attachLocale(locale)
+    const html = renderToString(createElement(TextEditor, viewerProps({
+      content: '# External report',
+      readOnly: true,
+    })))
+    expect(html).toContain('External report')
+    expect(html).not.toContain('>Edit<')
+    expect(html).not.toContain('aria-label="Save"')
+  })
 })

--- a/tests/openpath-intercept.spec.ts
+++ b/tests/openpath-intercept.spec.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { registerOpenPathInterception } from '../src/client/intercept.tsx'
 import {
+  isAbsoluteMarkdownPath,
   isFolderRevealPath,
+  wrapAbsoluteMarkdownMentions,
   wrapOpenWorkspacePath,
+  type ChatFileMentionsService,
+  type FileMentionOwner,
   type OpenPathInterceptDeps,
   type OpenWorkspacePathService,
 } from '../src/client/openpath-intercept.ts'
@@ -132,6 +136,15 @@ describe('open-path interception (wrapOpenWorkspacePath)', () => {
     expect(d.sidebar).toEqual([])
   })
 
+  it('does not let an older disposer clobber a newer wrapper', () => {
+    const service = fakeNamespaceService([])
+    const restore = wrapOpenWorkspacePath(service, deps())
+    const newer = async () => ({ ok: true, value: { opened: true } } as const)
+    service.openWorkspacePath = newer
+    restore()
+    expect(service.openWorkspacePath).toBe(newer)
+  })
+
   it('propagates a rejection from the original (no swallowing)', async () => {
     const target = {} as Record<string, unknown>
     Object.defineProperty(target, 'openWorkspacePath', {
@@ -165,6 +178,69 @@ describe('isFolderRevealPath', () => {
     expect(isFolderRevealPath('C:\\w\\.')).toBe(true)
     expect(isFolderRevealPath('/w/a.ts')).toBe(false)
     expect(isFolderRevealPath('/w/.hidden')).toBe(false)
+  })
+})
+
+describe('absolute Markdown inline-code mentions', () => {
+  it('accepts complete POSIX, drive-letter, and UNC Markdown paths', () => {
+    expect(isAbsoluteMarkdownPath('/Users/me/报告.md')).toBe(true)
+    expect(isAbsoluteMarkdownPath('C:\\Users\\me\\report.MARKDOWN')).toBe(true)
+    expect(isAbsoluteMarkdownPath('\\\\server\\share\\docs\\report.md')).toBe(true)
+  })
+
+  it('rejects relative paths, URLs, non-Markdown files, and command-like code', () => {
+    for (const value of [
+      'docs/report.md', './report.md', 'https://example.test/report.md',
+      'file:///tmp/report.md', '/tmp/report.txt', 'cat /tmp/report.md',
+    ]) expect(isAbsoluteMarkdownPath(value), value).toBe(false)
+  })
+
+  it('preserves the stock produced-file resolver before the absolute fallback', () => {
+    const stock = { open: () => {}, label: 'stock', title: '/produced/report.md' }
+    const service: ChatFileMentionsService = {
+      forClosing: () => ({ resolve: value => value === 'report.md' ? stock : undefined }),
+    }
+    const owner: FileMentionOwner = { openFile: () => {} }
+    const restore = wrapAbsoluteMarkdownMentions(service, { enabled: () => true, label: path => path })
+    expect(service.forClosing(owner)?.resolve('report.md')).toBe(stock)
+    restore()
+  })
+
+  it('links a Chinese absolute Markdown path through owner.openFile and restores safely', () => {
+    const opened: string[] = []
+    const service: ChatFileMentionsService = { forClosing: () => undefined }
+    const original = service.forClosing
+    const owner: FileMentionOwner = { openFile: path => { opened.push(path) } }
+    const restore = wrapAbsoluteMarkdownMentions(service, {
+      enabled: () => true,
+      label: path => `Open in sidebar: ${path}`,
+    })
+    const path = '/Users/wangmingming/AI/tmp/2026-08-30/会通学宫-产品目标-评审报告.md'
+    const mention = service.forClosing(owner)?.resolve(path)
+    expect(mention).toMatchObject({ title: path, label: `Open in sidebar: ${path}` })
+    mention?.open()
+    expect(opened).toEqual([path])
+    restore()
+    expect(service.forClosing).toBe(original)
+  })
+
+  it('does not let an older disposer clobber a newer mention wrapper', () => {
+    const service: ChatFileMentionsService = { forClosing: () => undefined }
+    const restore = wrapAbsoluteMarkdownMentions(service, { enabled: () => true, label: path => path })
+    const newer = () => ({ resolve: () => undefined })
+    service.forClosing = newer
+    restore()
+    expect(service.forClosing).toBe(newer)
+  })
+
+  it('stays inert while takeover is disabled', () => {
+    let enabled = false
+    const service: ChatFileMentionsService = { forClosing: () => undefined }
+    const restore = wrapAbsoluteMarkdownMentions(service, { enabled: () => enabled, label: path => path })
+    expect(service.forClosing({ openFile: () => {} })).toBeUndefined()
+    enabled = true
+    expect(service.forClosing({ openFile: () => {} })?.resolve('/tmp/report.md')).toBeDefined()
+    restore()
   })
 })
 
@@ -239,6 +315,101 @@ describe('open-path interception wiring', () => {
     restore()
     const descriptor = Object.getOwnPropertyDescriptor(remoteSession, 'openWorkspacePath')
     expect(typeof descriptor?.get).toBe('function')
+  })
+
+  it('makes an arbitrary absolute Markdown result clickable and opens it read-only after authorization', async () => {
+    const opened: Array<Record<string, unknown>> = []
+    const hostOpened: string[] = []
+    const remoteSession = fakeNamespaceService(hostOpened)
+    const mentions: ChatFileMentionsService = { forClosing: () => undefined }
+    const sidebar = {
+      openTab: (seed: unknown) => { opened.push(seed as Record<string, unknown>) },
+      updateTab: () => {},
+      getSnapshot: () => ({ state: undefined }),
+    }
+    let effectDisposer: (() => void) | undefined
+    const ctx = {
+      sessions: { list: { getSnapshot: () => ({ current: 's1', byId: { s1: { cwd: '/workspace' } } }) } },
+      get: (name: string) => name === 'betterSidebar' ? sidebar : name === 'chatFileMentions' ? mentions : undefined,
+      inject: (_deps: string[], callback: (fctx: unknown) => void) => {
+        callback({
+          get: (name: string) => name === 'remote.session' ? remoteSession : undefined,
+          effect: (fn: () => () => void) => { effectDisposer = fn() },
+        })
+        return { dispose: async () => { effectDisposer?.() } }
+      },
+    }
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      value: { outside: true, grant: 'exact-read-grant' },
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const store = createSidebarStore()
+    const originalMentions = mentions.forClosing
+    const restore = registerOpenPathInterception(ctx as unknown as Context, store)
+    try {
+      const owner: FileMentionOwner = {
+        openFile: path => { void remoteSession.openWorkspacePath({ path }) },
+      }
+      const path = '/Users/wangmingming/AI/tmp/2026-08-30/会通学宫-产品目标-评审报告.md'
+      const mention = mentions.forClosing(owner)?.resolve(path)
+      expect(mention).toMatchObject({ title: path })
+      mention?.open()
+      await vi.waitFor(() => {
+        expect(opened).toEqual([{
+          type: 'editor',
+          title: '会通学宫-产品目标-评审报告.md',
+          path,
+          id: `editor:${path}`,
+          meta: { previewGrant: 'exact-read-grant', readOnly: true },
+        }])
+      })
+      expect(fetchMock).toHaveBeenCalledWith('/sidebar/api/preview.markdown', expect.objectContaining({ method: 'POST' }))
+      expect(hostOpened).toEqual([])
+    } finally {
+      restore()
+      vi.unstubAllGlobals()
+    }
+    expect(mentions.forClosing).toBe(originalMentions)
+    expect(Object.getOwnPropertyDescriptor(remoteSession, 'openWorkspacePath')?.get).toBeDefined()
+  })
+
+  it('fails closed when external Markdown authorization is refused', async () => {
+    const opened: Array<Record<string, unknown>> = []
+    const remoteSession = fakeNamespaceService([])
+    const mentions: ChatFileMentionsService = { forClosing: () => undefined }
+    let effectDisposer: (() => void) | undefined
+    const ctx = {
+      sessions: { list: { getSnapshot: () => ({ current: 's1', byId: { s1: { cwd: '/workspace' } } }) } },
+      get: (name: string) => name === 'betterSidebar'
+        ? { openTab: (seed: unknown) => { opened.push(seed as Record<string, unknown>) } }
+        : name === 'chatFileMentions' ? mentions : undefined,
+      inject: (_deps: string[], callback: (fctx: unknown) => void) => {
+        callback({
+          get: (name: string) => name === 'remote.session' ? remoteSession : undefined,
+          effect: (fn: () => () => void) => { effectDisposer = fn() },
+        })
+        return { dispose: async () => { effectDisposer?.() } }
+      },
+    }
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: false,
+      error: { code: 'forbidden', message: 'no grant' },
+    }), { status: 403, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const restore = registerOpenPathInterception(ctx as unknown as Context, createSidebarStore())
+    try {
+      const owner: FileMentionOwner = { openFile: path => { void remoteSession.openWorkspacePath({ path }) } }
+      mentions.forClosing(owner)?.resolve('/outside/report.md')?.open()
+      await vi.waitFor(() => { expect(error).toHaveBeenCalled() })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(opened).toEqual([])
+    } finally {
+      restore()
+      error.mockRestore()
+      vi.unstubAllGlobals()
+    }
   })
 
   it('re-applies the shadow when the namespace service is remounted', async () => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -521,12 +521,14 @@ describe('session cwd resolution over the API route', () => {
     route: SidebarWebRoute,
     method: string,
     payload: unknown,
+    remoteAddress = '127.0.0.1',
   ): Promise<{ ok: boolean; status: number; value?: { cwd: string }; error?: { code?: string; message: string } }> => {
     const body = Buffer.from(JSON.stringify(payload))
     const req = {
       method: 'POST',
       url: `/sidebar/api/${method}`,
       headers: { host: '127.0.0.1:3080' },
+      socket: { remoteAddress },
       [Symbol.asyncIterator]: async function* () { yield body },
     } as never
     const out: { status: number; body: string } = { status: 200, body: '' }
@@ -706,6 +708,55 @@ describe('session cwd resolution over the API route', () => {
       expect(read).toMatchObject({ ok: false, status: 403, error: { code: 'forbidden' } })
     } finally {
       rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('grants one loopback-clicked external Markdown document read-only access', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-sidebar-markdown-preview-'))
+    const workspace = join(root, 'workspace')
+    const outside = join(root, 'outside')
+    mkdirSync(workspace)
+    mkdirSync(outside)
+    const report = join(outside, '中文评审报告.md')
+    const other = join(outside, 'other.md')
+    const nonMarkdown = join(outside, 'secret.txt')
+    writeFileSync(report, '# 评审报告\n\n只读内容')
+    writeFileSync(other, '# Other')
+    writeFileSync(nonMarkdown, 'secret')
+    try {
+      const route = mount({ sessions: { get: () => ({ header: { cwd: workspace } }) } })
+      const issued = await invoke(route, 'preview.markdown', { sessionId: 'preview', path: report })
+      expect(issued).toMatchObject({ ok: true, value: { outside: true, grant: expect.any(String) } })
+      const token = (issued as unknown as { value: { grant: string } }).value.grant
+
+      const read = await invoke(route, 'fs.read', { sessionId: 'preview', path: report, previewGrant: token })
+      expect(read).toMatchObject({ ok: true, value: { kind: 'text', content: '# 评审报告\n\n只读内容' } })
+      const wrongPath = await invoke(route, 'fs.read', { sessionId: 'preview', path: other, previewGrant: token })
+      expect(wrongPath).toMatchObject({ ok: false, status: 403, error: { code: 'forbidden' } })
+      const wrongSession = await invoke(route, 'fs.read', { sessionId: 'other-session', cwd: workspace, path: report, previewGrant: token })
+      expect(wrongSession).toMatchObject({ ok: false, status: 403, error: { code: 'forbidden' } })
+      const write = await invoke(route, 'fs.write', { sessionId: 'preview', path: report, content: 'changed' })
+      expect(write).toMatchObject({ ok: false, status: 403, error: { code: 'forbidden' } })
+      expect(readFileSync(report, 'utf8')).toBe('# 评审报告\n\n只读内容')
+      const textGrant = await invoke(route, 'preview.markdown', { sessionId: 'preview', path: nonMarkdown })
+      expect(textGrant).toMatchObject({ ok: false, status: 400, error: { code: 'bad-request' } })
+      const remoteGrant = await invoke(route, 'preview.markdown', { sessionId: 'preview', path: report }, '192.0.2.10')
+      expect(remoteGrant).toMatchObject({ ok: false, status: 403, error: { code: 'forbidden' } })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps an in-workspace Markdown click on the ordinary editable path', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'dsh-sidebar-markdown-workspace-'))
+    const report = join(workspace, 'report.md')
+    writeFileSync(report, '# Local')
+    try {
+      const route = mount({ sessions: { get: () => ({ header: { cwd: workspace } }) } })
+      const issued = await invoke(route, 'preview.markdown', { sessionId: 'preview', path: report })
+      expect(issued).toMatchObject({ ok: true, value: { outside: false } })
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Summary
- make complete absolute `.md` / `.markdown` inline-code paths clickable while preserving the stock produced-file resolver first
- route clicks through `remote.session.openWorkspacePath` into the sidebar
- authorize external Markdown with a random, session-bound, exact-canonical-path read capability minted only for loopback TCP peers
- force external preview tabs read-only at both the viewer UI and CodeMirror transaction layers while leaving writes and all unrelated paths workspace-fenced

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (121 files, 1291 passed, 9 skipped)
- `pnpm build`
- `pnpm check:consumer-types`
- `pnpm peers check`
