### PR TITLE
fix(editor): rewrite local images in markdown runs of the split renderer

### DIFF
--- a/src/client/MarkdownHtml.tsx
+++ b/src/client/MarkdownHtml.tsx
@@ -10,9 +10,10 @@
  * Security posture: every HTML string (block leaves, inline text, wrapper
  * open-tag attributes) goes through DOMPurify with an explicit denylist on
  * top of its defaults (no script/style/iframe/forms), anchors are forced to
- * open in a new tab with noopener, and local media `src` attributes are
- * rewritten through the session-scoped `/sidebar/file` media route — the same
- * trust fence the markdown image rewriter (`markdown-images.ts`) uses.
+ * open in a new tab with noopener, and local media goes through the
+ * session-scoped `/sidebar/file` media route — markdown-syntax image
+ * destinations are rewritten via `markdown-images.ts` and `src` attributes
+ * through `resolveLocalMediaDest` (the same trust fence).
  */
 import { useLayoutEffect, useMemo, useRef } from 'react'
 import { createElement, type ReactNode } from 'react'
@@ -21,7 +22,7 @@ import { MarkdownText } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { ComponentType } from 'react'
 import { markdownTextProps } from './markdown-labels.tsx'
 import { lazyChunkComponent } from './lazy-chunk.tsx'
-import { resolveLocalMediaDest } from './markdown-images.ts'
+import { resolveLocalMediaDest, rewriteLocalImageUrls } from './markdown-images.ts'
 import {
   analyzeHtmlSegment,
   type AnalyzedMarkdownHtml,
@@ -235,7 +236,12 @@ export function MarkdownDocument({ info, media, codeLabels }: MarkdownDocumentPr
   const prepared = useMemo<PreparedSegment[]>(() => info.segments.map((segment): PreparedSegment => {
     if (segment.kind === 'markdown') {
       const defs = info.referenceDefinitions
-      const text = defs === '' ? segment.text : `${segment.text}\n\n${defs}`
+      const raw = defs === '' ? segment.text : `${segment.text}\n\n${defs}`
+      // MarkdownText drops non-http(s) image destinations (chat-security
+      // stance), so rewrite local ones into /sidebar/file media URLs first —
+      // the same trust fence the sanitized HTML leaves below go through.
+      // Idempotent: already-absolute media URLs pass through untouched.
+      const text = rewriteLocalImageUrls(raw, media.scope, media.path, media.origin)
       return {
         kind: 'markdown',
         text,

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -346,9 +346,11 @@ export function TextEditor(props: FileViewerProps) {
     () => (markdown && mode === 'preview' ? splitMermaidBlocks(previewMdText) : []),
     [markdown, mode, previewMdText],
   )
-  /** Raw-HTML analysis (block runs lifted out + inline gate). Non-null only
-   *  for documents that actually contain HTML — plain markdown keeps the
-   *  legacy single-pass render path below, byte-for-byte. */
+  /** Raw-HTML analysis (block runs lifted out + inline gate). Non-null for
+   *  every markdown preview, so the render below always takes the split
+   *  renderer — its markdown runs rewrite local image destinations internally
+   *  (see MarkdownHtml.tsx). The legacy single-pass branches (fed the
+   *  pre-rewritten `previewText`) are dead in the current wiring. */
   const htmlInfo = useMemo(
     () => (markdown && mode === 'preview' ? analyzeMarkdownHtml(previewMdText) : null),
     [markdown, mode, previewMdText],

--- a/tests/markdown-html-render.spec.tsx
+++ b/tests/markdown-html-render.spec.tsx
@@ -175,3 +175,51 @@ describe('MarkdownDocument (inline pass)', () => {
     await unmount(root)
   })
 })
+
+describe('MarkdownDocument (local markdown images)', () => {
+  it('renders markdown-syntax local images through the /sidebar/file route', async () => {
+    const { container, root } = await renderDocument([
+      '# Title',
+      '',
+      '![icon](./assets/icon.svg)',
+      '',
+      '![logo][logo]',
+      '',
+      '[logo]: ./logo.png',
+    ].join('\n'))
+    const imgs = [...container.querySelectorAll('img')]
+    expect(imgs.length, 'both local images must render as <img>, not alt fallback').toBe(2)
+    expect(imgs[0]?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fassets%2Ficon.svg&cwd=%2Fws')
+    expect(imgs[0]?.getAttribute('alt')).toBe('icon')
+    expect(imgs[1]?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Flogo.png&cwd=%2Fws')
+    expect(imgs[1]?.getAttribute('alt')).toBe('logo')
+    await unmount(root)
+  })
+
+  it('renders local markdown images in HTML-mixed documents (the production path)', async () => {
+    const { container, root } = await renderDocument([
+      '<div align="center">badges</div>',
+      '',
+      '![shot](./img.png)',
+    ].join('\n'))
+    const img = container.querySelector('img')
+    expect(img, 'the markdown-syntax image after an HTML run must render').not.toBeNull()
+    expect(img?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws')
+    await unmount(root)
+  })
+
+  it('keeps remote image destinations untouched', async () => {
+    const { container, root } = await renderDocument('![r](https://example.com/x.png)')
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toBe('https://example.com/x.png')
+    await unmount(root)
+  })
+
+  it('is idempotent for already-rewritten media URLs', async () => {
+    const url = 'http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws'
+    const { container, root } = await renderDocument(`![a](${url})`)
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toBe(url)
+    await unmount(root)
+  })
+})


### PR DESCRIPTION
## 问题

`.md` 文件预览中，markdown 图片语法引用的**本地图标/图片**全部无法渲染（回退为 alt 文本）：

```markdown
![icon](./assets/icon.svg)
![logo][logo]

[logo]: ./logo.png
```

而 HTML 标签写法 `<img src="./icon.png">` 正常。

## 根因

1. `TextEditor` 计算了重写后的 `previewText`（本地图片目的地 → `${origin}/sidebar/file?...` 绝对 URL），但只有**旧版渲染分支**消费它；
2. `htmlInfo` 从**未重写**的 `previewMdText` 计算，且对所有 markdown 预览恒非 null（注释声称的门控从未生效）→ **每个 .md 预览都走 `MarkdownDocument` 分流渲染器**，旧分支为死代码；
3. `MarkdownDocument` 把 markdown segment 的原始文本直接喂给 `MarkdownText`，其 `media` prop 只用于 HTML run 的 `<img src>` 消毒重写（`postProcessSanitized`），不覆盖 markdown 图片语法；
4. 共享原语 `MarkdownText.renderImage` → `remoteImageUrl` 只接受绝对 http/https → 相对路径回退 alt 文本。

该断链自分流渲染器引入（7f63486）起即存在。

## 修复（KISS）

在 `MarkdownDocument` 的 `prepared` memo 内，对每个 markdown run（segment + 追加的引用定义）先经 `rewriteLocalImageUrls` 再交给 `MarkdownText`/mermaid chunk —— 与 HTML leaves 走**同一道** `/sidebar/file` 媒体信任栅栏（同一 `markdown-images.ts` 工具族）：

- `TextEditor` 接线零改动；渲染器自持本地媒体解析职责，组件 spec 可直接守护
- 幂等：已重写的绝对媒体 URL 原样放行，双重重写不可能
- 远程 http/https 目的地不受影响
- 顺带修正 `htmlInfo` 上方失实的"Non-null only for HTML documents"注释

## 验证

- 新增 4 个回归用例（`tests/markdown-html-render.spec.tsx`）：纯 markdown 内联 + 引用式图片、HTML 混排文档（生产实际路径）、远程不动、幂等 —— **修复前 2 个核心用例失败（复现 bug），修复后 13/13 通过**
- markdown 相关 6 个 spec 全绿（56 项）；`pnpm typecheck` / `pnpm lint` 干净
- 全量 `pnpm test`：仅 5 个文件 26 项失败，经 stash 对照确认为 **main 上既有失败**（free-window / sidebar-activation / sidebar-crash / bottom-terminal，与本改动无关）