### PR TITLE
fix(explorer): align directory mentions with workspace-root grammar

### DIFF
--- a/src/client/Sidebar.tsx
+++ b/src/client/Sidebar.tsx
@@ -33,7 +33,7 @@ import { useSyncExternalStore } from 'react'
 import clsx from 'clsx'
 import { IconCloseFill14, Tooltip } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { Context } from '../context-types.ts'
-import { appendToDraft, insertFileReference } from './conversation-draft.ts'
+import { insertWorkspaceReference } from './conversation-draft.ts'
 import {
   BOTTOM_MIN, PANEL_MIN, agentUuidOf, firstLeaf, floatTab,
   isAgentTabId, leafWithTab, migrateBottomTabs,
@@ -56,7 +56,6 @@ import { useHostFeeds } from './sidebar/use-host-feeds.ts'
 import { usePinnedTabs } from './sidebar/use-pinned-tabs.ts'
 import { FreeWindowLayer, useFloatDragout } from './sidebar/free-windows.tsx'
 import type { TabDragPayload } from './TabBar.tsx'
-import { relativeTo } from './paths.ts'
 import { t } from './locales.ts'
 import { api } from './api.ts'
 import css from './sidebar.module.css'
@@ -752,15 +751,8 @@ export function Sidebar(props: { ctx: Context; store: SidebarStore }) {
    */
   const referenceInChat = useCallback((path: string, isDir: boolean): void => {
     if (sessionId === undefined) return
-    const rel = relativeTo(cwd ?? '', path)
-    if (isDir) {
-      appendToDraft(ctx, sessionId, `@${rel === '.' ? './' : `${rel}/`}`)
-      return
-    }
-    if (!insertFileReference(ctx, sessionId, rel)) {
-      appendToDraft(ctx, sessionId, `@${rel}`)
-    }
-  }, [ctx, sessionId, cwd])
+    insertWorkspaceReference(ctx, sessionId, path, isDir)
+  }, [ctx, sessionId])
 
   if (state === undefined || sessionId === undefined) {
     // Keep the unavailable controls focusable: touch users have no hover, so

--- a/src/client/conversation-draft.ts
+++ b/src/client/conversation-draft.ts
@@ -59,7 +59,7 @@ interface SpliceResult {
  */
 function spliceInsert(draft: string, text: string, caret: DraftCaret | null): SpliceResult {
   if (caret === null || draft === '') {
-    const next = draft.trim() === '' ? text : `${draft} ${text}`
+    const next = draft.trim() === '' ? text : `${draft}${/\s$/.test(draft) ? '' : ' '}${text}`
     return { draft: next, caretAfter: next.length }
   }
   const prefix = draft.slice(0, caret.start)
@@ -69,7 +69,7 @@ function spliceInsert(draft: string, text: string, caret: DraftCaret | null): Sp
   // (or the string edges) — mirrors how typing in the middle of a sentence
   // behaves.
   const left = prefix === '' || /\s$/.test(prefix) ? '' : ' '
-  const right = suffix === '' || /^\s/.test(suffix) ? '' : ' '
+  const right = suffix === '' || /^\s/.test(suffix) || /\s$/.test(text) ? '' : ' '
   return {
     draft: `${prefix}${left}${text}${right}${suffix}`,
     caretAfter: prefix.length + left.length + text.length,
@@ -245,7 +245,9 @@ export function insertWorkspaceReference(ctx: Context, sessionId: string, path: 
       return false
     }
     if (!isDir && insertFileReference(ctx, sessionId, relative)) return true
-    return appendToDraft(ctx, sessionId, mention)
+    // The host adds space after a file chip, but not before it. Complete
+    // directory inserts need their own separator for the next @ click.
+    return appendToDraft(ctx, sessionId, isDir ? `${mention} ` : mention)
   } catch (error) {
     console.warn('[dsh-better-sidebar] workspace-reference insert failed:', error)
     return false

--- a/src/client/conversation-draft.ts
+++ b/src/client/conversation-draft.ts
@@ -33,6 +33,7 @@
  * position (A|B + C + D → ACD|B).
  */
 import type { Context, SidebarConversation } from '../context-types.ts'
+import { workspaceRelativePath } from './paths.ts'
 
 /** A resolved composer caret/selection in draft coordinates. */
 export interface DraftCaret {
@@ -211,14 +212,54 @@ export function fileMention(relativePath: string): { mention: string; label: str
   return { mention, label }
 }
 
+/** A complete directory token: normalize separators and put '/' inside quotes. */
+export function directoryMention(relativePath: string): string | undefined {
+  const reference = fileMention(relativePath.replace(/\\/g, '/'))
+  if (reference === undefined) return undefined
+  return reference.mention.endsWith('"')
+    ? `${reference.mention.slice(0, -1)}/"`
+    : `${reference.mention}/`
+}
+
+/**
+ * Insert an explorer entry using WorkspaceView.path, selected by exact
+ * session membership (the same lookup as the native conversation shell).
+ * Read the public workspace snapshot at click time so reconnects and session
+ * changes cannot leave a captured root stale. Missing/unready membership or
+ * an unrepresentable path is a logged no-op; never guess from session cwd.
+ */
+export function insertWorkspaceReference(ctx: Context, sessionId: string, path: string, isDir: boolean): boolean {
+  try {
+    const snapshot = ctx.get('workspaces')?.list.getSnapshot()
+    const root = snapshot?.phase === 'ready' && snapshot.state === 'idle'
+      ? snapshot.items.find(workspace => workspace.sessionIds.includes(sessionId))?.path
+      : undefined
+    const relative = workspaceRelativePath(root, path)
+    if (relative === undefined) {
+      console.warn('[dsh-better-sidebar] reference insert skipped: workspace root unavailable or path outside workspace')
+      return false
+    }
+    const mention = isDir ? directoryMention(relative) : fileMention(relative)?.mention
+    if (mention === undefined) {
+      console.warn('[dsh-better-sidebar] reference insert skipped: path cannot be represented as a mention')
+      return false
+    }
+    if (!isDir && insertFileReference(ctx, sessionId, relative)) return true
+    return appendToDraft(ctx, sessionId, mention)
+  } catch (error) {
+    console.warn('[dsh-better-sidebar] workspace-reference insert failed:', error)
+    return false
+  }
+}
+
 /**
  * Insert one FILE reference as a structured chip (like DSH's own `@` picker).
  * The chip displays `@<basename>` but serializes to `@<relative path>` on
  * send, so the reference stays a single link from trigger to basename.
  *
- * Directories are NOT handled here: DSH's folder grammar wants the trailing
- * slash as plain text (`@dir/`) so completion can descend, which
- * `appendToDraft` already covers.
+ * Directories keep the sidebar's plain-text completion behavior (`@dir/`)
+ * through `insertWorkspaceReference`. The rc.1 picker also supports folder
+ * chips on explicit selection; its drill action still inserts plain text.
  */
 export function insertFileReference(ctx: Context, sessionId: string, relativePath: string): boolean {
   const reference = fileMention(relativePath)

--- a/src/client/paths.ts
+++ b/src/client/paths.ts
@@ -1,6 +1,6 @@
 /**
- * Path projection helpers shared by the explorer rows: a path relative to
- * the session cwd (for the @-reference button and "copy relative path").
+ * Path projection helpers shared by the explorer rows: workspace-relative
+ * mentions and session-cwd-relative "copy relative path".
  * The fs-tree joins with '/' even on Windows, so both separators normalize
  * to '/' before comparison.
  *
@@ -44,6 +44,27 @@ export function relativeTo(cwd: string, path: string): string {
   if (nPath === nBase) return '.'
   if (nPath.toLowerCase().startsWith(`${nBase.toLowerCase()}/`)) return nPath.slice(nBase.length + 1)
   return path
+}
+
+/**
+ * Project an absolute explorer entry against the host-confirmed workspace
+ * root. Unlike copy-relative-path's `relativeTo`, mention insertion must
+ * never fall back to an absolute token. Unknown roots, traversal components
+ * and paths outside the workspace are refused. Windows drive/UNC paths are
+ * case-insensitive; POSIX paths retain their case-sensitive distinction.
+ */
+export function workspaceRelativePath(root: string | undefined, path: string): string | undefined {
+  if (root === undefined || !isAbsolutePath(root) || !isAbsolutePath(path)) return undefined
+  const norm = (value: string): string => value.replace(/\\/g, '/').replace(/\/+$/, '')
+  const base = norm(root)
+  const target = norm(path)
+  if ([base, target].some(value => value.split('/').some(part => part === '.' || part === '..'))) return undefined
+  const windows = /^[A-Za-z]:\//.test(root.replace(/\\/g, '/')) || /^[\\/]{2}/.test(root)
+  const compare = (value: string): string => windows ? value.toLowerCase() : value
+  if (compare(target) === compare(base)) return '.'
+  if (!compare(target).startsWith(`${compare(base)}/`)) return undefined
+  const relative = target.slice(base.length + 1)
+  return relative === '' || isAbsolutePath(relative) ? undefined : relative
 }
 
 /**

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -408,6 +408,21 @@ export interface SidebarConversation {
   }
 }
 
+/** Read-only subset of api-workspace-controller's public IWorkspaces.list. */
+export interface SidebarWorkspacesService {
+  readonly list: {
+    getSnapshot(): {
+      readonly phase: 'pending' | 'ready'
+      readonly state: 'idle' | 'loading' | 'error'
+      readonly items: readonly {
+        /** Canonical host directory, from WorkspaceView.path. */
+        readonly path: string
+        readonly sessionIds: readonly string[]
+      }[]
+    }
+  }
+}
+
 /**
  * The client `remote.session` namespace face (mirror of the gateway client's
  * RemoteNamespaceService for the session-controller contribution on alpha
@@ -551,6 +566,8 @@ export interface SidebarContextShape {
   }
   /** The composer draft face (client ui-conversation, lazy `ctx.get` probe). */
   conversation: SidebarConversation
+  /** Host-authoritative workspace membership; resolved lazily at reference insertion. */
+  workspaces?: SidebarWorkspacesService
   /**
    * The client-side sidebar registry: external plugins register tab types
    * and file previewers here. Provided by the client half (see

--- a/tests/conversation-draft.spec.ts
+++ b/tests/conversation-draft.spec.ts
@@ -92,6 +92,15 @@ describe('insertAtCaret', () => {
     expect(insertAtCaret('   ', 'X', null)).toBe('X')
   })
 
+  it('keeps a directory separator when appending another reference', () => {
+    expect(insertAtCaret('@src/ ', '@notes.md', null)).toBe('@src/ @notes.md')
+    expect(insertAtCaret('@src/\n', '@notes.md', null)).toBe('@src/\n@notes.md')
+  })
+
+  it('uses the inserted directory separator before a following word', () => {
+    expect(insertAtCaret('hello world', '@src/ ', { start: 6, end: 6 })).toBe('hello @src/ world')
+  })
+
   it('inserts at the caret in the middle of a sentence with one space each side', () => {
     expect(insertAtCaret('hello world', 'CODE', { start: 5, end: 5 })).toBe('hello CODE world')
   })

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isAbsolutePath, relativeTo } from '../src/client/paths.ts'
+import { isAbsolutePath, relativeTo, workspaceRelativePath } from '../src/client/paths.ts'
 import { resolveSidebarPath } from '../src/client/produced-files.ts'
 import { htmlUrl } from '../src/client/api.ts'
 
@@ -65,5 +65,35 @@ describe('path helpers', () => {
       .toBe('/sidebar/html/s//server/share/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '/home/me/index.html'))
       .toBe('/sidebar/html/s/home/me/index.html')
+  })
+})
+
+describe('workspaceRelativePath', () => {
+  it.each([
+    ['/work', '/work/src/a.ts', 'src/a.ts'],
+    ['/work/', '/work', '.'],
+    ['/', '/src/a.ts', 'src/a.ts'],
+    ['/', '/', '.'],
+    ['C:\\Work', 'c:/work/SRC/a.ts', 'SRC/a.ts'],
+    ['C:\\Work\\', 'c:/WORK', '.'],
+    ['C:\\', 'c:/SRC/a.ts', 'SRC/a.ts'],
+    ['C:\\Work', 'c:/work/my dir\\a.ts', 'my dir/a.ts'],
+    ['\\\\server\\share\\Work', '//SERVER/share/work/src/a.ts', 'src/a.ts'],
+  ])('projects %s / %s', (root, path, expected) => {
+    expect(workspaceRelativePath(root, path)).toBe(expected)
+  })
+
+  it.each([
+    [undefined, '/work/a.ts'],
+    ['', '/work/a.ts'],
+    ['work', '/work/a.ts'],
+    ['/work', '/outside/a.ts'],
+    ['/work', '/work-other/a.ts'],
+    ['/work', '/WORK/a.ts'],
+    ['/work', '/work/../outside/a.ts'],
+    ['/work', 'src/a.ts'],
+    ['C:/Work', 'D:/Work/a.ts'],
+  ])('refuses an unavailable root or unsafe projection %j / %s', (root, path) => {
+    expect(workspaceRelativePath(root, path)).toBeUndefined()
   })
 })

--- a/tests/reference-mention.spec.ts
+++ b/tests/reference-mention.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { fileMention } from '../src/client/conversation-draft.ts'
+import { directoryMention, fileMention } from '../src/client/conversation-draft.ts'
 
 describe('fileMention', () => {
   it('formats a plain relative file path as an @file mention', () => {
@@ -26,5 +26,23 @@ describe('fileMention', () => {
   it('rejects embedded quotes and control characters', () => {
     expect(fileMention('src/a"b.ts')).toBeUndefined()
     expect(fileMention('src/a\u0000b.ts')).toBeUndefined()
+  })
+})
+
+describe('directoryMention', () => {
+  it.each([
+    ['src', '@src/'],
+    ['my dir', '@"my dir/"'],
+    ['docs/my dir/notes here', '@"docs/my dir/notes here/"'],
+    ['src/', '@src/'],
+    ['.', '@./'],
+    ['src\\my dir\\', '@"src/my dir/"'],
+    ['src\\my dir/nested', '@"src/my dir/nested/"'],
+  ])('formats %s as a complete plain-text directory token', (path, mention) => {
+    expect(directoryMention(path)).toBe(mention)
+  })
+
+  it.each(['a"b', 'a\n b', 'a\t b', 'a\u0000b', 'a\u007fb', 'a\u0085b'])('rejects an unrepresentable directory %j', path => {
+    expect(directoryMention(path)).toBeUndefined()
   })
 })

--- a/tests/sidebar-workspace-reference.spec.tsx
+++ b/tests/sidebar-workspace-reference.spec.tsx
@@ -74,7 +74,7 @@ describe('Sidebar workspace references', () => {
     const view = mount(cwd, { root: '/work' })
     try {
       view.insert('/work/my dir', true)
-      expect(view.draft()).toBe('before @"my dir/"')
+      expect(view.draft()).toBe('before @"my dir/" ')
       expect(view.emit).not.toHaveBeenCalled()
     } finally { view.unmount() }
   })
@@ -91,6 +91,21 @@ describe('Sidebar workspace references', () => {
     } finally { view.unmount() }
   })
 
+  it.each(['src', 'my dir', 'docs/my dir'])('separates a directory %s from the next file chip', directory => {
+    const view = mount('/work', { root: '/work', chip: true })
+    try {
+      view.insert(`/work/${directory}`, true)
+      const beforeFile = view.draft()
+      expect(beforeFile).toMatch(/\s$/)
+      view.insert('/work/notes.md', false)
+      expect(view.emit).toHaveBeenCalledWith('slash/input-insert-reference', {
+        reference: { source: 'reference', ref: '@notes.md', label: 'notes.md', appearance: 'file', clipboardText: '@notes.md' },
+        span: { draftRev: 2, start: beforeFile.length, end: beforeFile.length },
+      })
+      expect(view.setDraft).toHaveBeenCalledTimes(1)
+    } finally { view.unmount() }
+  })
+
   it('keeps quoted file text when the chip event is not handled', () => {
     const view = mount('/work', { root: '/work' })
     try {
@@ -103,9 +118,9 @@ describe('Sidebar workspace references', () => {
     const view = mount('C:\\Work\\src', { root: 'C:\\Work\\' })
     try {
       view.insert('c:/WORK/my dir\\nested', true)
-      expect(view.draft()).toBe('before @"my dir/nested/"')
+      expect(view.draft()).toBe('before @"my dir/nested/" ')
       view.insert('c:/work', true)
-      expect(view.draft()).toBe('before @"my dir/nested/" @./')
+      expect(view.draft()).toBe('before @"my dir/nested/" @./ ')
     } finally { view.unmount() }
   })
 
@@ -125,7 +140,7 @@ describe('Sidebar workspace references', () => {
       // Resolve the host snapshot later: the next click must see fresh data.
       Object.assign(options, { root: '/work', phase: 'ready', state: 'idle', workspaceService: true })
       view.insert('/work/src', true)
-      expect(view.draft()).toBe('before @src/')
+      expect(view.draft()).toBe('before @src/ ')
     } finally { view.unmount() }
   })
 

--- a/tests/sidebar-workspace-reference.spec.tsx
+++ b/tests/sidebar-workspace-reference.spec.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { Sidebar } from '../src/client/Sidebar.tsx'
+import { createSidebarStore } from '../src/client/state.ts'
+import { createBetterSidebarService } from '../src/client/service.ts'
+import { setupReactAct } from './test-utils.ts'
+
+setupReactAct()
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+function mount(cwd: string, options: { root?: string; phase?: 'pending' | 'ready'; state?: 'idle' | 'loading' | 'error'; chip?: boolean; workspaceService?: boolean } = {}) {
+  vi.stubGlobal('WebSocket', class { close() {} })
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const store = createSidebarStore()
+  store.setSession('s1')
+  const service = createBetterSidebarService(store)
+  const sessions = { current: 's1', byId: { s1: { id: 's1', cwd } } }
+  const locale = { active: 'en' }
+  let draft = 'before'
+  let draftRev = 1
+  const setDraft = vi.fn((text: string) => { draft = text; draftRev++ })
+  const emit = vi.fn((_event: string, _payload: unknown) => {
+    if (options.chip) draftRev++
+  })
+  const input = { state: { getSnapshot: () => ({ draft, draftRev }) }, setDraft }
+  const workspaces = { list: { getSnapshot: () => ({
+    phase: options.phase ?? 'ready',
+    state: options.state ?? 'idle',
+    items: [
+      { path: '/decoy', sessionIds: ['other'] },
+      ...(options.root === undefined ? [] : [{ path: options.root, sessionIds: ['s1'] }]),
+    ],
+  }) } }
+  const ctx = {
+    locale: { subscribe: () => () => {}, getSnapshot: () => locale },
+    sessions: {
+      list: { subscribe: () => () => {}, getSnapshot: () => sessions },
+      scope: () => ({ emit }),
+    },
+    get: (name: string) => ({
+      betterSidebar: service,
+      conversation: { input: { for: () => input } },
+      workspaces: options.workspaceService === false ? undefined : workspaces,
+    })[name],
+  }
+  let reference: ((path: string, isDir: boolean) => void) | undefined
+  service.registerTab({ id: 'reference-test', title: 'Reference', component: props => {
+    reference = props.onReferenceFile
+    return null
+  } })
+  service.openTab({ type: 'reference-test', title: 'Reference' })
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  act(() => { root.render(createElement(Sidebar, { ctx: ctx as never, store })) })
+  expect(reference).toBeTypeOf('function')
+  return {
+    insert: (path: string, isDir: boolean) => { act(() => { reference!(path, isDir) }) },
+    draft: () => draft, emit, setDraft, warn,
+    unmount: () => { act(() => { root.unmount() }); container.remove() },
+  }
+}
+
+describe('Sidebar workspace references', () => {
+  it.each(['/work', '/work/src'])('uses workspace membership with session cwd %s', cwd => {
+    const view = mount(cwd, { root: '/work' })
+    try {
+      view.insert('/work/my dir', true)
+      expect(view.draft()).toBe('before @"my dir/"')
+      expect(view.emit).not.toHaveBeenCalled()
+    } finally { view.unmount() }
+  })
+
+  it('uses workspace-relative file chips outside the session cwd', () => {
+    const view = mount('/work/src', { root: '/work', chip: true })
+    try {
+      view.insert('/work/docs/my notes.md', false)
+      expect(view.emit).toHaveBeenCalledWith('slash/input-insert-reference', {
+        reference: { source: 'reference', ref: '@"docs/my notes.md"', label: 'my notes.md', appearance: 'file', clipboardText: '@"docs/my notes.md"' },
+        span: { draftRev: 1, start: 6, end: 6 },
+      })
+      expect(view.setDraft).not.toHaveBeenCalled()
+    } finally { view.unmount() }
+  })
+
+  it('keeps quoted file text when the chip event is not handled', () => {
+    const view = mount('/work', { root: '/work' })
+    try {
+      view.insert('/work/my notes.md', false)
+      expect(view.draft()).toBe('before @"my notes.md"')
+    } finally { view.unmount() }
+  })
+
+  it('normalizes Windows drive casing and mixed separators', () => {
+    const view = mount('C:\\Work\\src', { root: 'C:\\Work\\' })
+    try {
+      view.insert('c:/WORK/my dir\\nested', true)
+      expect(view.draft()).toBe('before @"my dir/nested/"')
+      view.insert('c:/work', true)
+      expect(view.draft()).toBe('before @"my dir/nested/" @./')
+    } finally { view.unmount() }
+  })
+
+  it.each([
+    { root: undefined },
+    { root: '/work', workspaceService: false },
+    { root: '/work', phase: 'pending' as const },
+    { root: '/work', state: 'loading' as const },
+    { root: '/work', state: 'error' as const },
+  ])('leaves the draft intact and logs when workspace data is unavailable: %j', options => {
+    const view = mount('/work/src', options)
+    try {
+      view.insert('/work/src/a.ts', false)
+      expect(view.draft()).toBe('before')
+      expect(view.emit).not.toHaveBeenCalled()
+      expect(view.warn).toHaveBeenCalled()
+      // Resolve the host snapshot later: the next click must see fresh data.
+      Object.assign(options, { root: '/work', phase: 'ready', state: 'idle', workspaceService: true })
+      view.insert('/work/src', true)
+      expect(view.draft()).toBe('before @src/')
+    } finally { view.unmount() }
+  })
+
+  it.each(['/outside/file.ts', '/work/a"b', '/work/a\nb'])('never inserts an unsafe path %j as a file or directory', path => {
+    const view = mount('/work', { root: '/work' })
+    try {
+      view.insert(path, false)
+      view.insert(path, true)
+      expect(view.draft()).toBe('before')
+      expect(view.emit).not.toHaveBeenCalled()
+      expect(view.warn).toHaveBeenCalled()
+    } finally { view.unmount() }
+  })
+})


### PR DESCRIPTION
Fixes #479

The explorer inserts complete directory references such as `@src/` and `@"my dir/"`, and derives file and directory tokens from the host-confirmed workspace root. Earlier fixes already added quoted file mentions, structured file chips, and directory trailing slashes; this PR addresses the two remaining gaps identified by the maintainer. It also fixes the missing separator between consecutive directory and file insertions discovered during real-host verification.

The old callback interpolated directories directly and called `relativeTo(sessionCwd, path)`, whose outside-cwd fallback returns an absolute path. The callback now shares a validated workspace-relative insertion path. File chips retain their payload and quoted plain-text fallback. Directories retain plain-text completion behavior: normalize separators to `/`, place the trailing slash inside the closing quote, and reject embedded quotes and control characters. Referencing the workspace itself remains `@./`.

Workspace authority is the public, read-only `ctx.get('workspaces').list.getSnapshot()`: match the current session ID in `WorkspaceView.sessionIds`, then read its canonical `path`. This is the membership lookup used by the native conversation shell, without guessing a root from cwd or parent directories. The structural mirror follows published rc.1 declarations without adding a dependency or runtime import:

- [IWorkspaces.list and WorkspaceSource](https://unpkg.com/@deepseek-ai/dsh-api-workspace-controller@0.1.2-rc.1/lib/types/client/service.d.ts)
- [WorkspaceView.path and sessionIds](https://unpkg.com/@deepseek-ai/dsh-api-workspace-controller@0.1.2-rc.1/lib/types/types.d.ts)
- [Native conversation membership lookup](https://unpkg.com/@deepseek-ai/dsh-client-ui-conversation@0.1.2-rc.1/lib/client.js)

The snapshot is read on each click. Missing service/membership, pending/loading/error snapshots, outside-workspace entries and unsafe path projections leave the draft unchanged and log the reason. There is no absolute-mention fallback. Windows drive/UNC comparisons tolerate casing and mixed separators while preserving target spelling; POSIX comparisons remain case-sensitive. The existing copy-relative-path helper is unchanged.

The [rc.1 native picker](https://unpkg.com/@deepseek-ai/dsh-client-ui-reference@0.1.2-rc.1/lib/client.js) uses plain text for directory drill and supports folder chips on explicit selection. Its drill formatter leaves a quote open for completion; the sidebar inserts a complete closed token as requested in #479. The host's `insertReference` adds space after a file chip but not before it. Completed directory insertions therefore add a separator outside the token, preventing `@"my dir/"@"docs/my notes.md"`. Plain-text joins reuse existing whitespace. `insertFileReference` itself remains byte-for-byte unchanged from the original parent commit.

Regression coverage includes ordinary/spaced/nested directories, Windows drive/UNC/mixed separators, root self-reference, quotes/control characters, cwd equal to or below workspace root, a file outside cwd but inside workspace, unavailable workspace data and recovery, structured file payloads, unhandled-chip fallback, and consecutive-reference separation. Tests exercise pure functions and the rendered Sidebar callback without copying production logic or asserting source strings.

Actual local validation on latest commit `1ad9ac75068261ffcf4e595d7e2d71dfde7808bb` (Linux/WSL2, Node 24.20.0):

| Check | Result |
| --- | --- |
| Complete `reference-mention` + `paths` files | 43 passed |
| Complete `sidebar-workspace-reference` file | 16 passed |
| Complete `conversation-draft` file | 27 passed |
| Above four complete files after restoring the production fix | 86 passed |
| New separator regressions before implementation | 5 failed / 38 passed across two complete files |
| Withdraw separator production fix and rerun only the five new cases | All 5 failed; restoring it passes |
| Full `pnpm test` | 124 files passed, 1358 passed / 9 skipped / 0 failed |
| `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm check:consumer-types`, `git diff --check` | Passed |

The original issue regressions also failed before implementation (44 failed / 12 passed when all original production changes were withdrawn), and passed after restoration. The missing system build tools were installed earlier (GNU Make 4.3, GCC/G++ 13.3), and `pnpm rebuild node-pty` succeeded. All 31 earlier node-pty failures disappeared after repairing the environment; prior branch/baseline runs had the same 31 failing test names. No test exclusions or dependency changes were used to mask the environment problem.

Latest-commit real UI validation on 2026-09-07: **9 checks passed on Linux and 9 on native Windows**, using the packed plugin installed by the official DSH CLI into isolated profiles. DSH was 0.1.2-rc.1 on both; Linux Node 24.20.0, Windows Node 24.19.0 / `process.platform=win32` / Windows 10.0.26200 x64. Browser automation ran in Chromium on each OS, with no host/session mocks:

- Actual file-tree @ clicks produced ordinary, spaced, nested and root directory tokens, each followed by an insertion separator.
- Moving the caret before the closing quote displayed the native nested-directory completion candidate.
- Consecutive directory clicks serialized with a single separator.
- Directory followed by file, without manually typing whitespace, serialized `@"my dir/" @"docs/my notes.md" ` and retained one native file chip.
- Sending that combination persisted both separated complete tokens in a real `user/message` and cleared the composer; screenshots record the resulting message display.
- Removing the workspace registration through the public API made @ insertion a no-op with draft `KEEP` unchanged; registration was restored.
- No page errors occurred. Runtime records, screenshots and structured event evidence are retained locally; generated artifacts are not committed.

The latest combined sends used keyless profiles and establish host acceptance/rendering, not successful model execution. Earlier on commit `cb271e0`, after the user configured credentials, `deepseek-official / deepseek-v4-flash` successfully ran two real browser-submitted checks: `read` returned a random verification value from a spaced-path file, and `glob` returned two random child filenames from a spaced directory. Final replies exactly matched values not supplied in the prompts; both turns completed and fixture contents were unchanged. Those two model calls were not repeated on the separator follow-up commit. No API key was read or recorded.

Remaining live-contract limitation: the [local discovery provider](https://unpkg.com/@deepseek-ai/dsh-file-reference-local@0.1.2-rc.1/lib/index.js) searches from session header cwd, and the [workspace registry](https://unpkg.com/@deepseek-ai/dsh-workspace@0.1.2-rc.1/lib/types/index.js) filters membership to canonical cwd equality. Actual rc.1 API attempts rejected `workspaceId` plus child `cwd` with `gateway/bad-request`, and rejected adopting an existing child-cwd session into a parent workspace with `session/conflict`. Thus the differing-cwd case is covered by authoritative workspace snapshot fixtures; it is not claimed as a reproduced live rc.1 configuration. No DSH source was modified or patched to manufacture one.

CI for latest commit `1ad9ac7`:

- [Fork CI](https://github.com/bulingbuling688/DSH-better-sidebar/actions/runs/34113731683): **success**. Linux: 124 files passed, 1358 passed / 9 skipped. Windows: 124 files passed, 1364 passed / 3 skipped. Both lanes passed typecheck, lint, build and consumer types. Real DSH mount smoke: 18 passed; aggregate double-mount regression: passed.
- [Upstream PR workflow](https://github.com/omdsh-dev/DSH-better-sidebar/actions/runs/34113689352): `action_required`, awaiting maintainer approval.

The PR is ready for review, open and unmerged. Fork CI does not replace upstream approval or review. Version, dependencies, lockfile and release configuration are unchanged; the worktree is clean. These UI checks are browser automation, not a human manual walkthrough.

