### PR TITLE
fix: preserve reverse-proxy base paths

### DIFF
--- a/src/client/MarkdownHtml.tsx
+++ b/src/client/MarkdownHtml.tsx
@@ -40,7 +40,8 @@ import { LazyMermaidMarkdown } from './mermaid-lazy.tsx'
 export interface MarkdownHtmlMedia {
   scope: SessionScope
   path: string
-  origin: string
+  /** The injected document base, including any reverse-proxy prefix. */
+  baseUrl: string
 }
 
 /** Tag-like text in a rendered text node — the inline pass gate. */
@@ -67,7 +68,7 @@ function postProcessSanitized(root: Element, media: MarkdownHtmlMedia): void {
   for (const element of root.querySelectorAll('img, video, audio, source')) {
     const src = element.getAttribute('src')
     if (src === null) continue
-    element.setAttribute('src', resolveLocalMediaDest(src, media.scope, media.path, media.origin))
+    element.setAttribute('src', resolveLocalMediaDest(src, media.scope, media.path, media.baseUrl))
   }
 }
 
@@ -239,7 +240,7 @@ export function MarkdownDocument({ info, media, codeLabels }: MarkdownDocumentPr
       // stance), so rewrite local ones into /sidebar/file media URLs first —
       // the same trust fence the sanitized HTML leaves below go through.
       // Idempotent: already-absolute media URLs pass through untouched.
-      const text = rewriteLocalImageUrls(raw, media.scope, media.path, media.origin)
+      const text = rewriteLocalImageUrls(raw, media.scope, media.path, media.baseUrl)
       return {
         kind: 'markdown',
         text,
@@ -255,7 +256,7 @@ export function MarkdownDocument({ info, media, codeLabels }: MarkdownDocumentPr
       }),
     }
   // `media` is a memoized object in the host (TextEditor); identity tracks
-  // scope/path/origin changes so sanitization re-runs exactly when needed.
+  // scope/path/baseUrl changes so sanitization re-runs exactly when needed.
   }), [info, media])
 
   const nodes: ReactNode[] = []

--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -41,6 +41,7 @@ import { ONE_DARK, ONE_LIGHT } from './one-dark-palette.ts'
 import { openWhenSized } from './open-when-sized.ts'
 import { api, type SessionScope, type TerminalDepsStatus } from './api.ts'
 import { agentUuidOf, isAgentTabId, type SidebarStore } from './state.ts'
+import { hostWebSocketUrl } from './host-route-url.ts'
 import { isDarkScheme, subscribeColorScheme, effectiveTokenValue, tokenValue } from './theme.ts'
 import { resolveTerminalFont } from './terminal-font.ts'
 import {
@@ -183,8 +184,7 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
     let failures = 0
 
     const wsUrl = (): string => {
-      const url = new URL('/sidebar/ws/terminal', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/terminal')
       // Agent terminals attach by uuid (the host looks them up in the agent
       // pty registry); UI-tab terminals attach by sessionId+tab (the host
       // uses the UI-tab pty manager). Same upgrade endpoint, different query.
@@ -195,9 +195,8 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
         if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
         url.search = params.toString()
       }
-      // Same construction the app's own downlink WebSockets use (new URL
-      // over location.origin + protocol swap): whatever the environment
-      // does to the app's websockets applies identically here.
+      // Resolve through the injected document base so reverse-proxy prefixes
+      // survive the http→websocket protocol swap.
       return url.toString()
     }
 

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -330,7 +330,7 @@ export function TextEditor(props: FileViewerProps) {
   /** The preview source with local image destinations rewritten to absolute
    *  media URLs (see {@link rewriteLocalImageUrls}). */
   const previewText = markdown
-    ? rewriteLocalImageUrls(previewMdText, scope, path, window.location.origin)
+    ? rewriteLocalImageUrls(previewMdText, scope, path, document.baseURI)
     : previewMdText
   /** md/mermaid block split for the preview (mermaid fences lift out). Split
    *  only in preview mode: edit-mode keystrokes must not re-scan the source. */
@@ -359,7 +359,7 @@ export function TextEditor(props: FileViewerProps) {
    *  `media` identity, so a fresh object per render would re-sanitize every
    *  keystroke. */
   const htmlMedia = useMemo<MarkdownHtmlMedia>(
-    () => ({ scope, path, origin: window.location.origin }),
+    () => ({ scope, path, baseUrl: document.baseURI }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [scope.sessionId, scope.cwd, path],
   )

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,12 +1,13 @@
 /**
- * Typed fetch wrapper over the /sidebar JSON API. Every call posts to
- * `/sidebar/api/<method>` with the sessionId and — when known — the session's
+ * Typed fetch wrapper over the /sidebar JSON API. Every call posts through
+ * the injected document base to `/sidebar/api/<method>` with the sessionId and — when known — the session's
  * cwd from the client's own list summary. The host prefers its attached
  * session header and uses the summary cwd only while the session is still
  * hydrating at page load (a detached session would otherwise fail the
  * request). Failures surface as {@link SidebarApiError} with the wire code.
  */
 import { encodeHtmlUrl } from '../html-route.ts'
+import { hostRouteUrl } from './host-route-url.ts'
 import type { LastActivity } from '../subagent-activity.ts'
 import type { SidechatLogEvent, SidechatThreadInfo } from '../sidechat-core.ts'
 import type { SidebarSessionEvent } from '../context-types.ts'
@@ -151,7 +152,7 @@ async function readEnvelope<T>(response: Response): Promise<T> {
 async function call<T>(method: string, payload: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
   let response: Response
   try {
-    response = await fetch(`/sidebar/api/${method}`, {
+    response = await fetch(hostRouteUrl(`sidebar/api/${method}`), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),
@@ -181,7 +182,7 @@ async function fetchUpload<T>(
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
   let response: Response
   try {
-    response = await fetch(`/sidebar/upload?${params.toString()}`, {
+    response = await fetch(hostRouteUrl(`sidebar/upload?${params.toString()}`), {
       method: 'POST',
       headers: { 'content-type': 'application/octet-stream' },
       body,
@@ -413,12 +414,12 @@ export const api = {
   openExternal,
 }
 
-/** Absolute URL of the media route for one path (images only). */
+/** Absolute media-route URL for one path (images only), resolved through the document base. */
 export function mediaUrl(scope: SessionScope, path: string): string {
   return fileUrl(scope, path, false)
 }
 
-/** Absolute URL of the download route: serves raw bytes (binary-safe) with
+/** Absolute download-route URL: serves raw bytes (binary-safe) with
  *  `Content-Disposition: attachment`, so the browser saves the file. */
 export function downloadUrl(scope: SessionScope, path: string): string {
   return fileUrl(scope, path, true)
@@ -429,11 +430,11 @@ function fileUrl(scope: SessionScope, path: string, download: boolean): string {
   const params = new URLSearchParams({ sessionId: scope.sessionId, path })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
   if (download) params.set('download', '1')
-  return `/sidebar/file?${params.toString()}`
+  return hostRouteUrl(`sidebar/file?${params.toString()}`).href
 }
 
 /**
- * Absolute URL of the HTML preview route (see html-route.ts): the path is
+ * Absolute HTML-preview URL (see html-route.ts): the path is
  * fully encoded so the previewed page's relative assets resolve back into
  * the same route with the session scope intact. The UNC marker is
  * platform-neutral — the host's requireAbsolute resolves the decoded
@@ -441,5 +442,5 @@ function fileUrl(scope: SessionScope, path: string, download: boolean): string {
  * client-side platform signal is needed.
  */
 export function htmlUrl(scope: SessionScope, path: string): string {
-  return encodeHtmlUrl(scope.sessionId, path)
+  return hostRouteUrl(encodeHtmlUrl(scope.sessionId, path)).href
 }

--- a/src/client/changes/DiffPane.tsx
+++ b/src/client/changes/DiffPane.tsx
@@ -288,7 +288,7 @@ export function DiffPane({ target, scope, height, onHeightCommit, onClose, onExp
   }, [mdOp, op, prior])
   const readingText = useMemo(
     () => (mdOp && reading && readingSrc !== '' && target.kind === 'op'
-      ? rewriteLocalImageUrls(readingSrc, scope, target.path, window.location.origin)
+      ? rewriteLocalImageUrls(readingSrc, scope, target.path, document.baseURI)
       : ''),
     [mdOp, reading, readingSrc, scope, target],
   )

--- a/src/client/chunk-loader.ts
+++ b/src/client/chunk-loader.ts
@@ -18,9 +18,10 @@
  * graph rows; a chunk id is none of those, so resolution would be version-
  * dependent). Materialization is plugin-owned:
  *
- * 1. inject <script src="/sidebar/bundle/<name>.js"> (classic same-origin
- *    script; the official /plugins/<id>/client.js route cannot serve
- *    arbitrary file names, so the plugin's own host route serves the chunks),
+ * 1. inject a classic same-origin `/sidebar/bundle/<name>.js` script, resolved
+ *    through the injected document base so proxy prefixes survive; the official
+ *    /plugins/<id>/client.js route cannot serve arbitrary file names, so the
+ *    plugin's own host route serves the chunks,
  * 2. read the factory from the global registry,
  * 3. call it with a require that resolves the platform externals through
  *    the injected module system's `import(spec)` (the `ctx.modules` service)
@@ -50,6 +51,8 @@
  * client.js); an edit that does land while a core HMR happens is caught by
  * the ETag comparison on the next activation.
  */
+import { hostRouteUrl } from './host-route-url.ts'
+
 export type ChunkName = 'terminal' | 'editor' | 'mermaid' | 'locale'
 
 /** The module exports a chunk factory provides (namespace-ish record). */
@@ -80,7 +83,7 @@ export const CHUNK_EXTERNALS: readonly string[] = [
 ]
 
 /** Chunk script endpoint served by the plugin host half (src/bundle-route.ts). */
-const CHUNK_URL = (name: ChunkName): string => `/sidebar/bundle/${name}.js`
+const CHUNK_URL = (name: ChunkName): string => hostRouteUrl(`sidebar/bundle/${name}.js`).href
 
 /** Bound on the revalidation HEAD round-trip. A timeout fails open (drop +
  *  re-fetch on the next open) so a stuck bundle route can never wedge lazy

--- a/src/client/host-route-url.ts
+++ b/src/client/host-route-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve one host-owned route through the GUI document base. This preserves
+ * reverse-proxy prefixes (for example code-server's `/proxy/<port>/`) that
+ * are intentionally absent from `location.origin`.
+ */
+export function hostRouteUrl(path: string, baseUrl: string = document.baseURI): URL {
+  return new URL(path.replace(/^\/+/, ''), baseUrl)
+}
+
+/** Resolve one host-owned WebSocket route through the GUI document base. */
+export function hostWebSocketUrl(path: string, baseUrl: string = document.baseURI): URL {
+  const url = hostRouteUrl(path, baseUrl)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url
+}

--- a/src/client/markdown-images.ts
+++ b/src/client/markdown-images.ts
@@ -5,12 +5,13 @@
  * a previewed `.md` (`![alt](./img.png)`, an absolute `/cwd/img.png`, or a
  * reference definition) would otherwise fall back to its alt text. This
  * dependency-free helper rewrites those destinations into absolute
- * `/sidebar/file` media URLs (prefixed with the GUI's own origin) so
+ * `/sidebar/file` media URLs resolved against the injected document base so
  * `MarkdownText` accepts them; the host media route then serves the bytes,
  * still restricted to files under the session cwd.
  */
 
 import type { SessionScope } from './api.ts'
+import { hostRouteUrl } from './host-route-url.ts'
 import { isAbsolutePath } from './paths.ts'
 
 /**
@@ -61,15 +62,15 @@ function normalizeLocalPath(path: string): string {
  * @param text - The raw markdown source (inline + reference images).
  * @param scope - The session scope (sessionId + cwd) for the media route.
  * @param filePath - The absolute path of the opened `.md` file.
- * @param origin - The GUI's own origin (`window.location.origin`); injected
- * so the core rewrite stays pure and unit-testable.
+ * @param baseUrl - The injected document base; supplied explicitly so this
+ * helper remains pure and retains any reverse-proxy prefix.
  * @returns The markdown with local image destinations rewritten in place.
  */
 /**
  * Resolve one media destination against the session's media route: local
- * (relative or absolute) paths become absolute `/sidebar/file` URLs (prefixed
- * with the GUI's own origin so the shared MarkdownText http(s) allowlist
- * accepts them), while remote URLs, `#`-anchors and empty destinations are
+ * (relative or absolute) paths become absolute `/sidebar/file` URLs resolved
+ * through the injected document base so the shared MarkdownText http(s)
+ * allowlist accepts them), while remote URLs, `#`-anchors and empty destinations are
  * returned untouched. Shared by the markdown image rewriter below and by the
  * preview's raw-HTML sanitizer (`markdown-html.tsx`, which meets the same
  * allowlist when rendering `<img src="./x.png">` inside HTML blocks).
@@ -78,7 +79,7 @@ export function resolveLocalMediaDest(
   dest: string,
   scope: SessionScope,
   filePath: string,
-  origin: string,
+  baseUrl: string,
 ): string {
   const trimmed = dest.trim()
   if (trimmed === '' || trimmed.startsWith('#')) return dest
@@ -90,16 +91,16 @@ export function resolveLocalMediaDest(
   // absolute so the shared MarkdownText http(s) allowlist accepts it.
   const params = new URLSearchParams({ sessionId: scope.sessionId, path: normalizeLocalPath(candidate) })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
-  return `${origin}/sidebar/file?${params.toString()}`
+  return hostRouteUrl(`sidebar/file?${params.toString()}`, baseUrl).href
 }
 
 export function rewriteLocalImageUrls(
   text: string,
   scope: SessionScope,
   filePath: string,
-  origin: string,
+  baseUrl: string,
 ): string {
-  const resolve = (dest: string): string => resolveLocalMediaDest(dest, scope, filePath, origin)
+  const resolve = (dest: string): string => resolveLocalMediaDest(dest, scope, filePath, baseUrl)
 
   // Mask fenced code blocks and inline code spans so image-looking text
   // inside documentation examples is never rewritten. The sentinel uses a

--- a/src/client/sidebar/use-host-feeds.ts
+++ b/src/client/sidebar/use-host-feeds.ts
@@ -12,6 +12,7 @@ import { isNarrowWidth } from '../breakpoints.ts'
 import { detectNewDirectSubagent } from '../subagent-detect.ts'
 import { detectNewJob } from '../subagent-jobs.ts'
 import { t } from '../locales.ts'
+import { hostWebSocketUrl } from '../host-route-url.ts'
 
 /** How many consecutive reconnect failures stop the agent-terminals push loop
  * (mirror of the terminal view's own cap; the loop restarts on session switch). */
@@ -56,8 +57,7 @@ export function useHostFeeds(feeds: {
     let failures = 0
     const connect = (): void => {
       if (closed) return
-      const url = new URL('/sidebar/ws/agent-terminals', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/agent-terminals')
       url.search = new URLSearchParams({ sessionId }).toString()
       socket = new WebSocket(url.toString())
       socket.onmessage = (event) => {
@@ -113,8 +113,7 @@ export function useHostFeeds(feeds: {
     let failures = 0
     const connect = (): void => {
       if (closed) return
-      const url = new URL('/sidebar/ws/agent-opens', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/agent-opens')
       url.search = new URLSearchParams({ sessionId }).toString()
       socket = new WebSocket(url.toString())
       socket.onmessage = (event) => {

--- a/tests/base-path.spec.ts
+++ b/tests/base-path.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { hostRouteUrl, hostWebSocketUrl } from '../src/client/host-route-url.ts'
+
+/**
+ * Every browser-to-host transport must resolve relative to the injected page
+ * base. A leading slash would discard this prefix and make a reverse proxy
+ * route `/sidebar/*` at the origin root instead.
+ */
+describe('host route URLs behind a reverse-proxy base path', () => {
+  const baseUrl = 'https://example.test/dataops/proxy/3080/'
+
+  it('keeps the page prefix for API, uploads, media, HTML, and lazy bundles', () => {
+    expect(hostRouteUrl('/sidebar/api/fs.tree', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/api/fs.tree')
+    expect(hostRouteUrl('/sidebar/upload?sessionId=s', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/upload?sessionId=s')
+    expect(hostRouteUrl('/sidebar/file?sessionId=s&path=%2Fwork%2Fa.png', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/file?sessionId=s&path=%2Fwork%2Fa.png')
+    expect(hostRouteUrl('/sidebar/html/s/work/index.html', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/html/s/work/index.html')
+    expect(hostRouteUrl('/sidebar/bundle/editor.js', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/bundle/editor.js')
+  })
+
+  it('converts every WebSocket transport after preserving the page prefix', () => {
+    expect(hostWebSocketUrl('/sidebar/ws/terminal', baseUrl).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/terminal')
+    expect(hostWebSocketUrl('/sidebar/ws/agent-terminals', baseUrl).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/agent-terminals')
+    expect(hostWebSocketUrl('/sidebar/ws/agent-opens', baseUrl).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/agent-opens')
+  })
+})

--- a/tests/browser-globals.ts
+++ b/tests/browser-globals.ts
@@ -28,6 +28,7 @@ const elementStub = (): Record<string, unknown> => ({
 
 if (g.document === undefined) {
   g.document = {
+    baseURI: 'http://localhost/',
     createElement: () => elementStub(),
     createDocumentFragment: () => elementStub(),
     addEventListener: () => {},

--- a/tests/chunk-loader.spec.ts
+++ b/tests/chunk-loader.spec.ts
@@ -91,7 +91,7 @@ describe('production path (script injection + global registry + externals requir
       simulateScript('editor', (require) => ({ TextEditor: `view:${String(require('react'))}` }))
     })
     const exports = await loadChunk('editor')
-    expect(loaded).toEqual(['/sidebar/bundle/editor.js'])
+    expect(loaded).toEqual(['http://localhost/sidebar/bundle/editor.js'])
     expect(exports).toEqual({ TextEditor: 'view:[object Object]' })
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
     // The injection also lands on a plugin-owned global so chunk-bundle
@@ -116,7 +116,7 @@ describe('production path (script injection + global registry + externals requir
       simulateScript('editor', (require) => ({ TextEditor: `view:${String(require('react'))}` }))
     })
     const exports = await loadChunk('editor')
-    expect(loaded).toEqual(['/sidebar/bundle/editor.js'])
+    expect(loaded).toEqual(['http://localhost/sidebar/bundle/editor.js'])
     expect(exports).toEqual({ TextEditor: 'view:[object Object]' })
     // Externals resolved through the module system's seed branch, once.
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
@@ -135,7 +135,7 @@ describe('production path (script injection + global registry + externals requir
     })
     await loadChunk('terminal')
     await loadChunk('editor')
-    expect(seen).toEqual(['/sidebar/bundle/terminal.js', '/sidebar/bundle/editor.js'])
+    expect(seen).toEqual(['http://localhost/sidebar/bundle/terminal.js', 'http://localhost/sidebar/bundle/editor.js'])
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
   })
 
@@ -225,8 +225,10 @@ describe('revalidateChunksOnReactivate (HMR re-activation keeps unchanged chunks
     }))
   }
 
-  /** Let the fire-and-forget ETag recorder (recordEtag) settle. */
-  const settleEtag = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 5))
+  /** Wait until the fire-and-forget ETag recorder has issued its HEAD request. */
+  const settleEtag = async (): Promise<void> => {
+    await vi.waitFor(() => { expect(vi.mocked(globalThis.fetch)).toHaveBeenCalled() })
+  }
 
   it('keeps the resolved exports of an unchanged chunk — no re-inject / re-execute', async () => {
     installModuleSystem()

--- a/tests/markdown-html-render.spec.tsx
+++ b/tests/markdown-html-render.spec.tsx
@@ -21,7 +21,7 @@ setupReactAct()
 const media: MarkdownHtmlMedia = {
   scope: { sessionId: 's1', cwd: '/ws' },
   path: '/ws/docs/README.md',
-  origin: 'http://gui.origin',
+  baseUrl: 'http://gui.origin/proxy/3080/',
 }
 const codeLabels = { copyLabel: 'Copy', copiedLabel: 'Copied' }
 
@@ -84,7 +84,7 @@ describe('MarkdownDocument (HTML leaves)', () => {
   it('rewrites local media sources through the /sidebar/file route', async () => {
     const { container, root } = await renderDocument('<picture><img src="./shot.png" alt="shot"/></picture>')
     const img = container.querySelector('img')
-    expect(img?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fshot.png&cwd=%2Fws')
+    expect(img?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fshot.png&cwd=%2Fws')
     await unmount(root)
   })
 })
@@ -189,9 +189,9 @@ describe('MarkdownDocument (local markdown images)', () => {
     ].join('\n'))
     const imgs = [...container.querySelectorAll('img')]
     expect(imgs.length, 'both local images must render as <img>, not alt fallback').toBe(2)
-    expect(imgs[0]?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fassets%2Ficon.svg&cwd=%2Fws')
+    expect(imgs[0]?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fassets%2Ficon.svg&cwd=%2Fws')
     expect(imgs[0]?.getAttribute('alt')).toBe('icon')
-    expect(imgs[1]?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Flogo.png&cwd=%2Fws')
+    expect(imgs[1]?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Flogo.png&cwd=%2Fws')
     expect(imgs[1]?.getAttribute('alt')).toBe('logo')
     await unmount(root)
   })
@@ -204,7 +204,7 @@ describe('MarkdownDocument (local markdown images)', () => {
     ].join('\n'))
     const img = container.querySelector('img')
     expect(img, 'the markdown-syntax image after an HTML run must render').not.toBeNull()
-    expect(img?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws')
+    expect(img?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws')
     await unmount(root)
   })
 
@@ -216,7 +216,7 @@ describe('MarkdownDocument (local markdown images)', () => {
   })
 
   it('is idempotent for already-rewritten media URLs', async () => {
-    const url = 'http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws'
+    const url = 'http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws'
     const { container, root } = await renderDocument(`![a](${url})`)
     const img = container.querySelector('img')
     expect(img?.getAttribute('src')).toBe(url)

--- a/tests/markdown-images.spec.ts
+++ b/tests/markdown-images.spec.ts
@@ -3,6 +3,7 @@ import { rewriteLocalImageUrls } from '../src/client/markdown-images.ts'
 import type { SessionScope } from '../src/client/api.ts'
 
 const ORIGIN = 'http://127.0.0.1:3080'
+const PROXY_BASE = 'https://gui.example.test/user/proxy/3080/'
 const scope: SessionScope = { sessionId: 'abc', cwd: '/repo' }
 
 describe('rewriteLocalImageUrls', () => {
@@ -11,6 +12,11 @@ describe('rewriteLocalImageUrls', () => {
     const out = rewriteLocalImageUrls(md, scope, '/repo/docs/readme.md', ORIGIN)
     expect(out).toContain(`![a](${ORIGIN}/sidebar/file?sessionId=abc&path=%2Frepo%2Fdocs%2Fimg.png&cwd=%2Frepo)`)
     expect(out).toContain(`![b](${ORIGIN}/sidebar/file?sessionId=abc&path=%2Frepo%2Fdocs%2Fimages%2Fb.jpg&cwd=%2Frepo)`)
+  })
+
+  it('retains a reverse-proxy prefix while keeping the destination absolute', () => {
+    const out = rewriteLocalImageUrls('![a](./img.png)', scope, '/repo/readme.md', PROXY_BASE)
+    expect(out).toContain('https://gui.example.test/user/proxy/3080/sidebar/file?')
   })
 
   it('expects the rewritten destination to be an absolute http URL MarkdownText accepts', () => {

--- a/tests/open-external-client.spec.ts
+++ b/tests/open-external-client.spec.ts
@@ -4,6 +4,7 @@
  * editor URLs and reveal actions keep using the DSH host opener.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import './browser-globals.ts'
 import { api } from '../src/client/api.ts'
 
 afterEach(() => {
@@ -64,7 +65,7 @@ describe('api.openExternal', () => {
 
     expect(assign).not.toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledOnce()
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('/sidebar/api/open.external')
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('http://localhost/sidebar/api/open.external')
   })
 
   it('keeps reveal actions and http(s) lookalikes on the host opener', async () => {

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -1,3 +1,4 @@
+import './browser-globals.ts'
 import { describe, expect, it } from 'vitest'
 import { isAbsolutePath, relativeTo } from '../src/client/paths.ts'
 import { resolveSidebarPath } from '../src/client/produced-files.ts'
@@ -60,10 +61,10 @@ describe('path helpers', () => {
     // The marker is platform-neutral now: the host resolves the decoded
     // '//server/share/...' form per-platform, so no cwd/OS signal is needed.
     expect(htmlUrl({ sessionId: 's' }, '\\\\server\\share\\proj\\a.html'))
-      .toBe('/sidebar/html/s//server/share/proj/a.html')
+      .toBe('http://localhost/sidebar/html/s//server/share/proj/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '//server/share/a.html'))
-      .toBe('/sidebar/html/s//server/share/a.html')
+      .toBe('http://localhost/sidebar/html/s//server/share/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '/home/me/index.html'))
-      .toBe('/sidebar/html/s/home/me/index.html')
+      .toBe('http://localhost/sidebar/html/s/home/me/index.html')
   })
 })

--- a/tests/sandbox-views.spec.tsx
+++ b/tests/sandbox-views.spec.tsx
@@ -51,8 +51,9 @@ describe('HTML preview iframe sandbox', () => {
     // ...which must never contain the dangerous tokens.
     expect(HTML_IFRAME_SANDBOX).not.toContain('allow-same-origin')
     expect(HTML_IFRAME_SANDBOX).not.toContain('allow-top-navigation')
-    // Cross-origin framing by construction: route-src (never srcdoc).
-    expect(iframe).toContain('src="/sidebar/html/s1/p/a/index.html"')
+    // Cross-origin framing by construction: route-src (never srcdoc). The
+    // default test document base remains part of the client-generated route.
+    expect(iframe).toContain('src="http://localhost/sidebar/html/s1/p/a/index.html"')
     expect(iframe).not.toContain('srcdoc=')
     // Referrer + permissions policy stay locked even when sandboxed.
     // (React SSR renders the referrerPolicy prop camelCase as written.)


### PR DESCRIPTION
## Summary

Revives and rebases the unmerged intent of #422 to resolve #573 and every other Better Sidebar client transport when DSH is served beneath a reverse-proxy base path (for example `dsh-mobile` remote access or code-server `/proxy/<port>/`).

The root cause was client code resolving `/sidebar/*` against `location.origin` or using root-relative URLs. Both discard the path part of `document.baseURI`, so browser requests escaped the proxy prefix. Terminal upgrades therefore reached a non-existent origin-root route and failed with WebSocket close code `1006`.

### Implementation

- Added `src/client/host-route-url.ts`, which removes leading slashes and resolves host-owned routes against `document.baseURI`; its WebSocket companion preserves the base path before converting `http(s)` to `ws(s)`.
- Updated all Better Sidebar browser-to-host URL call sites:
  - `src/client/api.ts`: JSON API, raw upload, file/media/download, and HTML preview URLs.
  - `src/client/TerminalView.tsx`: interactive terminal WebSocket.
  - `src/client/sidebar/use-host-feeds.ts`: agent-terminal and agent-open WebSockets.
  - `src/client/chunk-loader.ts`: lazy chunk script loads and ETag HEAD revalidation.
  - `src/client/markdown-images.ts`, `src/client/MarkdownHtml.tsx`, `src/client/TextEditor.tsx`, and `src/client/changes/DiffPane.tsx`: markdown/HTML local-media URLs now retain the page base path while remaining absolute `http(s)` URLs accepted by `MarkdownText`.
- Kept server route registrations and `html-route.ts` route vocabulary unchanged: the server still owns `/sidebar/*`; only browser URL resolution changes.

### Tests

- Added `tests/base-path.spec.ts` for a nested reverse-proxy base, covering API, upload, file/media, HTML, lazy bundle, terminal WS, agent-terminal WS, and agent-open WS URLs.
- Updated URL-oriented coverage in `tests/browser-globals.ts`, `tests/chunk-loader.spec.ts`, `tests/markdown-html-render.spec.tsx`, `tests/markdown-images.spec.ts`, `tests/open-external-client.spec.ts`, `tests/paths.spec.ts`, and `tests/sandbox-views.spec.tsx`. The chunk ETag test now waits for its observable HEAD request instead of a timing delay.

### Verification

- `pnpm exec vitest run tests/base-path.spec.ts tests/upload.spec.ts tests/markdown-images.spec.ts tests/markdown-html-render.spec.tsx tests/chunk-loader.spec.ts tests/html-route.spec.ts tests/paths.spec.ts tests/sandbox-views.spec.tsx tests/open-external-client.spec.ts` — **115 passed, 1 skipped**.
- `pnpm run typecheck` — passed.
- `pnpm run build` — passed.
- Targeted ESLint across all modified source and test files — passed.
- Full `pnpm test` was also attempted. Non-base-path failures are limited to the existing native PTY integration tests (`tests/agent-pty.spec.ts` and PTY cases in `tests/smoke.spec.ts`) because this sandbox cannot spawn a pseudo-terminal (`node-pty`: `posix_spawnp failed`); the URL/base-path regression suite passed independently.