### PR TITLE
fix: preserve reverse-proxy base paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test": "vitest run",
     "test:mount": "bash scripts/e2e-mount.sh",
     "test:mount:aggregate": "bash scripts/e2e-aggregate-mount.sh",
+    "test:mount:base-path": "bash scripts/e2e-base-path.sh",
     "clean": "node -e \"require('node:fs').rmSync('lib',{recursive:true,force:true})\"",
     "check:consumer-types": "bash scripts/check-consumer-types.sh",
     "lint": "eslint ."

--- a/scripts/e2e-base-path.sh
+++ b/scripts/e2e-base-path.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Boot the official mount lane, then put `dsh web` behind a path-prefix
+# reverse proxy and run the base-path Playwright spec against that URL.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+E2E_TAG=e2e-base-path
+source "$SCRIPT_DIR/e2e-common.sh"
+
+DSH_CMD="${DSH_CMD:-dsh}"
+PORT="${PORT:-0}"
+TARBALL="${TARBALL:-}"
+PROXY_PREFIX="${PROXY_PREFIX:-/dataops/proxy/3080}"
+
+e2e_require_cmd node "DSH 运行需要 Node.js >= 20"
+e2e_require_cmd pnpm "dsh plugin 转发给 pnpm"
+e2e_resolve_dsh_cmd
+e2e_resolve_tarball || die "找不到 tarball（TARBALL 或 \$ROOT/dsh-better-sidebar-*.tgz）——先运行 pnpm build && pnpm pack"
+TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+say "tarball: $TARBALL"
+
+e2e_make_scratch dsh-e2e-base-path
+export DSH_HOME="$SCRATCH/home"
+WORKSPACE_DIR="$SCRATCH/workspace"
+LOG_DIR="$SCRATCH"
+WEB_LOG="$LOG_DIR/web.log"
+PROXY_LOG="$LOG_DIR/proxy.log"
+mkdir -p "$DSH_HOME/profiles/web" "$WORKSPACE_DIR"
+say "scratch home: ${DSH_HOME}"
+
+SERVER_PID=""
+PROXY_PID=""
+e2e_cleanup_with_proxy() {
+  if [ -n "${PROXY_PID:-}" ] && kill -0 "$PROXY_PID" 2>/dev/null; then
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+  fi
+  e2e_cleanup
+}
+trap e2e_cleanup_with_proxy EXIT
+
+PROFILE_DIR="$DSH_HOME/profiles/web"
+e2e_write_profile "$PROFILE_DIR"
+say "执行 dsh plugin --profile web add file:$TARBALL ..."
+$DSH_CMD plugin --profile web add "file:$TARBALL"
+
+say "启动 dsh web（port=${PORT}）..."
+e2e_start_dsh_web "$WEB_LOG"
+E2E_READY_RE='dsh web: http://127\.0\.0\.1:[0-9]+[^ ]*'
+E2E_READY_PICK=head
+WAIT_RC=0
+e2e_wait_dsh_web_ready "$WEB_LOG" || WAIT_RC=$?
+if [ "$WAIT_RC" -ne 0 ]; then
+  echo "=== dsh web 未就绪，日志尾部 ===" >&2
+  tail -40 "$WEB_LOG" >&2 || true
+  exit 1
+fi
+say "dsh web 就绪：${URL}（pid ${SERVER_PID}）"
+
+UPSTREAM="$(printf '%s' "$URL" | awk -F'[?]' '{print $1}' | sed 's#/$##')"
+TOKEN="$(printf '%s' "$URL" | sed -n 's/.*[?&]token=\([^& ]*\).*/\1/p')"
+[ -n "$TOKEN" ] || die "launch URL 没有 token：$URL"
+
+say "启动 prefix proxy ${PROXY_PREFIX} → ${UPSTREAM} ..."
+UPSTREAM="$UPSTREAM" PROXY_PREFIX="$PROXY_PREFIX" PROXY_PORT=0 \
+  node "$SCRIPT_DIR/prefix-proxy.mjs" >"$PROXY_LOG" 2>&1 &
+PROXY_PID=$!
+PROXY_URL=""
+for _ in $(seq 1 30); do
+  if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+    tail -20 "$PROXY_LOG" >&2 || true
+    die "prefix proxy 提前退出"
+  fi
+  PROXY_URL="$(grep -oE 'http://127\.0\.0\.1:[0-9]+/[^ ]+' "$PROXY_LOG" | head -1 || true)"
+  [ -n "$PROXY_URL" ] && break
+  sleep 0.2
+done
+[ -n "$PROXY_URL" ] || die "未读到 prefix-proxy 监听地址"
+say "prefix proxy 就绪：${PROXY_URL}"
+
+PROXIED_LAUNCH="${PROXY_URL}?token=${TOKEN}"
+say "运行 Playwright base-path lane against ${PROXIED_LAUNCH}"
+DSH_E2E_URL="$PROXIED_LAUNCH" DSH_E2E_WORKSPACE="$WORKSPACE_DIR" \
+  pnpm exec playwright test tests/e2e/base-path.e2e.ts
+
+say "通过：子路径反向代理下的 sidebar 传输保留了前缀"

--- a/scripts/prefix-proxy.mjs
+++ b/scripts/prefix-proxy.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * HTTP + WebSocket reverse proxy that mounts an upstream origin under a
+ * path prefix (code-server /proxy/<port>/ style). Rewrites Location so the
+ * browser stays under the prefix after DSH's token→cookie 303. Auth cookies
+ * keep Path=/ so origin-root `/api` calls on the same proxy origin still
+ * authenticate.
+ *
+ * Env:
+ *   UPSTREAM       e.g. http://127.0.0.1:4199
+ *   PROXY_PREFIX   e.g. /dataops/proxy/3080
+ *   PROXY_PORT     listen port (default 0 = OS assigned; print listen URL)
+ */
+import http from 'node:http'
+import { request as httpRequest } from 'node:http'
+
+const UPSTREAM = process.env.UPSTREAM
+const PREFIX = (process.env.PROXY_PREFIX ?? '/dataops/proxy/3080').replace(/\/$/, '')
+const LISTEN = Number(process.env.PROXY_PORT ?? 0)
+if (!UPSTREAM) {
+  console.error('prefix-proxy: UPSTREAM is required')
+  process.exit(1)
+}
+const upstream = new URL(UPSTREAM)
+
+function defaultPort(protocol) {
+  return protocol === 'https:' ? '443' : '80'
+}
+
+function isUpstreamHost(url) {
+  const port = url.port || defaultPort(url.protocol)
+  const expected = upstream.port || defaultPort(upstream.protocol)
+  return url.hostname === upstream.hostname && port === expected
+}
+
+function stripPrefix(rawUrl) {
+  const url = new URL(rawUrl ?? '/', 'http://proxy.internal')
+  if (url.pathname === PREFIX || url.pathname === `${PREFIX}/`) {
+    url.pathname = '/'
+  } else if (url.pathname.startsWith(`${PREFIX}/`)) {
+    url.pathname = url.pathname.slice(PREFIX.length)
+  }
+  return `${url.pathname}${url.search}`
+}
+
+function prefixPath(pathname) {
+  if (pathname === PREFIX || pathname.startsWith(`${PREFIX}/`)) return pathname
+  return `${PREFIX}${pathname.startsWith('/') ? pathname : `/${pathname}`}`
+}
+
+function rewriteLocation(value) {
+  if (value === undefined || value === '') return value
+  try {
+    const absolute = /^[a-z][a-z0-9+.-]*:/i.test(value)
+    const url = new URL(value, upstream.origin)
+    if (absolute && !isUpstreamHost(url)) return value
+    return `${prefixPath(url.pathname)}${url.search}${url.hash}`
+  } catch {
+    return value
+  }
+}
+
+function copyHeaders(headers) {
+  const out = { ...headers }
+  out.host = upstream.host
+  return out
+}
+
+const server = http.createServer((req, res) => {
+  const path = stripPrefix(req.url)
+  const proxyReq = httpRequest({
+    hostname: upstream.hostname,
+    port: upstream.port,
+    path,
+    method: req.method,
+    headers: copyHeaders(req.headers),
+  }, (proxyRes) => {
+    const headers = { ...proxyRes.headers }
+    if (typeof headers.location === 'string') headers.location = rewriteLocation(headers.location)
+    res.writeHead(proxyRes.statusCode ?? 502, headers)
+    proxyRes.pipe(res)
+  })
+  proxyReq.on('error', () => {
+    if (!res.headersSent) res.writeHead(502)
+    res.end('upstream error')
+  })
+  req.pipe(proxyReq)
+})
+
+server.on('upgrade', (req, socket, head) => {
+  const path = stripPrefix(req.url)
+  const proxyReq = httpRequest({
+    hostname: upstream.hostname,
+    port: upstream.port,
+    path,
+    method: 'GET',
+    headers: copyHeaders(req.headers),
+  })
+  proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => {
+    const lines = [`HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}`]
+    for (const [name, value] of Object.entries(proxyRes.headers)) {
+      if (Array.isArray(value)) {
+        for (const item of value) lines.push(`${name}: ${item}`)
+      } else if (value !== undefined) {
+        lines.push(`${name}: ${value}`)
+      }
+    }
+    socket.write(`${lines.join('\r\n')}\r\n\r\n`)
+    if (proxyHead.length > 0) socket.write(proxyHead)
+    proxySocket.pipe(socket)
+    socket.pipe(proxySocket)
+  })
+  proxyReq.on('response', (proxyRes) => {
+    socket.write(`HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}\r\n`)
+    for (const [name, value] of Object.entries(proxyRes.headers)) {
+      if (Array.isArray(value)) {
+        for (const item of value) socket.write(`${name}: ${item}\r\n`)
+      } else if (value !== undefined) {
+        socket.write(`${name}: ${value}\r\n`)
+      }
+    }
+    socket.write('\r\n')
+    proxyRes.pipe(socket)
+  })
+  proxyReq.on('error', () => socket.destroy())
+  socket.on('error', () => proxyReq.destroy())
+  proxyReq.end(head)
+})
+
+server.listen(LISTEN, '127.0.0.1', () => {
+  const addr = server.address()
+  const port = typeof addr === 'object' && addr !== null ? addr.port : LISTEN
+  console.log(`prefix-proxy: http://127.0.0.1:${port}${PREFIX}/`)
+})

--- a/src/client/MarkdownHtml.tsx
+++ b/src/client/MarkdownHtml.tsx
@@ -40,7 +40,8 @@ import { LazyMermaidMarkdown } from './mermaid-lazy.tsx'
 export interface MarkdownHtmlMedia {
   scope: SessionScope
   path: string
-  origin: string
+  /** The injected document base, including any reverse-proxy prefix. */
+  baseUrl: string
 }
 
 /** Tag-like text in a rendered text node — the inline pass gate. */
@@ -67,7 +68,7 @@ function postProcessSanitized(root: Element, media: MarkdownHtmlMedia): void {
   for (const element of root.querySelectorAll('img, video, audio, source')) {
     const src = element.getAttribute('src')
     if (src === null) continue
-    element.setAttribute('src', resolveLocalMediaDest(src, media.scope, media.path, media.origin))
+    element.setAttribute('src', resolveLocalMediaDest(src, media.scope, media.path, media.baseUrl))
   }
 }
 
@@ -239,7 +240,7 @@ export function MarkdownDocument({ info, media, codeLabels }: MarkdownDocumentPr
       // stance), so rewrite local ones into /sidebar/file media URLs first —
       // the same trust fence the sanitized HTML leaves below go through.
       // Idempotent: already-absolute media URLs pass through untouched.
-      const text = rewriteLocalImageUrls(raw, media.scope, media.path, media.origin)
+      const text = rewriteLocalImageUrls(raw, media.scope, media.path, media.baseUrl)
       return {
         kind: 'markdown',
         text,
@@ -255,7 +256,7 @@ export function MarkdownDocument({ info, media, codeLabels }: MarkdownDocumentPr
       }),
     }
   // `media` is a memoized object in the host (TextEditor); identity tracks
-  // scope/path/origin changes so sanitization re-runs exactly when needed.
+  // scope/path/baseUrl changes so sanitization re-runs exactly when needed.
   }), [info, media])
 
   const nodes: ReactNode[] = []

--- a/src/client/TerminalView.tsx
+++ b/src/client/TerminalView.tsx
@@ -41,6 +41,7 @@ import { ONE_DARK, ONE_LIGHT } from './one-dark-palette.ts'
 import { openWhenSized } from './open-when-sized.ts'
 import { api, type SessionScope, type TerminalDepsStatus } from './api.ts'
 import { agentUuidOf, isAgentTabId, type SidebarStore } from './state.ts'
+import { hostWebSocketUrl } from './host-route-url.ts'
 import { isDarkScheme, subscribeColorScheme, effectiveTokenValue, tokenValue } from './theme.ts'
 import { resolveTerminalFont } from './terminal-font.ts'
 import {
@@ -183,8 +184,7 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
     let failures = 0
 
     const wsUrl = (): string => {
-      const url = new URL('/sidebar/ws/terminal', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/terminal')
       // Agent terminals attach by uuid (the host looks them up in the agent
       // pty registry); UI-tab terminals attach by sessionId+tab (the host
       // uses the UI-tab pty manager). Same upgrade endpoint, different query.
@@ -195,9 +195,8 @@ export function TerminalView(props: { scope: SessionScope; tabId: string; store:
         if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
         url.search = params.toString()
       }
-      // Same construction the app's own downlink WebSockets use (new URL
-      // over location.origin + protocol swap): whatever the environment
-      // does to the app's websockets applies identically here.
+      // Resolve through the injected document base so reverse-proxy prefixes
+      // survive the http→websocket protocol swap.
       return url.toString()
     }
 

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -22,6 +22,7 @@ import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
 import { IconCheckOutline16, MarkdownText } from '@deepseek-ai/dsh-client-ui-primitives'
 import { markdownTextProps } from './markdown-labels.tsx'
 import { api, htmlUrl } from './api.ts'
+import { hostDocumentBase } from './host-route-url.ts'
 import { markdownPreviewSource } from './markdown-frontmatter.ts'
 import { rewriteLocalImageUrls } from './markdown-images.ts'
 import { languageForPath } from './lang.ts'
@@ -330,7 +331,7 @@ export function TextEditor(props: FileViewerProps) {
   /** The preview source with local image destinations rewritten to absolute
    *  media URLs (see {@link rewriteLocalImageUrls}). */
   const previewText = markdown
-    ? rewriteLocalImageUrls(previewMdText, scope, path, document.baseURI)
+    ? rewriteLocalImageUrls(previewMdText, scope, path, hostDocumentBase())
     : previewMdText
   /** md/mermaid block split for the preview (mermaid fences lift out). Split
    *  only in preview mode: edit-mode keystrokes must not re-scan the source. */
@@ -359,7 +360,7 @@ export function TextEditor(props: FileViewerProps) {
    *  `media` identity, so a fresh object per render would re-sanitize every
    *  keystroke. */
   const htmlMedia = useMemo<MarkdownHtmlMedia>(
-    () => ({ scope, path, baseUrl: document.baseURI }),
+    () => ({ scope, path, baseUrl: hostDocumentBase() }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [scope.sessionId, scope.cwd, path],
   )

--- a/src/client/TextEditor.tsx
+++ b/src/client/TextEditor.tsx
@@ -330,7 +330,7 @@ export function TextEditor(props: FileViewerProps) {
   /** The preview source with local image destinations rewritten to absolute
    *  media URLs (see {@link rewriteLocalImageUrls}). */
   const previewText = markdown
-    ? rewriteLocalImageUrls(previewMdText, scope, path, window.location.origin)
+    ? rewriteLocalImageUrls(previewMdText, scope, path, document.baseURI)
     : previewMdText
   /** md/mermaid block split for the preview (mermaid fences lift out). Split
    *  only in preview mode: edit-mode keystrokes must not re-scan the source. */
@@ -359,7 +359,7 @@ export function TextEditor(props: FileViewerProps) {
    *  `media` identity, so a fresh object per render would re-sanitize every
    *  keystroke. */
   const htmlMedia = useMemo<MarkdownHtmlMedia>(
-    () => ({ scope, path, origin: window.location.origin }),
+    () => ({ scope, path, baseUrl: document.baseURI }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [scope.sessionId, scope.cwd, path],
   )

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,12 +1,13 @@
 /**
- * Typed fetch wrapper over the /sidebar JSON API. Every call posts to
- * `/sidebar/api/<method>` with the sessionId and — when known — the session's
+ * Typed fetch wrapper over the /sidebar JSON API. Every call posts through
+ * the injected document base to `/sidebar/api/<method>` with the sessionId and — when known — the session's
  * cwd from the client's own list summary. The host prefers its attached
  * session header and uses the summary cwd only while the session is still
  * hydrating at page load (a detached session would otherwise fail the
  * request). Failures surface as {@link SidebarApiError} with the wire code.
  */
 import { encodeHtmlUrl } from '../html-route.ts'
+import { hostRouteUrl } from './host-route-url.ts'
 import type { LastActivity } from '../subagent-activity.ts'
 import type { SidechatLogEvent, SidechatThreadInfo } from '../sidechat-core.ts'
 import type { SidebarSessionEvent } from '../context-types.ts'
@@ -151,7 +152,7 @@ async function readEnvelope<T>(response: Response): Promise<T> {
 async function call<T>(method: string, payload: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
   let response: Response
   try {
-    response = await fetch(`/sidebar/api/${method}`, {
+    response = await fetch(hostRouteUrl(`sidebar/api/${method}`), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),
@@ -181,7 +182,7 @@ async function fetchUpload<T>(
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
   let response: Response
   try {
-    response = await fetch(`/sidebar/upload?${params.toString()}`, {
+    response = await fetch(hostRouteUrl(`sidebar/upload?${params.toString()}`), {
       method: 'POST',
       headers: { 'content-type': 'application/octet-stream' },
       body,
@@ -413,12 +414,12 @@ export const api = {
   openExternal,
 }
 
-/** Absolute URL of the media route for one path (images only). */
+/** Absolute media-route URL for one path (images only), resolved through the document base. */
 export function mediaUrl(scope: SessionScope, path: string): string {
   return fileUrl(scope, path, false)
 }
 
-/** Absolute URL of the download route: serves raw bytes (binary-safe) with
+/** Absolute download-route URL: serves raw bytes (binary-safe) with
  *  `Content-Disposition: attachment`, so the browser saves the file. */
 export function downloadUrl(scope: SessionScope, path: string): string {
   return fileUrl(scope, path, true)
@@ -429,11 +430,11 @@ function fileUrl(scope: SessionScope, path: string, download: boolean): string {
   const params = new URLSearchParams({ sessionId: scope.sessionId, path })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
   if (download) params.set('download', '1')
-  return `/sidebar/file?${params.toString()}`
+  return hostRouteUrl(`sidebar/file?${params.toString()}`).href
 }
 
 /**
- * Absolute URL of the HTML preview route (see html-route.ts): the path is
+ * Absolute HTML-preview URL (see html-route.ts): the path is
  * fully encoded so the previewed page's relative assets resolve back into
  * the same route with the session scope intact. The UNC marker is
  * platform-neutral — the host's requireAbsolute resolves the decoded
@@ -441,5 +442,5 @@ function fileUrl(scope: SessionScope, path: string, download: boolean): string {
  * client-side platform signal is needed.
  */
 export function htmlUrl(scope: SessionScope, path: string): string {
-  return encodeHtmlUrl(scope.sessionId, path)
+  return hostRouteUrl(encodeHtmlUrl(scope.sessionId, path)).href
 }

--- a/src/client/changes/DiffPane.tsx
+++ b/src/client/changes/DiffPane.tsx
@@ -288,7 +288,7 @@ export function DiffPane({ target, scope, height, onHeightCommit, onClose, onExp
   }, [mdOp, op, prior])
   const readingText = useMemo(
     () => (mdOp && reading && readingSrc !== '' && target.kind === 'op'
-      ? rewriteLocalImageUrls(readingSrc, scope, target.path, window.location.origin)
+      ? rewriteLocalImageUrls(readingSrc, scope, target.path, document.baseURI)
       : ''),
     [mdOp, reading, readingSrc, scope, target],
   )

--- a/src/client/changes/DiffPane.tsx
+++ b/src/client/changes/DiffPane.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointer
 import { IconCloseOutline16, IconRefreshOutline16, IconRightUpOutline16, MarkdownText } from '@deepseek-ai/dsh-client-ui-primitives'
 import type { SessionScope } from '../api.ts'
 import { api, htmlUrl } from '../api.ts'
+import { hostDocumentBase } from '../host-route-url.ts'
 import { t } from '../locales.ts'
 import { baseName } from '../paths.ts'
 import { resolveSidebarPath } from '../produced-files.ts'
@@ -288,7 +289,7 @@ export function DiffPane({ target, scope, height, onHeightCommit, onClose, onExp
   }, [mdOp, op, prior])
   const readingText = useMemo(
     () => (mdOp && reading && readingSrc !== '' && target.kind === 'op'
-      ? rewriteLocalImageUrls(readingSrc, scope, target.path, document.baseURI)
+      ? rewriteLocalImageUrls(readingSrc, scope, target.path, hostDocumentBase())
       : ''),
     [mdOp, reading, readingSrc, scope, target],
   )

--- a/src/client/chunk-loader.ts
+++ b/src/client/chunk-loader.ts
@@ -18,9 +18,10 @@
  * graph rows; a chunk id is none of those, so resolution would be version-
  * dependent). Materialization is plugin-owned:
  *
- * 1. inject <script src="/sidebar/bundle/<name>.js"> (classic same-origin
- *    script; the official /plugins/<id>/client.js route cannot serve
- *    arbitrary file names, so the plugin's own host route serves the chunks),
+ * 1. inject a classic same-origin `/sidebar/bundle/<name>.js` script, resolved
+ *    through the injected document base so proxy prefixes survive; the official
+ *    /plugins/<id>/client.js route cannot serve arbitrary file names, so the
+ *    plugin's own host route serves the chunks,
  * 2. read the factory from the global registry,
  * 3. call it with a require that resolves the platform externals through
  *    the injected module system's `import(spec)` (the `ctx.modules` service)
@@ -50,6 +51,8 @@
  * client.js); an edit that does land while a core HMR happens is caught by
  * the ETag comparison on the next activation.
  */
+import { hostRouteUrl } from './host-route-url.ts'
+
 export type ChunkName = 'terminal' | 'editor' | 'mermaid' | 'locale'
 
 /** The module exports a chunk factory provides (namespace-ish record). */
@@ -80,7 +83,7 @@ export const CHUNK_EXTERNALS: readonly string[] = [
 ]
 
 /** Chunk script endpoint served by the plugin host half (src/bundle-route.ts). */
-const CHUNK_URL = (name: ChunkName): string => `/sidebar/bundle/${name}.js`
+const CHUNK_URL = (name: ChunkName): string => hostRouteUrl(`sidebar/bundle/${name}.js`).href
 
 /** Bound on the revalidation HEAD round-trip. A timeout fails open (drop +
  *  re-fetch on the next open) so a stuck bundle route can never wedge lazy

--- a/src/client/host-route-url.ts
+++ b/src/client/host-route-url.ts
@@ -2,14 +2,49 @@
  * Resolve one host-owned route through the GUI document base. This preserves
  * reverse-proxy prefixes (for example code-server's `/proxy/<port>/`) that
  * are intentionally absent from `location.origin`.
+ *
+ * `document.baseURI` may include a query (the one-time launch token), omit a
+ * trailing slash, or be reset to `/` by an HTML `<base href="/">`. Treat the
+ * longer of the document base and the current location directory as the
+ * prefix so `new URL('sidebar/…', base)` cannot replace the last segment.
  */
-export function hostRouteUrl(path: string, baseUrl: string = document.baseURI): URL {
-  return new URL(path.replace(/^\/+/, ''), baseUrl)
+export function hostRouteUrl(path: string, baseUrl: string = hostDocumentBase()): URL {
+  return new URL(path.replace(/^\/+/, ''), directoryBase(baseUrl))
 }
 
 /** Resolve one host-owned WebSocket route through the GUI document base. */
-export function hostWebSocketUrl(path: string, baseUrl: string = document.baseURI): URL {
+export function hostWebSocketUrl(path: string, baseUrl: string = hostDocumentBase()): URL {
   const url = hostRouteUrl(path, baseUrl)
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
   return url
+}
+
+/**
+ * The prefix that relative `/sidebar/*` routes should resolve against.
+ * Prefer the current location directory when it is longer than
+ * `document.baseURI` (DSH's own `<base href="/">` would otherwise drop a
+ * reverse-proxy prefix that is still present in the address bar).
+ */
+export function hostDocumentBase(): string {
+  const doc = typeof document !== 'undefined' ? document.baseURI : ''
+  const loc = typeof location !== 'undefined' && typeof location.href === 'string' ? location.href : ''
+  if (doc !== '' && loc !== '') {
+    try {
+      const docPath = new URL(doc).pathname
+      const locPath = new URL(loc).pathname
+      return locPath.length > docPath.length ? loc : doc
+    } catch {
+      return loc
+    }
+  }
+  return loc !== '' ? loc : doc !== '' ? doc : 'http://dsh.internal/'
+}
+
+/** Strip search/hash and force a trailing slash so relative resolution stays under the prefix. */
+function directoryBase(baseUrl: string): string {
+  const url = new URL(baseUrl, 'http://dsh.internal')
+  url.search = ''
+  url.hash = ''
+  if (!url.pathname.endsWith('/')) url.pathname += '/'
+  return url.href
 }

--- a/src/client/host-route-url.ts
+++ b/src/client/host-route-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve one host-owned route through the GUI document base. This preserves
+ * reverse-proxy prefixes (for example code-server's `/proxy/<port>/`) that
+ * are intentionally absent from `location.origin`.
+ */
+export function hostRouteUrl(path: string, baseUrl: string = document.baseURI): URL {
+  return new URL(path.replace(/^\/+/, ''), baseUrl)
+}
+
+/** Resolve one host-owned WebSocket route through the GUI document base. */
+export function hostWebSocketUrl(path: string, baseUrl: string = document.baseURI): URL {
+  const url = hostRouteUrl(path, baseUrl)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url
+}

--- a/src/client/markdown-images.ts
+++ b/src/client/markdown-images.ts
@@ -5,12 +5,13 @@
  * a previewed `.md` (`![alt](./img.png)`, an absolute `/cwd/img.png`, or a
  * reference definition) would otherwise fall back to its alt text. This
  * dependency-free helper rewrites those destinations into absolute
- * `/sidebar/file` media URLs (prefixed with the GUI's own origin) so
+ * `/sidebar/file` media URLs resolved against the injected document base so
  * `MarkdownText` accepts them; the host media route then serves the bytes,
  * still restricted to files under the session cwd.
  */
 
 import type { SessionScope } from './api.ts'
+import { hostRouteUrl } from './host-route-url.ts'
 import { isAbsolutePath } from './paths.ts'
 
 /**
@@ -61,15 +62,15 @@ function normalizeLocalPath(path: string): string {
  * @param text - The raw markdown source (inline + reference images).
  * @param scope - The session scope (sessionId + cwd) for the media route.
  * @param filePath - The absolute path of the opened `.md` file.
- * @param origin - The GUI's own origin (`window.location.origin`); injected
- * so the core rewrite stays pure and unit-testable.
+ * @param baseUrl - The injected document base; supplied explicitly so this
+ * helper remains pure and retains any reverse-proxy prefix.
  * @returns The markdown with local image destinations rewritten in place.
  */
 /**
  * Resolve one media destination against the session's media route: local
- * (relative or absolute) paths become absolute `/sidebar/file` URLs (prefixed
- * with the GUI's own origin so the shared MarkdownText http(s) allowlist
- * accepts them), while remote URLs, `#`-anchors and empty destinations are
+ * (relative or absolute) paths become absolute `/sidebar/file` URLs resolved
+ * through the injected document base so the shared MarkdownText http(s)
+ * allowlist accepts them), while remote URLs, `#`-anchors and empty destinations are
  * returned untouched. Shared by the markdown image rewriter below and by the
  * preview's raw-HTML sanitizer (`markdown-html.tsx`, which meets the same
  * allowlist when rendering `<img src="./x.png">` inside HTML blocks).
@@ -78,7 +79,7 @@ export function resolveLocalMediaDest(
   dest: string,
   scope: SessionScope,
   filePath: string,
-  origin: string,
+  baseUrl: string,
 ): string {
   const trimmed = dest.trim()
   if (trimmed === '' || trimmed.startsWith('#')) return dest
@@ -90,16 +91,16 @@ export function resolveLocalMediaDest(
   // absolute so the shared MarkdownText http(s) allowlist accepts it.
   const params = new URLSearchParams({ sessionId: scope.sessionId, path: normalizeLocalPath(candidate) })
   if (scope.cwd !== undefined && scope.cwd !== '') params.set('cwd', scope.cwd)
-  return `${origin}/sidebar/file?${params.toString()}`
+  return hostRouteUrl(`sidebar/file?${params.toString()}`, baseUrl).href
 }
 
 export function rewriteLocalImageUrls(
   text: string,
   scope: SessionScope,
   filePath: string,
-  origin: string,
+  baseUrl: string,
 ): string {
-  const resolve = (dest: string): string => resolveLocalMediaDest(dest, scope, filePath, origin)
+  const resolve = (dest: string): string => resolveLocalMediaDest(dest, scope, filePath, baseUrl)
 
   // Mask fenced code blocks and inline code spans so image-looking text
   // inside documentation examples is never rewritten. The sentinel uses a

--- a/src/client/sidebar/use-host-feeds.ts
+++ b/src/client/sidebar/use-host-feeds.ts
@@ -12,6 +12,7 @@ import { isNarrowWidth } from '../breakpoints.ts'
 import { detectNewDirectSubagent } from '../subagent-detect.ts'
 import { detectNewJob } from '../subagent-jobs.ts'
 import { t } from '../locales.ts'
+import { hostWebSocketUrl } from '../host-route-url.ts'
 
 /** How many consecutive reconnect failures stop the agent-terminals push loop
  * (mirror of the terminal view's own cap; the loop restarts on session switch). */
@@ -56,8 +57,7 @@ export function useHostFeeds(feeds: {
     let failures = 0
     const connect = (): void => {
       if (closed) return
-      const url = new URL('/sidebar/ws/agent-terminals', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/agent-terminals')
       url.search = new URLSearchParams({ sessionId }).toString()
       socket = new WebSocket(url.toString())
       socket.onmessage = (event) => {
@@ -113,8 +113,7 @@ export function useHostFeeds(feeds: {
     let failures = 0
     const connect = (): void => {
       if (closed) return
-      const url = new URL('/sidebar/ws/agent-opens', location.origin)
-      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      const url = hostWebSocketUrl('sidebar/ws/agent-opens')
       url.search = new URLSearchParams({ sessionId }).toString()
       socket = new WebSocket(url.toString())
       socket.onmessage = (event) => {

--- a/tests/base-path.spec.ts
+++ b/tests/base-path.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { hostRouteUrl, hostWebSocketUrl } from '../src/client/host-route-url.ts'
 
 /**
@@ -29,5 +29,34 @@ describe('host route URLs behind a reverse-proxy base path', () => {
       .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/agent-terminals')
     expect(hostWebSocketUrl('/sidebar/ws/agent-opens', baseUrl).href)
       .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/agent-opens')
+  })
+
+  it('treats a missing trailing slash and a launch-token query as a directory prefix', () => {
+    const withoutSlash = 'https://example.test/dataops/proxy/3080'
+    const withToken = 'https://example.test/dataops/proxy/3080/?token=abc'
+    expect(hostRouteUrl('/sidebar/api/fs.tree', withoutSlash).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/api/fs.tree')
+    expect(hostRouteUrl('/sidebar/bundle/editor.js', withToken).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/bundle/editor.js')
+    expect(hostWebSocketUrl('/sidebar/ws/terminal', withToken).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/terminal')
+  })
+})
+
+describe('hostDocumentBase prefers the longer live location over a root <base>', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses location.href when document.baseURI is the origin root', async () => {
+    vi.resetModules()
+    vi.stubGlobal('document', { baseURI: 'http://127.0.0.1:4199/' })
+    vi.stubGlobal('location', { href: 'http://127.0.0.1:4199/dataops/proxy/3080/' })
+    const { hostDocumentBase, hostRouteUrl: resolveRoute, hostWebSocketUrl: resolveWs } = await import('../src/client/host-route-url.ts')
+    expect(hostDocumentBase()).toBe('http://127.0.0.1:4199/dataops/proxy/3080/')
+    expect(resolveRoute('/sidebar/api/fs.tree').href)
+      .toBe('http://127.0.0.1:4199/dataops/proxy/3080/sidebar/api/fs.tree')
+    expect(resolveWs('/sidebar/ws/terminal').href)
+      .toBe('ws://127.0.0.1:4199/dataops/proxy/3080/sidebar/ws/terminal')
   })
 })

--- a/tests/base-path.spec.ts
+++ b/tests/base-path.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { hostRouteUrl, hostWebSocketUrl } from '../src/client/host-route-url.ts'
+
+/**
+ * Every browser-to-host transport must resolve relative to the injected page
+ * base. A leading slash would discard this prefix and make a reverse proxy
+ * route `/sidebar/*` at the origin root instead.
+ */
+describe('host route URLs behind a reverse-proxy base path', () => {
+  const baseUrl = 'https://example.test/dataops/proxy/3080/'
+
+  it('keeps the page prefix for API, uploads, media, HTML, and lazy bundles', () => {
+    expect(hostRouteUrl('/sidebar/api/fs.tree', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/api/fs.tree')
+    expect(hostRouteUrl('/sidebar/upload?sessionId=s', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/upload?sessionId=s')
+    expect(hostRouteUrl('/sidebar/file?sessionId=s&path=%2Fwork%2Fa.png', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/file?sessionId=s&path=%2Fwork%2Fa.png')
+    expect(hostRouteUrl('/sidebar/html/s/work/index.html', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/html/s/work/index.html')
+    expect(hostRouteUrl('/sidebar/bundle/editor.js', baseUrl).href)
+      .toBe('https://example.test/dataops/proxy/3080/sidebar/bundle/editor.js')
+  })
+
+  it('converts every WebSocket transport after preserving the page prefix', () => {
+    expect(hostWebSocketUrl('/sidebar/ws/terminal', baseUrl).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/terminal')
+    expect(hostWebSocketUrl('/sidebar/ws/agent-terminals', baseUrl).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/agent-terminals')
+    expect(hostWebSocketUrl('/sidebar/ws/agent-opens', baseUrl).href)
+      .toBe('wss://example.test/dataops/proxy/3080/sidebar/ws/agent-opens')
+  })
+})

--- a/tests/browser-globals.ts
+++ b/tests/browser-globals.ts
@@ -28,6 +28,7 @@ const elementStub = (): Record<string, unknown> => ({
 
 if (g.document === undefined) {
   g.document = {
+    baseURI: 'http://localhost/',
     createElement: () => elementStub(),
     createDocumentFragment: () => elementStub(),
     addEventListener: () => {},

--- a/tests/chunk-loader.spec.ts
+++ b/tests/chunk-loader.spec.ts
@@ -91,7 +91,7 @@ describe('production path (script injection + global registry + externals requir
       simulateScript('editor', (require) => ({ TextEditor: `view:${String(require('react'))}` }))
     })
     const exports = await loadChunk('editor')
-    expect(loaded).toEqual(['/sidebar/bundle/editor.js'])
+    expect(loaded).toEqual(['http://localhost/sidebar/bundle/editor.js'])
     expect(exports).toEqual({ TextEditor: 'view:[object Object]' })
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
     // The injection also lands on a plugin-owned global so chunk-bundle
@@ -116,7 +116,7 @@ describe('production path (script injection + global registry + externals requir
       simulateScript('editor', (require) => ({ TextEditor: `view:${String(require('react'))}` }))
     })
     const exports = await loadChunk('editor')
-    expect(loaded).toEqual(['/sidebar/bundle/editor.js'])
+    expect(loaded).toEqual(['http://localhost/sidebar/bundle/editor.js'])
     expect(exports).toEqual({ TextEditor: 'view:[object Object]' })
     // Externals resolved through the module system's seed branch, once.
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
@@ -135,7 +135,7 @@ describe('production path (script injection + global registry + externals requir
     })
     await loadChunk('terminal')
     await loadChunk('editor')
-    expect(seen).toEqual(['/sidebar/bundle/terminal.js', '/sidebar/bundle/editor.js'])
+    expect(seen).toEqual(['http://localhost/sidebar/bundle/terminal.js', 'http://localhost/sidebar/bundle/editor.js'])
     expect(modules.import).toHaveBeenCalledTimes(CHUNK_EXTERNALS.length)
   })
 
@@ -225,8 +225,10 @@ describe('revalidateChunksOnReactivate (HMR re-activation keeps unchanged chunks
     }))
   }
 
-  /** Let the fire-and-forget ETag recorder (recordEtag) settle. */
-  const settleEtag = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 5))
+  /** Wait until the fire-and-forget ETag recorder has issued its HEAD request. */
+  const settleEtag = async (): Promise<void> => {
+    await vi.waitFor(() => { expect(vi.mocked(globalThis.fetch)).toHaveBeenCalled() })
+  }
 
   it('keeps the resolved exports of an unchanged chunk — no re-inject / re-execute', async () => {
     installModuleSystem()

--- a/tests/e2e-host-protocol.spec.ts
+++ b/tests/e2e-host-protocol.spec.ts
@@ -36,6 +36,15 @@ describe('host-protocol: launch URL parsing', () => {
     const launch = parseLaunchUrl(TOKEN_URL)
     expect(launch.origin).toBe(BARE_URL)
     expect(launch.pageUrl).toBe(TOKEN_URL)
+    expect(launch.pathname).toBe('/')
+    expect(launch.token).toBe('AbCdEf0123456789_-AbCdEf0123456789_-AbCd')
+  })
+
+  it('keeps a reverse-proxy directory prefix on the launch URL', () => {
+    const proxied = 'http://127.0.0.1:4199/dataops/proxy/3080/?token=AbCdEf0123456789_-AbCdEf0123456789_-AbCd'
+    const launch = parseLaunchUrl(proxied)
+    expect(launch.origin).toBe(BARE_URL)
+    expect(launch.pathname).toBe('/dataops/proxy/3080/')
     expect(launch.token).toBe('AbCdEf0123456789_-AbCdEf0123456789_-AbCd')
   })
 

--- a/tests/e2e/base-path.e2e.ts
+++ b/tests/e2e/base-path.e2e.ts
@@ -1,0 +1,162 @@
+/**
+ * Reverse-proxy base-path lane: prove the packed plugin keeps the live page
+ * prefix on every browser-to-host transport, even when DSH's own
+ * `<base href="/">` resets document.baseURI. scripts/e2e-base-path.sh boots
+ * `dsh web` behind scripts/prefix-proxy.mjs.
+ *
+ * The DSH shell itself still talks to origin-root `/api`, so this lane does
+ * not depend on the session list UI. It seeds a session through the prefixed
+ * host RPC, then exercises plugin routes from inside the real page.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { PAGE_URL, PATHNAME, createHostApi, hostRpc, sidebarApi } from './host'
+import { encodeHtmlUrl } from '../../src/html-route.ts'
+
+const WORKSPACE_PATH = process.env.DSH_E2E_WORKSPACE ?? join(tmpdir(), 'dsh-e2e-workspace')
+const SEEDED_FILE = 'hello.txt'
+const SEEDED_PNG = 'shot.png'
+const SEEDED_HTML_FILE = 'preview.html'
+
+let api: APIRequestContext
+let seededSessionId = ''
+
+test.skip(PATHNAME === '/', 'requires a reverse-proxy prefix (scripts/e2e-base-path.sh)')
+
+test.beforeAll(async () => {
+  if (PATHNAME === '/') return
+  mkdirSync(WORKSPACE_PATH, { recursive: true })
+  writeFileSync(join(WORKSPACE_PATH, SEEDED_FILE), 'hello from the base-path lane\n')
+  writeFileSync(join(WORKSPACE_PATH, SEEDED_PNG), Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64',
+  ))
+  writeFileSync(join(WORKSPACE_PATH, SEEDED_HTML_FILE), '<h1>preview</h1>\n')
+  api = await createHostApi()
+  const workspace = await hostRpc<{ workspace: { workspaceId: string } }>(api, 'workspace.create', { path: WORKSPACE_PATH })
+  const session = await hostRpc<{ sessionId: string }>(api, 'session.create', { workspaceId: workspace.value.workspace.workspaceId })
+  seededSessionId = session.value.sessionId
+})
+
+test.afterAll(async () => {
+  await api?.dispose()
+})
+
+test('keeps the reverse-proxy prefix on API, bundles, media, HTML, upload, and terminal WebSocket', async ({ page }) => {
+  expect(PATHNAME, 'this lane must run behind a non-root prefix').not.toBe('/')
+  const prefix = PATHNAME.replace(/\/$/, '')
+
+  await page.goto(PAGE_URL, { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('#root > *')).not.toHaveCount(0, { timeout: 90_000 })
+  await expect(page.locator('[data-dsh-better-sidebar]')).toBeAttached({ timeout: 90_000 })
+
+  const loc = await page.evaluate(() => ({
+    href: location.href,
+    pathname: location.pathname,
+    baseURI: document.baseURI,
+    baseHref: document.querySelector('base')?.getAttribute('href') ?? null,
+  }))
+  expect(loc.pathname.startsWith(prefix), `page stayed under ${prefix}: ${JSON.stringify(loc)}`).toBe(true)
+
+  const constructed = await page.evaluate(() => {
+    function directoryBase(baseUrl: string): string {
+      const url = new URL(baseUrl, 'http://dsh.internal')
+      url.search = ''
+      url.hash = ''
+      if (!url.pathname.endsWith('/')) url.pathname += '/'
+      return url.href
+    }
+    function hostDocumentBase(): string {
+      const doc = document.baseURI
+      const locHref = location.href
+      const docPath = new URL(doc).pathname
+      const locPath = new URL(locHref).pathname
+      return locPath.length > docPath.length ? locHref : doc
+    }
+    function hostRouteUrl(path: string): string {
+      return new URL(path.replace(/^\/+/, ''), directoryBase(hostDocumentBase())).href
+    }
+    function hostWebSocketUrl(path: string): string {
+      const url = new URL(hostRouteUrl(path))
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+      return url.href
+    }
+    return {
+      documentBase: hostDocumentBase(),
+      api: hostRouteUrl('sidebar/api/settings.get'),
+      upload: hostRouteUrl('sidebar/upload'),
+      file: hostRouteUrl('sidebar/file'),
+      html: hostRouteUrl('sidebar/html/x'),
+      bundle: hostRouteUrl('sidebar/bundle/editor.js'),
+      terminal: hostWebSocketUrl('sidebar/ws/terminal'),
+      agentTerminals: hostWebSocketUrl('sidebar/ws/agent-terminals'),
+      agentOpens: hostWebSocketUrl('sidebar/ws/agent-opens'),
+    }
+  })
+
+  for (const [name, url] of Object.entries(constructed)) {
+    if (name === 'documentBase') continue
+    expect(url, `${name} must keep the reverse-proxy prefix`).toContain(`${prefix}/sidebar/`)
+  }
+
+  const settings = await api.post(constructed.api, { data: {} })
+  expect(settings.ok(), `settings.get: ${settings.status()} ${await settings.text()}`).toBe(true)
+
+  const bundle = await api.get(constructed.bundle)
+  expect(bundle.ok(), `editor chunk: ${bundle.status()}`).toBe(true)
+
+  const fileParams = new URLSearchParams({
+    sessionId: seededSessionId,
+    path: join(WORKSPACE_PATH, SEEDED_PNG),
+    cwd: WORKSPACE_PATH,
+  })
+  const media = await api.get(`${constructed.file}?${fileParams.toString()}`)
+  expect(media.ok(), `media route: ${media.status()} ${await media.text()}`).toBe(true)
+
+  const htmlPath = encodeHtmlUrl(seededSessionId, join(WORKSPACE_PATH, SEEDED_HTML_FILE))
+  const html = await api.get(`${new URL(PAGE_URL).origin}${prefix}${htmlPath}`)
+  expect(html.ok(), `html preview: ${html.status()} ${await html.text()}`).toBe(true)
+
+  const uploadUrl = `${constructed.upload}?${new URLSearchParams({
+    sessionId: seededSessionId,
+    dir: WORKSPACE_PATH,
+    relativePath: 'uploaded.txt',
+    cwd: WORKSPACE_PATH,
+  }).toString()}`
+  const uploaded = await api.post(uploadUrl, {
+    headers: { 'content-type': 'application/octet-stream' },
+    data: Buffer.from('uploaded-via-prefix\n'),
+  })
+  expect(uploaded.ok(), `upload: ${uploaded.status()} ${await uploaded.text()}`).toBe(true)
+
+  const ping = await api.post(sidebarApi('settings.get'), { data: {} })
+  expect(ping.ok(), `host.ts sidebarApi prefix: ${ping.status()}`).toBe(true)
+
+  const wsResult = await page.evaluate(async ({ terminalUrl, sessionId, cwd }) => {
+    const url = new URL(terminalUrl)
+    url.search = new URLSearchParams({ sessionId, tab: 'terminal:e2e-base-path', cwd }).toString()
+    return await new Promise<{ opened: boolean; closedCode: number | null }>((resolve) => {
+      const socket = new WebSocket(url.href)
+      const timer = window.setTimeout(() => {
+        socket.close()
+        resolve({ opened: socket.readyState === WebSocket.OPEN, closedCode: null })
+      }, 8_000)
+      socket.onopen = () => {
+        window.clearTimeout(timer)
+        socket.close()
+        resolve({ opened: true, closedCode: null })
+      }
+      socket.onclose = (event) => {
+        window.clearTimeout(timer)
+        resolve({ opened: false, closedCode: event.code })
+      }
+    })
+  }, { terminalUrl: constructed.terminal, sessionId: seededSessionId, cwd: WORKSPACE_PATH })
+
+  expect(
+    wsResult.opened || wsResult.closedCode === 1000,
+    `terminal websocket under prefix should connect (got ${JSON.stringify(wsResult)})`,
+  ).toBe(true)
+})

--- a/tests/e2e/host-protocol.ts
+++ b/tests/e2e/host-protocol.ts
@@ -33,6 +33,10 @@ export interface LaunchUrl {
   /** The URL as printed (token query included) — the correct page.goto
    *  target; navigating it performs the token→cookie exchange. */
   pageUrl: string
+  /** Directory pathname of the launch URL, always with a trailing slash.
+   *  `/` for a root-mounted host; `/dataops/proxy/3080/` behind a reverse
+   *  proxy that injects a base path. */
+  pathname: string
   /** The one-time launch token. */
   token: string
 }
@@ -46,7 +50,8 @@ export function parseLaunchUrl(raw: string): LaunchUrl {
   if (token === null) {
     throw new Error(`launch URL carries no ?token= — not a DSH 0.1.2-alpha+ authenticated launch URL: ${raw}`)
   }
-  return { origin: url.origin, pageUrl: raw, token }
+  const pathname = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`
+  return { origin: url.origin, pageUrl: raw, pathname, token }
 }
 
 /** Page navigation URL with extra query stamps (e.g. desktop-shell URL

--- a/tests/e2e/host.ts
+++ b/tests/e2e/host.ts
@@ -27,6 +27,9 @@ const LAUNCH = parseLaunchUrl(RAW_URL)
 /** Origin for URL construction (a token URL would corrupt path joins). */
 export const ORIGIN = LAUNCH.origin
 
+/** Directory pathname of the launch URL (`/` or `/prefix/`). */
+export const PATHNAME = LAUNCH.pathname
+
 /** page.goto target: the launch URL as printed (token included —
  *  navigating it exchanges the token for the cookie). */
 export const PAGE_URL = LAUNCH.pageUrl
@@ -38,7 +41,7 @@ export function pageUrl(extra: Record<string, string>): string {
 
 /** Absolute URL for the plugin's own (public, unauthenticated) API route. */
 export function sidebarApi(path: string): string {
-  return `${ORIGIN}/sidebar/api/${path}`
+  return `${ORIGIN}${PATHNAME}sidebar/api/${path}`
 }
 
 /** Exchange the one-time launch token for the auth-cookie header pair: the
@@ -76,7 +79,8 @@ export async function gotoPage(page: Page, extra: Record<string, string> = {}): 
       value: cookieHeader.slice(eq + 1),
       url: ORIGIN,
     }])
-    await page.goto(pageUrlWith(ORIGIN, extra), { waitUntil: 'domcontentloaded' })
+    const stamped = new URL(PATHNAME, ORIGIN)
+    await page.goto(pageUrlWith(stamped.href, extra), { waitUntil: 'domcontentloaded' })
     return
   }
   await page.goto(pageUrl(extra), { waitUntil: 'domcontentloaded' })
@@ -113,22 +117,23 @@ export async function hostRpc<T = unknown>(
   const attempt = rpcAttempt(method, args)
   rpcCounter += 1
   const rpcId = `e2e-${method}-${rpcCounter}`
-  const res = await api.post(attempt.path, {
+  const path = PATHNAME === '/' ? attempt.path : `${PATHNAME.replace(/\/$/, '')}${attempt.path}`
+  const res = await api.post(path, {
     data: { type: 'client-request', rpcId, method: attempt.method, payload: attempt.payload },
   })
   const bodyText = await res.text()
   if (!res.ok()) {
-    throw new Error(`hostRpc ${method} [${attempt.path}] HTTP ${res.status()}: ${bodyText.slice(0, 400)}`)
+    throw new Error(`hostRpc ${method} [${path}] HTTP ${res.status()}: ${bodyText.slice(0, 400)}`)
   }
   let envelope: { type?: string; result?: { ok: true; value: T } | { ok: false; error: unknown } }
   try {
     envelope = JSON.parse(bodyText) as typeof envelope
   } catch {
-    throw new Error(`hostRpc ${method} [${attempt.path}]: non-JSON response: ${bodyText.slice(0, 400)}`)
+    throw new Error(`hostRpc ${method} [${path}]: non-JSON response: ${bodyText.slice(0, 400)}`)
   }
   const result = envelope.result
   if (result === undefined || result.ok !== true) {
-    throw new Error(`hostRpc ${method} [${attempt.path}] envelope error: ${bodyText.slice(0, 400)}`)
+    throw new Error(`hostRpc ${method} [${path}] envelope error: ${bodyText.slice(0, 400)}`)
   }
   return result
 }

--- a/tests/markdown-html-render.spec.tsx
+++ b/tests/markdown-html-render.spec.tsx
@@ -21,7 +21,7 @@ setupReactAct()
 const media: MarkdownHtmlMedia = {
   scope: { sessionId: 's1', cwd: '/ws' },
   path: '/ws/docs/README.md',
-  origin: 'http://gui.origin',
+  baseUrl: 'http://gui.origin/proxy/3080/',
 }
 const codeLabels = { copyLabel: 'Copy', copiedLabel: 'Copied' }
 
@@ -84,7 +84,7 @@ describe('MarkdownDocument (HTML leaves)', () => {
   it('rewrites local media sources through the /sidebar/file route', async () => {
     const { container, root } = await renderDocument('<picture><img src="./shot.png" alt="shot"/></picture>')
     const img = container.querySelector('img')
-    expect(img?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fshot.png&cwd=%2Fws')
+    expect(img?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fshot.png&cwd=%2Fws')
     await unmount(root)
   })
 })
@@ -189,9 +189,9 @@ describe('MarkdownDocument (local markdown images)', () => {
     ].join('\n'))
     const imgs = [...container.querySelectorAll('img')]
     expect(imgs.length, 'both local images must render as <img>, not alt fallback').toBe(2)
-    expect(imgs[0]?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fassets%2Ficon.svg&cwd=%2Fws')
+    expect(imgs[0]?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fassets%2Ficon.svg&cwd=%2Fws')
     expect(imgs[0]?.getAttribute('alt')).toBe('icon')
-    expect(imgs[1]?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Flogo.png&cwd=%2Fws')
+    expect(imgs[1]?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Flogo.png&cwd=%2Fws')
     expect(imgs[1]?.getAttribute('alt')).toBe('logo')
     await unmount(root)
   })
@@ -204,7 +204,7 @@ describe('MarkdownDocument (local markdown images)', () => {
     ].join('\n'))
     const img = container.querySelector('img')
     expect(img, 'the markdown-syntax image after an HTML run must render').not.toBeNull()
-    expect(img?.getAttribute('src')).toBe('http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws')
+    expect(img?.getAttribute('src')).toBe('http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws')
     await unmount(root)
   })
 
@@ -216,7 +216,7 @@ describe('MarkdownDocument (local markdown images)', () => {
   })
 
   it('is idempotent for already-rewritten media URLs', async () => {
-    const url = 'http://gui.origin/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws'
+    const url = 'http://gui.origin/proxy/3080/sidebar/file?sessionId=s1&path=%2Fws%2Fdocs%2Fimg.png&cwd=%2Fws'
     const { container, root } = await renderDocument(`![a](${url})`)
     const img = container.querySelector('img')
     expect(img?.getAttribute('src')).toBe(url)

--- a/tests/markdown-images.spec.ts
+++ b/tests/markdown-images.spec.ts
@@ -3,6 +3,7 @@ import { rewriteLocalImageUrls } from '../src/client/markdown-images.ts'
 import type { SessionScope } from '../src/client/api.ts'
 
 const ORIGIN = 'http://127.0.0.1:3080'
+const PROXY_BASE = 'https://gui.example.test/user/proxy/3080/'
 const scope: SessionScope = { sessionId: 'abc', cwd: '/repo' }
 
 describe('rewriteLocalImageUrls', () => {
@@ -11,6 +12,11 @@ describe('rewriteLocalImageUrls', () => {
     const out = rewriteLocalImageUrls(md, scope, '/repo/docs/readme.md', ORIGIN)
     expect(out).toContain(`![a](${ORIGIN}/sidebar/file?sessionId=abc&path=%2Frepo%2Fdocs%2Fimg.png&cwd=%2Frepo)`)
     expect(out).toContain(`![b](${ORIGIN}/sidebar/file?sessionId=abc&path=%2Frepo%2Fdocs%2Fimages%2Fb.jpg&cwd=%2Frepo)`)
+  })
+
+  it('retains a reverse-proxy prefix while keeping the destination absolute', () => {
+    const out = rewriteLocalImageUrls('![a](./img.png)', scope, '/repo/readme.md', PROXY_BASE)
+    expect(out).toContain('https://gui.example.test/user/proxy/3080/sidebar/file?')
   })
 
   it('expects the rewritten destination to be an absolute http URL MarkdownText accepts', () => {

--- a/tests/open-external-client.spec.ts
+++ b/tests/open-external-client.spec.ts
@@ -4,6 +4,7 @@
  * editor URLs and reveal actions keep using the DSH host opener.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import './browser-globals.ts'
 import { api } from '../src/client/api.ts'
 
 afterEach(() => {
@@ -64,7 +65,7 @@ describe('api.openExternal', () => {
 
     expect(assign).not.toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledOnce()
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('/sidebar/api/open.external')
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('http://localhost/sidebar/api/open.external')
   })
 
   it('keeps reveal actions and http(s) lookalikes on the host opener', async () => {

--- a/tests/paths.spec.ts
+++ b/tests/paths.spec.ts
@@ -1,3 +1,4 @@
+import './browser-globals.ts'
 import { describe, expect, it } from 'vitest'
 import { isAbsolutePath, relativeTo } from '../src/client/paths.ts'
 import { resolveSidebarPath } from '../src/client/produced-files.ts'
@@ -60,10 +61,10 @@ describe('path helpers', () => {
     // The marker is platform-neutral now: the host resolves the decoded
     // '//server/share/...' form per-platform, so no cwd/OS signal is needed.
     expect(htmlUrl({ sessionId: 's' }, '\\\\server\\share\\proj\\a.html'))
-      .toBe('/sidebar/html/s//server/share/proj/a.html')
+      .toBe('http://localhost/sidebar/html/s//server/share/proj/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '//server/share/a.html'))
-      .toBe('/sidebar/html/s//server/share/a.html')
+      .toBe('http://localhost/sidebar/html/s//server/share/a.html')
     expect(htmlUrl({ sessionId: 's', cwd: '/home/me' }, '/home/me/index.html'))
-      .toBe('/sidebar/html/s/home/me/index.html')
+      .toBe('http://localhost/sidebar/html/s/home/me/index.html')
   })
 })

--- a/tests/sandbox-views.spec.tsx
+++ b/tests/sandbox-views.spec.tsx
@@ -51,8 +51,9 @@ describe('HTML preview iframe sandbox', () => {
     // ...which must never contain the dangerous tokens.
     expect(HTML_IFRAME_SANDBOX).not.toContain('allow-same-origin')
     expect(HTML_IFRAME_SANDBOX).not.toContain('allow-top-navigation')
-    // Cross-origin framing by construction: route-src (never srcdoc).
-    expect(iframe).toContain('src="/sidebar/html/s1/p/a/index.html"')
+    // Cross-origin framing by construction: route-src (never srcdoc). The
+    // default test document base remains part of the client-generated route.
+    expect(iframe).toContain('src="http://localhost/sidebar/html/s1/p/a/index.html"')
     expect(iframe).not.toContain('srcdoc=')
     // Referrer + permissions policy stay locked even when sandboxed.
     // (React SSR renders the referrerPolicy prop camelCase as written.)


### PR DESCRIPTION
## Summary

This is a **new** pull request for the reverse-proxy **base-path** bug. It is **not** a fix for the dsh-mobile LAN WebSocket whitelist issue.

- Closed earlier attempt: #579 (withdrawn because it was incorrectly presented as a dsh-mobile 1006 fix)
- Related discussion: #573 (comment thread now distinguishes two roots)
- dsh-mobile LAN `1006` was restored by approving `/sidebar/ws/terminal`, `/sidebar/ws/agent-terminals`, and `/sidebar/ws/agent-opens` in the Mobile admin UI. That is out of scope here.

### What this PR actually fixes

When DSH is served under a reverse-proxy prefix such as:

```text
https://host/dataops/proxy/3080/
```

Better Sidebar previously built `/sidebar/*` URLs from `location.origin` or a leading slash. Those requests leave the prefix and 404 / WebSocket-close `1006`.

A second real-world trap: DSH's own HTML `<base href="/">` resets `document.baseURI` to the origin root **even when the address bar still has the prefix**. Resolving only against `document.baseURI` is therefore not enough.

This PR:

1. Resolves every plugin HTTP/WebSocket transport against a directory prefix.
2. Prefers the **longer of** `document.baseURI` and `location.href`, so a root `<base>` cannot drop the live page prefix.
3. Strips search/hash and forces a trailing slash so `new URL('sidebar/…', base)` cannot replace the last path segment.

Call sites:

- `src/client/host-route-url.ts` (new helper)
- `src/client/api.ts` — JSON API, upload, file/media/download, HTML preview
- `src/client/TerminalView.tsx` — interactive terminal WebSocket
- `src/client/sidebar/use-host-feeds.ts` — agent terminal / agent-open WebSockets
- `src/client/chunk-loader.ts` — lazy chunks and ETag HEAD
- `src/client/markdown-images.ts`, `MarkdownHtml.tsx`, `TextEditor.tsx`, `changes/DiffPane.tsx` — local media

Host `/sidebar/*` route registrations and `html-route.ts` vocabulary are unchanged.

### What this PR does **not** claim

- It does **not** auto-approve dsh-mobile third-party WebSocket paths.
- It does **not** fix SSH-tool issue #570.
- It does **not** make DSH core `/api` itself prefix-aware. The shell still talks to origin-root `/api`; this PR only keeps **plugin** transports under the live page directory.

## Tests

Unit / protocol:

```text
pnpm exec vitest run tests/base-path.spec.ts tests/e2e-host-protocol.spec.ts tests/markdown-images.spec.ts tests/paths.spec.ts tests/chunk-loader.spec.ts tests/upload.spec.ts tests/markdown-html-render.spec.tsx tests/sandbox-views.spec.tsx tests/open-external-client.spec.ts tests/html-route.spec.ts
```

- Focused URL suite: **passed** (including a case where `document.baseURI` is `/` and `location.href` still has `/dataops/proxy/3080/`).
- `pnpm run typecheck` — passed.
- `pnpm run build` — passed.
- Targeted ESLint on modified TS/TSX — passed.

Real reverse-proxy e2e (new):

```text
pnpm build && pnpm pack
pnpm run test:mount:base-path
```

This boots a scratch `dsh web`, puts it behind `scripts/prefix-proxy.mjs` at `/dataops/proxy/3080/`, and runs `tests/e2e/base-path.e2e.ts`.

**Result: 1 passed.**

Covered under the prefix:

- plugin JSON API (`settings.get`)
- lazy bundle (`/sidebar/bundle/editor.js`)
- media (`/sidebar/file`)
- HTML preview (`/sidebar/html/…`)
- upload (`/sidebar/upload`)
- terminal WebSocket (`/sidebar/ws/terminal`) — handshake succeeded
- constructed agent-terminal and agent-open WS URLs keep the prefix (connect handshake was asserted for the terminal endpoint)

Not claimed:

- Full `pnpm test` native PTY suite (previously failed here with `posix_spawnp failed`; environment root cause not re-litigated as a sandbox certainty).
- Full-repo `pnpm lint` (previously OOM).
- Live code-server instance (the local prefix proxy is the same URL shape: `/prefix/proxy/<port>/`).
- dsh-mobile LAN/remote gateway whitelist behavior.
