### PR TITLE
fix(client): guard getSnapshot calls against undefined sources

### DIFF
--- a/src/client/SideChatView.tsx
+++ b/src/client/SideChatView.tsx
@@ -398,8 +398,8 @@ export function SideChatView(props: {
   // loop itself stays silent on wire failures; absent service (older host)
   // reads as `undefined` = never show the banner.
   const connectionState = useSyncExternalStore(
-    useMemo(() => (callback: () => void) => ctx.connection?.state.subscribe(callback) ?? (() => {}), [ctx]),
-    useCallback(() => ctx.connection?.state.getSnapshot(), [ctx]),
+    useMemo(() => (callback: () => void) => ctx.connection?.state?.subscribe(callback) ?? (() => {}), [ctx]),
+    useCallback(() => ctx.connection?.state?.getSnapshot(), [ctx]),
   )
 
   /** The agent-identity badge of the thread header (preset · model). */

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -146,14 +146,14 @@ export function apply(ctx: Context): void {
   let terminalTitle = fallbackTitle
   void api.shellGet().then(({ name }) => {
     terminalTitle = name
-    const snapshot = service.getSnapshot()
-    if (snapshot.state === undefined) return
+    const snapshot = service?.getSnapshot()
+    if (!snapshot || snapshot.state === undefined) return
     const tabs = allLeaves(snapshot.state.splits)
       .concat(allLeaves(snapshot.state.bottomSplits))
       .flatMap(leaf => leaf.tabs)
     for (const tab of tabs) {
       if (tab.type === 'terminal' && !isAgentTabId(tab.id) && tab.title === fallbackTitle) {
-        service.updateTab(tab.id, { title: name })
+        service?.updateTab(tab.id, { title: name })
       }
     }
   }).catch(() => { /* keep fallback */ })

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -28,8 +28,8 @@ import {
 } from './state.ts'
 import { isNarrowWidth } from './breakpoints.ts'
 import { extOf } from './paths.ts'
+import { SIDEBAR_PREFS_DEFAULTS, type SidebarPrefs } from '../prefs-shared.ts'
 import type { SessionScope } from './api.ts'
-import type { SidebarPrefs } from '../prefs-shared.ts'
 
 /**
  * Public state vocabulary re-exported for consumers (type-only; the values
@@ -605,13 +605,13 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
     if (descriptor === undefined) return
     // A scope targets another session: the open lands in THAT session's
     // state (loaded on demand) without switching the UI's active session.
-    const targetSessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+    const targetSessionId = scope?.sessionId ?? store?.getSnapshot()?.sessionId
     if (targetSessionId === undefined) return
     const callbackScope: SessionScope = scope ?? { sessionId: targetSessionId }
     // Whether this open targets a session that is NOT the one on screen: a
     // targeted open must not auto-expand panels the user cannot see (the
     // expansion is about landing "in sight" for the CURRENT viewer).
-    const activeSessionId = store.getSnapshot().sessionId
+    const activeSessionId = store?.getSnapshot()?.sessionId
     const targetsInactiveSession = scope !== undefined && scope.sessionId !== activeSessionId
     // Lifecycle capture: `created` when the open minted a NEW tab (a
     // dedupe/id-safety-net focus is an ACTIVATION, not an open).
@@ -752,7 +752,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
       return closeTabReducer(state, paneId, tabId)
     })
     if (closed !== undefined) {
-      const sessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+      const sessionId = scope?.sessionId ?? store?.getSnapshot()?.sessionId
       if (sessionId !== undefined) {
         const descriptor = tabs.get(closed.type)
         // An explicit scope (with its optional cwd) rides to the callback.
@@ -762,7 +762,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
   }
 
   /** The snapshot the store publishes (state/prefs carry the active session). */
-  const getSnapshot = (): SidebarSnapshot => store.getSnapshot()
+  const getSnapshot = (): SidebarSnapshot => store?.getSnapshot() ?? { sessionId: undefined, state: undefined, prefs: { ...SIDEBAR_PREFS_DEFAULTS } }
 
   /** Store changes: session switch, state mutations, prefs writes. */
   const subscribeState = (listener: () => void): (() => void) => store.subscribe(listener)
@@ -794,7 +794,7 @@ export function createBetterSidebarService(store: SidebarStore): BetterSidebarSe
       return activateTabReducer(state, paneId, tabId)
     })
     if (activated !== undefined) {
-      const sessionId = scope?.sessionId ?? store.getSnapshot().sessionId
+      const sessionId = scope?.sessionId ?? store?.getSnapshot()?.sessionId
       if (sessionId !== undefined) {
         const descriptor = tabs.get(activated.type)
         // An explicit scope (with its optional cwd) rides to the callback.


### PR DESCRIPTION
﻿## 问题

客户端在侧边栏挂载时报错：`Cannot read properties of undefined (reading 'getSnapshot')`。

## 根因

三处 getSnapshot 调用没有防御未挂载的对象：

1. `service.ts`：`getSnapshot()` 无条件解引用 `store`，store 缺失时崩溃。
2. `index.tsx`：shellGet 回调中 `service.getSnapshot()` 未检查 service 是否仍在。
3. `SideChatView.tsx`：订阅 `ctx.connection?.state` 时可选链只覆盖 connection——connection 存在但 state 面异步未挂载时，`.state.getSnapshot()` 抛错。

## 修复

三处均改为可选链 + 空值兜底（store 缺失时返回含默认 prefs 的空快照）。

## 验证

- `pnpm typecheck` ✅ 通过
- `pnpm test`：service.spec.ts 71/71 通过；仅 3 个环境相关文件失败（agent-pty / smoke 需真实 shell，fs-operations 需符号链接权限），已在干净基线复现确认与本次改动无关。
