### PR TITLE
feat(git): 支持工作区根目录为 Git 仓库时仍探测并展示子目录独立仓库

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -246,24 +246,26 @@ export function repoRoots(cwd: string): Promise<string[]> {
 }
 
 async function discoverRepoRoots(cwd: string): Promise<string[]> {
+  const roots: string[] = []
   try {
-    return [await directRepoRoot(cwd)]
+    roots.push(await directRepoRoot(cwd))
   } catch {
-    const entries = await readdir(cwd, { withFileTypes: true }).catch(() => [])
-    const roots: string[] = []
-    for (const entry of entries
-      .filter(entry => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules')
-      .sort((left, right) => left.name.localeCompare(right.name))
-      .slice(0, DISCOVERY_LIMIT)) {
-      try {
-        const root = await directRepoRoot(join(cwd, entry.name))
-        if (!roots.some(existing => pathIdentity(existing) === pathIdentity(root))) roots.push(root)
-      } catch {
-        // Ordinary child directory; keep discovering sibling repositories.
-      }
-    }
-    return roots
+    // Current directory is not a Git repository root.
   }
+
+  const entries = await readdir(cwd, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries
+    .filter(entry => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules')
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .slice(0, DISCOVERY_LIMIT)) {
+    try {
+      const root = await directRepoRoot(join(cwd, entry.name))
+      if (!roots.some(existing => pathIdentity(existing) === pathIdentity(root))) roots.push(root)
+    } catch {
+      // Ordinary child directory; keep discovering sibling repositories.
+    }
+  }
+  return roots
 }
 
 /** Resolve the selected repository, defaulting to the first discovered root. */

--- a/src/git.ts
+++ b/src/git.ts
@@ -192,6 +192,12 @@ function runGit(cwd: string, args: string[], timeoutMs = 30_000): Promise<string
  *  A home-directory cwd can hold hundreds of visible folders (Library, iCloud
  *  mounts…); probing them all serially is what froze the panel in #369. */
 const DISCOVERY_LIMIT = 200
+/** How many BFS levels the nested-repo discovery descends below cwd; repo
+ *  roots up to depth DISCOVERY_MAX_DEPTH - 1 are detected (level d holds
+ *  depth-(d-1) dirs, whose entries are read for `.git`). 4 is the minimum
+ *  useful value. Cost stays bounded by the depth ≤ 3 directory count; the
+ *  depth-4 frontier is collected but never expanded. */
+const DISCOVERY_MAX_DEPTH = 4
 /** Per-probe and direct-discovery budget. `rev-parse` is millisecond-scale on
  *  a healthy checkout; a probe that needs longer is a stalled mount and is
  *  better abandoned than waited on. */
@@ -222,9 +228,10 @@ async function directRepoRoot(cwd: string): Promise<string> {
   return out.trim()
 }
 
-/** Discover the current repository or direct child repositories. Results are
- *  cached per cwd and concurrent callers share one in-flight scan, so opening
- *  the panel (three parallel git.* requests) costs a single discovery pass. */
+/** Discover the current repository plus child repositories nested up to
+ *  DISCOVERY_MAX_DEPTH - 1 levels below cwd. Results are cached per cwd and
+ *  concurrent callers share one in-flight scan, so opening the panel (three
+ *  parallel git.* requests) costs a single discovery pass. */
 export function repoRoots(cwd: string): Promise<string[]> {
   const cached = repoRootsCache.get(cwd)
   if (cached !== undefined && cached.expires > Date.now()) return Promise.resolve(cached.roots)
@@ -245,6 +252,12 @@ export function repoRoots(cwd: string): Promise<string[]> {
   return promise
 }
 
+/** Breadth-first scan below `cwd`: one `readdir` per visited directory, no
+ *  per-child git process (dirent `.git` presence — directory, worktree file
+ *  or symlink form — decides). Keeps the serial `rev-parse`-per-child storm
+ *  that froze the panel in #369 structurally impossible. The scan descends
+ *  into repositories it finds, so repos embedded inside other repos (vendored
+ *  checkouts that are not submodules) are discovered too. */
 async function discoverRepoRoots(cwd: string): Promise<string[]> {
   const roots: string[] = []
   try {
@@ -253,17 +266,25 @@ async function discoverRepoRoots(cwd: string): Promise<string[]> {
     // Current directory is not a Git repository root.
   }
 
-  const entries = await readdir(cwd, { withFileTypes: true }).catch(() => [])
-  for (const entry of entries
-    .filter(entry => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules')
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .slice(0, DISCOVERY_LIMIT)) {
-    try {
-      const root = await directRepoRoot(join(cwd, entry.name))
-      if (!roots.some(existing => pathIdentity(existing) === pathIdentity(root))) roots.push(root)
-    } catch {
-      // Ordinary child directory; keep discovering sibling repositories.
+  let level = [cwd]
+  for (let depth = 1; depth <= DISCOVERY_MAX_DEPTH && level.length > 0; depth++) {
+    const next: string[] = []
+    for (const dir of level.slice(0, DISCOVERY_LIMIT)) {
+      const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+      let hasGit = false
+      const subdirs: string[] = []
+      for (const entry of entries) {
+        if (entry.name === '.git') {
+          // Worktrees and submodules carry `.git` as a file (or symlink), not a directory.
+          if (entry.isDirectory() || entry.isFile() || entry.isSymbolicLink()) hasGit = true
+        } else if (entry.isDirectory() && !entry.isSymbolicLink() && !entry.name.startsWith('.') && entry.name !== 'node_modules') {
+          subdirs.push(entry.name)
+        }
+      }
+      if (hasGit && dir !== cwd && !roots.some(existing => pathIdentity(existing) === pathIdentity(dir))) roots.push(dir)
+      for (const name of subdirs.sort((left, right) => left.localeCompare(right))) next.push(join(dir, name))
     }
+    level = next
   }
   return roots
 }

--- a/tests/git.spec.ts
+++ b/tests/git.spec.ts
@@ -62,6 +62,68 @@ describe('git parsing', () => {
     }
   })
 
+  it('discovers nested child repositories up to three levels below a git root', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'dsh-better-sidebar-nested-git-'))
+    const level2 = join(workspace, 'group', 'project')
+    const level3 = join(level2, 'vendor-lib')
+    const level3Worktree = join(level2, 'vendor-tools')
+    try {
+      mkdirSync(level3, { recursive: true })
+      mkdirSync(level3Worktree, { recursive: true })
+      await Promise.all([
+        execFileAsync('git', ['-C', workspace, 'init']),
+        execFileAsync('git', ['-C', level2, 'init']),
+        execFileAsync('git', ['-C', level3, 'init']),
+        // Worktree form: `.git` is a plain file pointing at the real gitdir.
+        writeFileSync(join(level3Worktree, '.git'), 'gitdir: /tmp/nonexistent/worktrees/x\n'),
+      ])
+
+      await expect(repoRoots(workspace)).resolves.toEqual([
+        canonical(workspace),
+        canonical(level2),
+        canonical(level3),
+        canonical(level3Worktree),
+      ])
+      await expect(status(workspace, canonical(level3))).resolves.toMatchObject({
+        isRepo: true,
+        root: canonical(level3),
+        repositories: [canonical(workspace), canonical(level2), canonical(level3), canonical(level3Worktree)],
+      })
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('descends into discovered repositories and skips hidden, node_modules and beyond-cap depths', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'dsh-better-sidebar-embedded-git-'))
+    const outer = join(workspace, 'outer')
+    const embedded = join(outer, 'packages', 'embedded')
+    const inNodeModules = join(outer, 'node_modules', 'shadowed')
+    const tooDeep = join(workspace, 'a', 'b', 'c', 'too-deep')
+    try {
+      mkdirSync(embedded, { recursive: true })
+      mkdirSync(inNodeModules, { recursive: true })
+      mkdirSync(tooDeep, { recursive: true })
+      await Promise.all([
+        execFileAsync('git', ['-C', workspace, 'init']),
+        execFileAsync('git', ['-C', outer, 'init']),
+        execFileAsync('git', ['-C', embedded, 'init']),
+        execFileAsync('git', ['-C', inNodeModules, 'init']),
+        execFileAsync('git', ['-C', tooDeep, 'init']),
+      ])
+
+      // Repos hidden inside node_modules or beyond depth DISCOVERY_MAX_DEPTH - 1
+      // stay invisible; the repo embedded inside `outer` is still discovered.
+      await expect(repoRoots(workspace)).resolves.toEqual([
+        canonical(workspace),
+        canonical(outer),
+        canonical(embedded),
+      ])
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
+  })
+
   it('parses porcelain -z entries including renames', () => {
     const output = ['M  src/a.ts', ' M src/b.ts', '?? src/c.ts', 'R  src/new.ts', 'src/old.ts', ''].join('\0')
     const entries = parsePorcelainZ(output)

--- a/tests/git.spec.ts
+++ b/tests/git.spec.ts
@@ -41,6 +41,27 @@ describe('git parsing', () => {
     }
   })
 
+  it('discovers root and direct child repositories when root is also a git repository', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'dsh-better-sidebar-root-git-'))
+    const child = join(workspace, 'child-repo')
+    try {
+      await mkdir(child)
+      await Promise.all([
+        execFileAsync('git', ['-C', workspace, 'init']),
+        execFileAsync('git', ['-C', child, 'init']),
+      ])
+
+      await expect(repoRoots(workspace)).resolves.toEqual([canonical(workspace), canonical(child)])
+      await expect(status(workspace, canonical(child))).resolves.toMatchObject({
+        isRepo: true,
+        root: canonical(child),
+        repositories: [canonical(workspace), canonical(child)],
+      })
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
+  })
+
   it('parses porcelain -z entries including renames', () => {
     const output = ['M  src/a.ts', ' M src/b.ts', '?? src/c.ts', 'R  src/new.ts', 'src/old.ts', ''].join('\0')
     const entries = parsePorcelainZ(output)


### PR DESCRIPTION
## What

在「文件变动（Git 视角）」的仓库探测逻辑中，解除「若当前工作区根目录是 Git 仓库则立即短路返回」的限制。改为：将根仓库加入探测列表后，**继续向下扫描一层直接子目录**，若子目录中存在独立的 Git 仓库则一并发现并去重收集。

## Why

在多项目复合工作区场景中，开发者常将根工作区初始化为一个顶层 Git 仓库（用于版本管理公共配置、工作区全局索引、任务记录或跨项目基础设施文档），同时在子目录下存放多个各自拥有独立 `.git` 的业务/插件代码库：

```text
workspace/ (Git 仓库：管理通用规范与文档)
├── .git/
├── docs/
├── AGENTS.md
├── repo-a/ (独立的业务 Git 仓库)
│   └── .git/
└── repo-b/ (独立的插件 Git 仓库)
    └── .git/
```

- **现状痛点**：当前 `discoverRepoRoots` 的逻辑是 `try { return [await directRepoRoot(cwd)]; } catch { ...扫描子目录... }`。只要根目录有 `.git`，便立即短路返回 `[cwd]`。这导致 `repositories.length === 1`，前端侧边栏顶部的仓库切换下拉选择器（`GitLens.tsx` 的 `status.repositories.length > 1` 判定）完全被隐藏，开发者无法在侧边栏内查看和切换子项目的 Git 变动与提交历史，只能看到外层根目录的 Git 状态。
- **改动效果**：根目录与子目录仓库同属一个视图候选集合，仓库切换下拉菜单正常展现，开发者可以在外层元仓库与各子工程仓库之间自由切换并管理变动。

## Changes

- `src/git.ts`
  - `discoverRepoRoots(cwd)`：解除 `try` 块的短路返回，改为将根仓库放入 `roots` 数组后，继续扫描一层子目录（保留原先跳过 `.` 开头隐藏目录、`node_modules` 以及数量上限 `DISCOVERY_LIMIT` 的保护逻辑）；
  - 保留既有的 `pathIdentity` 去重与后续基于 `repoRootsCache` 的并发防抖与缓存机制。
- `tests/git.spec.ts`
  - 新增单元测试 `discovers root and direct child repositories when root is also a git repository`：模拟根目录与子目录同时被 `git init` 初始化的工作区，断言 `repoRoots()` 与 `status()` 能准确返回两层仓库路径。

## 兼容性与边界

- **普通单仓库（非复合目录）**：子目录没有 `.git`，`roots.length === 1`，下拉菜单保持隐藏，行为与视觉与原先完全一致，无任何回归。
- **纯容器目录（根目录无 `.git`）**：`catch` 静默处理，原样扫描并发现子目录仓库，行为与原先完全一致。
- **性能影响**：仅向下扫描一层直接子目录，且享有既有的 3 秒 `repoRootsCache` 缓存与 in-flight promise 复用，无额外开销。

## 验证

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test tests/git.spec.ts` ✅（13/13 包含新增多层仓库发现测试全部通过）
- `pnpm build` ✅
- 本地 DSH 真机验证：根目录与子目录仓库同时出现在「文件变动」顶部下拉菜单中，分支切换、暂存、Diff 预览、提交与历史回溯均正常工作。
