### PR TITLE
fix(shell): keep the panel host full-height under page-level filters (sidebar vanishes under backdrop-filter skins)

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -228,6 +228,11 @@ export function apply(ctx: Context): void {
       let mounted = false
       let bodyObserver: MutationObserver | undefined
       let hostCheckFrame: number | null = null
+      /** Bounded retry budget for the geometry watchdog: the mount self-check
+       *  can run before React commits `[data-dsh-panel-host]`. ~120 frames is
+       *  far beyond any realistic commit latency, and a bounded budget keeps
+       *  the loop from spinning forever if the layer never appears. */
+      let retriesLeft = 120
       const unmount = (): void => {
         if (!mounted) return
         mounted = false
@@ -254,47 +259,78 @@ export function apply(ctx: Context): void {
         })
         bodyObserver.observe(document.body, { childList: true })
       }
-      /** One-shot geometry self-check: if the host page transforms
-       *  <html>/<body> itself (exotic shells), a fixed panel host would
-       *  track the transformed box instead of the viewport. Flip the
-       *  degraded mode and pin the host to the viewport every frame until
-       *  the ancestor transform is actually gone. The normal path (no
-       *  page-level transform) never runs the sync loop. */
+      /** Geometry self-check for the fixed panel host.
+       *
+       *  Two independent failure modes are covered:
+       *
+       *  1. LATE LAYER. The mount self-check runs right after `root.render()`,
+       *     but React has not committed yet, so `[data-dsh-panel-host]` is
+       *     usually still absent. The old code returned on that first miss and
+       *     was never rescheduled — the guard silently did nothing for the
+       *     whole session. Keep retrying for a bounded window instead.
+       *
+       *  2. HIJACKED CONTAINING BLOCK. A page-level `transform`, `filter`,
+       *     `backdrop-filter` (translucent skins), `will-change`,
+       *     `contain: paint` or `container-type` re-roots the containing block
+       *     of `position: fixed`, so the host stops tracking the viewport (the
+       *     height may collapse to 0, or the box shifts). Detected as a rect
+       *     that no longer matches the viewport — deliberately geometry-based
+       *     rather than a property allowlist, so any equivalent future trigger
+       *     is caught by the same check. Flip degraded mode and pin the host to
+       *     the viewport every frame. */
       const scheduleHostCheck = (): void => {
         hostCheckFrame ??= requestAnimationFrame(() => {
           hostCheckFrame = null
           const layer = host?.querySelector<HTMLElement>('[data-dsh-panel-host]')
-          if (layer === null || layer === undefined) return
+          if (layer === null || layer === undefined) {
+            // React has not committed the layer yet (or the host was replaced).
+            // Retry for a bounded window instead of giving up permanently.
+            if (host !== undefined && retriesLeft-- > 0) scheduleHostCheck()
+            return
+          }
           const rect = layer.getBoundingClientRect()
-          const mismatched = Math.abs(rect.left) > 8 || Math.abs(rect.top) > 8
-            || Math.abs(rect.width - window.innerWidth) > 8 || Math.abs(rect.height - window.innerHeight) > 8
+          const mismatched = Math.abs(rect.left) > 1 || Math.abs(rect.top) > 1
+            || Math.abs(rect.width - window.innerWidth) > 1 || Math.abs(rect.height - window.innerHeight) > 1
           if (!mismatched) {
             layer.removeAttribute('data-dsh-panel-host-degraded')
             layer.style.transform = ''
+            // Keep watching: a skin toggled or a shell wrapper added later
+            // re-roots the containing block mid-session. Cheap (one rect per
+            // frame); stops by itself once the host is gone.
+            if (host !== undefined) scheduleHostCheck()
             return
           }
           layer.setAttribute('data-dsh-panel-host-degraded', '')
-          console.warn('[dsh-better-sidebar] panel host geometry mismatch — a page-level transform was detected; using degraded viewport sync')
+          console.warn('[dsh-better-sidebar] panel host geometry mismatch — a page-level transform/filter/backdrop-filter is re-rooting the containing block; using degraded viewport sync')
           // Track our own compensating translation so the loop judges the
           // UNCORRECTED geometry: clearing degraded mode must wait for the
-          // ancestor transform to actually disappear — the frame right after
+          // page-level transform to actually disappear — the frame right after
           // our correction applies would otherwise look "fixed" and the
           // offset would return immediately (CR #232 P1).
           let applied = { x: 0, y: 0 }
           const sync = (): void => {
-            const r = layer.getBoundingClientRect()
+            const live = host?.querySelector<HTMLElement>('[data-dsh-panel-host]')
+            if (live === null || live === undefined) {
+              // Host unmounted: stop the loop rather than spinning on a
+              // detached node.
+              hostCheckFrame = null
+              return
+            }
+            const r = live.getBoundingClientRect()
             const rawLeft = r.left - applied.x
             const rawTop = r.top - applied.y
             if (Math.abs(rawLeft) <= 1 && Math.abs(rawTop) <= 1
               && Math.abs(r.width - window.innerWidth) <= 1 && Math.abs(r.height - window.innerHeight) <= 1) {
-              layer.removeAttribute('data-dsh-panel-host-degraded')
-              layer.style.transform = ''
+              live.removeAttribute('data-dsh-panel-host-degraded')
+              live.style.transform = ''
+              // Cause gone: resume the watchdog instead of ending the check.
+              scheduleHostCheck()
               return
             }
             const next = { x: -rawLeft, y: -rawTop }
             if (next.x !== applied.x || next.y !== applied.y) {
               applied = next
-              layer.style.transform = `translate(${applied.x}px, ${applied.y}px)`
+              live.style.transform = `translate(${applied.x}px, ${applied.y}px)`
             }
             hostCheckFrame = requestAnimationFrame(sync)
           }

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -35,6 +35,14 @@
 :global([data-dsh-panel-host]) {
   position: fixed;
   inset: 0;
+  /* Explicit viewport height: `inset: 0` alone derives the height from the
+     containing block, and an ancestor carrying `backdrop-filter` / `filter` /
+     `transform` (e.g. a skin's glass columns, wallpaper-exclusive) swaps that
+     containing block for a zero-height box — the width still stretches via
+     left/right, but the height collapses to 0 and the whole panel becomes
+     invisible while staying in the DOM. `100vh` resolves against the viewport
+     instead, so the host keeps its full height in every shell. */
+  height: 100vh;
   z-index: 25;
   pointer-events: none;
   /* Clip at the viewport edge: collapsed panels slide off-screen with


### PR DESCRIPTION
## 问题 / What

在带页面级 `backdrop-filter` 的皮肤下（实测皮肤中心 `wallpaper-exclusive`），**整条右侧侧边栏不可见——右侧区域完全空白，但面板并未卸载**：`[data-dsh-panel-host]` 与内部 `_panel` 都还在 DOM 里。

Under page-level `backdrop-filter` skins (measured with `wallpaper-exclusive`), the whole right sidebar becomes invisible while the panel stays mounted: both `[data-dsh-panel-host]` and its `_panel` are present in the DOM.

- 关掉该皮肤 → 侧边栏立刻回来 / turning the skin off restores it immediately.
- **与 #559 不是同一问题**：#559 是 client-store / `remote.session` 契约导致面板**从未挂载**（`node of nodes`、`cannot get property "remote.session" without inject`）；本例 host 与 panel 均已挂载，属几何/可见性问题。 / Not a duplicate of #559: there the panel never mounts; here it mounts and is simply invisible.

## 根因 / Root cause

`[data-dsh-panel-host]` 是视口尺寸固定层（`position: fixed; inset: 0`）。`inset: 0` 的盒尺寸由**包含块**推导；当祖先引入 `backdrop-filter` / `filter` / `transform`（半透明皮肤的玻璃层正是这类），包含块被换成零高盒子 —— 宽度仍由 left/right 撑开，**高度塌成 0**，配合 `overflow: clip` 被裁掉，视觉上就是整条侧边栏消失。

`[data-dsh-panel-host]` is a viewport-sized fixed layer. `inset: 0` derives the box size from the *containing block*; an ancestor carrying `backdrop-filter` / `filter` / `transform` (exactly what translucent skins do) swaps that containing block for a zero-height box. Width still stretches via left/right, but the height collapses to 0 and `overflow: clip` crops it — the whole sidebar disappears visually.

证据链（本次实测）/ Evidence:

| 证据 | 位置 |
|---|---|
| 宿主形态 `fixed; inset: 0` | `src/client/sidebar.module.css`（本 PR 上下文） |
| 皮肤注入 `backdrop-filter` | `wallpaper-exclusive/patches.css:47-54, 172-179, 614-621`（该皮肤**已**为 better-sidebar 做适配，说明二者是协同关系，冲突只在几何层） |
| 含块层设计说明 | `docs/2026-08-19-sidebar-injection-unified-host-design.md`（§挂载层 / §5.1 降级实现） |
| 现有检测只认 transform | `src/client/index.tsx` — `panel host geometry mismatch — a page-level transform was detected` |

## 改动 / Change

给宿主一个**不依赖包含块**的显式高度：

```css
:global([data-dsh-panel-host]) {
  position: fixed;
  inset: 0;
  height: 100vh;   /* <- 新增：resolve against the viewport */
  ...
}
```

`100vh` 相对**视口**解析而非包含块，因此无论皮肤怎么改包含块，宿主都保持满高。 / `100vh` resolves against the viewport instead of the containing block, so the host keeps its full height regardless of skin transforms.

## 验证 / Verification

- 环境 / Environment：DSH `0.1.2-rc.1` + Chromium 系浏览器（Windows 11），`wallpaper-exclusive` 皮肤。
- 修复前 / Before：右侧空白；`[data-dsh-panel-host]` 在 DOM 中但几何塌陷。
- 修复后 / After：重建插件产物 + 浏览器硬刷新，侧边栏恢复并稳定保持。 / rebuilt artifacts + hard refresh: the sidebar returns and stays.

## 范围说明 / Scope（重要，请维护者权衡 / please weigh in）

本 PR 是**症状层修复**，两个已知的替代/后续方向留在代码外，供维护者判断更希望怎么修：

This PR fixes the **symptom**. Two alternative directions are intentionally left out:

1. **放宽几何失配检测**：`index.tsx` 的降级检测目前只覆盖 `transform`，而实际触发者是 `backdrop-filter` / `filter` / `will-change`。扩到这些属性后，degraded 模式才能自动兜住同类场景（含根因自愈）。 / The degraded-mode detector only covers `transform`; extending it to `backdrop-filter` / `filter` / `will-change` would auto-catch this class of bug.
2. **挂载位置免疫包含块**：把宿主挂到 `body` / `documentElement`（需 A/B 验证）可根治，但会动挂载模型，本 PR 不碰。 / Mounting onto `body` / `documentElement` would root-fix it but changes the mounting model.

若维护者判定第 1 或第 2 条更合适，我可以按该方向重做本 PR。 / Happy to redo this PR along either direction if preferred.

## 关联 / Related

- Addresses #616
- `#232`（引入含块层与 `data-dsh-panel-host-degraded` 的重构）/ the refactor that introduced the containing-block layer and degraded mode.
