### PR TITLE
fix(native): restore middle-click close on the native right Sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ GitHub topic [`dsh-better-sidebar`](https://github.com/topics/dsh-better-sidebar
 |---|---|
 | 保存编辑 | `Ctrl/Cmd + S` |
 | Git 提交 | `Ctrl + Enter` |
-| 关闭 Tab | 鼠标中键 |
+| 关闭 Tab | 鼠标中键（DSH 原生右侧栏与插件底部工作台通用；宿主 tab 条自身没有该手势，插件按归属补回） |
 | Tab 右键菜单 | 关闭 / 关闭其他页签 / 关闭左侧页签 / 关闭右侧页签（当前标签组） |
 | 拆分/合并分栏 | 拖 Tab 到分栏边缘 / 中间 |
 | 引用文件到输入框 | 悬浮行尾 `@文件` 按钮 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -574,7 +574,7 @@ All changes since v0.14.0:
 |---|---|
 | Save edits | `Ctrl/Cmd + S` |
 | Git commit | `Ctrl + Enter` |
-| Close tab | Middle mouse button |
+| Close tab | Middle mouse button (the native right sidebar and the plugin's bottom workbench alike; the host strip has no such gesture of its own — the plugin restores it for the tabs it owns) |
 | Tab context menu (right-click) | Close / Close Other Tabs / Close Tabs to the Left / Close Tabs to the Right (current pane) |
 | Split / merge panes | Drag tab to pane edge / middle |
 | Reference file to input | Hover the `@file` button at end of line |

--- a/docs/external-plugin-guide.md
+++ b/docs/external-plugin-guide.md
@@ -26,6 +26,7 @@
 | 跨会话打开 | 目标会话的右侧栏 store 未挂载时，打开会排队到该会话上屏后重放 |
 | 内置类型接管 | 插件的 `editor` 类型以 `extension` 优先级认领 `dsh-resource://file/**`（压过内置 `ui-sidebar-documentpreview` 的 `text` 预览——即 `fallback` 带），并接管内置 `files` 页面 kind（`openTab('files')` 打开插件的文件树）；插件卸载/禁用时内置实现自动复位 |
 | 终端上限 | 终端 tab 的数量上限只统计插件自己底部工作台里的终端；原生栏里的终端不计入 |
+| tab 条手势 | 宿主自己的 tab 条**没有中键关闭**：它的 tab 元素只挂 pointerdown（拖拽）、click（激活）、keydown（方向键/Home/End/Enter/Space）与 contextmenu（右键菜单）。插件补回该手势——标题 chip 打上 `data-dsh-better-sidebar-native-tab`（归属 + 原生 tab id），文档级捕获监听在按下时 `preventDefault`（关掉 Chrome 中键自动滚动）并 `stopPropagation`（不让宿主的拖拽逻辑看到中键），释放落在同一 tab 上才经该 tab 自己的 `tab.actions.close()` 关闭（会话精确，宿主 tab 完全不受影响；左键激活 / 拖拽 / 右键菜单 / 方向键仍是宿主的）。语义与插件底部工作台一致：换位置释放、或漂移超过 4px 视为拖拽 → 取消。实现见 `src/client/native/tab-middle-click.ts` |
 | 底部工作台的开合 | 落到底部工作台的打开一律展开它（新建与聚焦都算），因此 `openTab` 的落点永远可见；开合按钮注册在 DSH 会话头的 utilities 槽（`conversation.session.header.utilities`），不在插件自己的宿主里 |
 | 新建标签页列表 | 每个 tab 类型在原生 guide 里占一行：标题取 `title` + 图标取 `icon`（缺图标时宿主补一个方块占位），说明取可选的 `description`——**宿主只在 guide 列出的条目 ≤ 4 条时渲染说明**（上游 `MAX_DESCRIBED_ENTRIES = 4`），更长的列表整列丢掉所有说明；未声明 `description` 的条目渲染成单行「图标 + 标题」（rc.1 起 `description` 回到宿主契约，但**宿主与插件都没有兜底句**，所以插件恢复字段而不恢复旧的通用句）；`hidden: true` 的类型不占行。插件的 `editor` 类型不再单独占行（它认领的文件资源由 `files` 接管页承载同一视图）。**注意默认组合看不到说明**：插件贡献 6 个 guide 条目（文件 / 文件变动 / 任务管理 / 侧边对话 / 终端 / 浏览器），已超过 4 条上限——要让说明出现，需在插件设置页关掉足够多的 tab 类型把 guide 压到 ≤ 4 条 |
 | 新建面板的种子（alpha.2） | 在新会话打开原生新面板时，宿主从已注册的 guide 条目里播种：恰好 1 个条目 → 直接打开那一页；0 或 ≥2 个条目 → 打开指南。`revealIfOpened` 打开的「页面」在**同一 pane 内**强制去重（已在该 pane 就不再新建）；由已有 tab 地址驱动的打开不受该去重影响 |

--- a/docs/plans/2026-09-10-native-tab-middle-click.md
+++ b/docs/plans/2026-09-10-native-tab-middle-click.md
@@ -1,0 +1,63 @@
+# 原生右侧栏的中键关闭：由插件补回（2026-09-10）
+
+> 起因：DSH 0.1.5 把右列交给宿主（v0.19.0-alpha.0 的承载面迁移）后，**中键关闭 tab 失效**。
+> 本文记录定位证据、方案取舍与验证方式；实现见 `src/client/native/tab-middle-click.ts`。
+
+---
+
+## 1. 问题与证据
+
+v0.18.x 的右侧栏是插件自绘的，中键关闭由 `src/client/TabBar.tsx` 提供（PR #145 的按下/释放语义）。
+承载面迁移后，右侧栏的 tab 条由宿主渲染（`@deepseek-ai/dsh-client-ui-sidebar-right` +
+`@deepseek-ai/dsh-client-ui-dockkit`），插件只贡献 tab 的**类型**、**正文**与**标题 chip**。
+
+对运行中的 DSH 0.1.5-rc.1 前端包逐一核对（`/assets/index-*.js` 与本地安装包 sha256 一致）：
+
+- dockkit 的 tab 元素只挂四个处理器：`onPointerDown`（`button!==2` → 拖拽跟踪）、`onClick`（激活）、
+  `onKeyDown`（方向键 / Home / End / Enter / Space）、`onContextMenu`（右键菜单）；
+- 全包只有 React DOM 自身的 `auxclick` 字样，**没有任何 `button===1` 分支**，也没有键盘关闭绑定；
+- 关闭入口只有两个：× 按钮（`data-dockkit-tab-close`）与右键菜单项（`data-dockkit-menu-close`）。
+
+结论：这不是插件回归，而是**宿主的 tab 条从未实现该手势**；插件的 TabBar 现在只服务底部工作台，
+所以底部工作台的中键关闭仍然有效，右侧栏失效。
+
+## 2. 方案取舍
+
+| 方案 | 取舍 |
+|---|---|
+| **A. chip 标记 + 文档级捕获监听 + `tab.actions.close()`（采用）** | chip 是插件在原生 tab 里唯一渲染的元素，标记即归属；`actions.close()` 由宿主按 `(sessionId, tabId)` 绑定（`navigator.closeIn`），与 × 按钮同一条路径，无需探测/排队 |
+| B. DOM 扫描 `[data-dockkit-tab]` + `ctx.sidebarRight.close(tabId)` | `close()` 只对**在屏会话**写入，跨会话要走不在接口里的 `closeIn`（需结构化探测）；且拿不到"这个 tab 是不是我的"的可靠判据 |
+| C. 用插件的 records 判归属（`records.has`） | records 由**正文**渲染时铸造、卸载时丢弃 —— 后台 tab（非活动页签）没有记录，关闭会漏 |
+| D. 反馈上游 | `deepseek-ai/deepseek-harness` **禁用了 issue**，且仓库硬约束禁止改 DSH 源码 |
+
+## 3. 行为规格
+
+- **归属**：只有带 `data-dsh-better-sidebar-native-tab` 标记的 chip（即插件自己的 tab）参与；
+  宿主 tab（内置指南 / 文档预览 / 内置 files 复位后）完全不受影响——不 `preventDefault`、不 `stopPropagation`。
+- **热区**：条带的整个 tab 元素（`[data-dockkit-tab]`）或浮动面板的**表头**（`[data-dockkit-float-grip]`），
+  **绝不含面板正文**——终端与网页里中键是粘贴 / 后台打开，不能被当成关闭；宿主自己不渲染关闭控件
+  （`canCloseTab` 为假）的 tab 也不参与，避免插件对"能否关闭"另立一套判断。
+- **语义**（与 `TabBar.tsx`、VS Code、Chrome 一致）：中键**按下**落在插件 tab 上 → 记录；**释放**落在同一个
+  热区内（含 × 与标题两侧的空白）才关闭；换位置释放、或漂移超过 4px（视为中键拖拽）→ 取消。
+- **消费手势**：`pointerdown` + `mousedown` 上 `preventDefault()`（关掉 Chrome 中键自动滚动）与
+  `stopPropagation()`（宿主的拖拽跟踪挂在 pointerdown 上，否则中键会变成拖 tab）；左键、右键、滚轮路径不变。
+- **生命周期**：控制器每次客户端激活新建一个（非模块单例），随 `registerNativeSurface` 的 disposer 一起
+  `dispose()`（解绑全部监听、清空已发布动作），不会在文档上留悬挂监听。
+
+## 4. 已知边界
+
+- 标题槽未渲染（该类型没注册 title，或 chip 尚未挂载）时没有标记 → 中键无动作；当前插件每个 tab 类型都注册了 title。
+- 标记是插件自定义 data 属性（宿主契约允许 title 槽内容自定），若上游改变 chip 的宿主元素结构，
+  受影响的是"整个 tab 都是热区"这一点，chip 自身仍可关闭。
+- 浮动面板的表头标题同属该标题槽，因此浮动 tab 也支持中键关闭（热区是表头，不是整个浮动窗口）。
+
+## 5. 验证
+
+- 单测 `tests/native-tab-middle-click.spec.tsx`（12 例）：归属、按下/释放语义、漂移取消、单次结算、
+  宿主 tab 不受影响、左键不受影响、动作发布/撤回、dispose 解绑、`NativeTabTitle` 集成。
+- 真机挂载冒烟 `tests/e2e/mount.e2e.ts`：在真实 `dsh web` 里经插件文件树打开种子文件后，
+  断言 chip 带标记 → `click({button:'middle'})` → 该 tab 在宿主 store 里消失（整条链路真机验证）。
+
+## 6. 实施偏差
+
+- 无（实现与本文一致）。

--- a/src/client/native/index.ts
+++ b/src/client/native/index.ts
@@ -33,6 +33,7 @@ import {
   type NativeTabParams,
   type NativeTabRecords,
 } from './tab-adapter.tsx'
+import { createNativeTabMiddleClick } from './tab-middle-click.ts'
 
 /** The native tab-type registry face (`ctx.sidebarRightTabs`). */
 interface NativeTabRegistry {
@@ -125,6 +126,11 @@ export interface NativeSurfaceDeps {
  */
 export function registerNativeSurface(deps: NativeSurfaceDeps): () => void {
   const { ctx, store, service, records } = deps
+  // The middle-click close the host's strip does not implement (see
+  // tab-middle-click.ts): one controller per activation, handed to every
+  // title chip and disposed with these registrations, so no document-level
+  // listener outlives the plugin.
+  const middleClick = createNativeTabMiddleClick()
   // Wait for the tab-type REGISTRY (a service), not for the slot declaration:
   // the native seat declares `sidebar.right.pane.tab` BEFORE it provides
   // `sidebarRightTabs`, so a declaration-triggered registration reads the
@@ -162,7 +168,7 @@ export function registerNativeSurface(deps: NativeSurfaceDeps): () => void {
       ctx.slots.inject('sidebar.right.pane.tab.title', () => ctx.slots.register({
         name: 'sidebar.right.pane.tab.title',
         key: id,
-        inject: () => ({ records }),
+        inject: () => ({ records, middleClick }),
       }, NativeTabTitle)),
     ]
 
@@ -276,6 +282,7 @@ export function registerNativeSurface(deps: NativeSurfaceDeps): () => void {
   })
   return () => {
     void seat.dispose()
+    middleClick.dispose()
   }
 }
 

--- a/src/client/native/tab-adapter.tsx
+++ b/src/client/native/tab-adapter.tsx
@@ -27,6 +27,7 @@ import type { SessionScope } from '../api.ts'
 import { RenderBoundary } from '../RenderBoundary.tsx'
 import { OrphanedTab } from '../OrphanedTab.tsx'
 import { referenceInChat } from '../reference-in-chat.ts'
+import { nativeTabMarker, type NativeTabMiddleClick } from './tab-middle-click.ts'
 import type { BetterSidebarService } from '../service.ts'
 import type { SidebarStore, SidebarTab, TabType } from '../state.ts'
 import css from '../sidebar.module.css'
@@ -64,6 +65,16 @@ export interface NativeTabInfo {
       readonly revision: number
     }
     readonly signal: AbortSignal
+    /**
+     * The tab's own actions (`sidebar.right.pane.tab.title` shares the body's
+     * hook context, so a title sees them too). `close()` ends the record in
+     * the session it lives in — the same call the host's × button makes.
+     * Optional: a partial runtime without the field leaves the plugin's
+     * middle-click close unregistered rather than throwing.
+     */
+    readonly actions?: {
+      readonly close?: () => void
+    }
   }
 }
 
@@ -330,6 +341,13 @@ export function NativeTabBody(props: NativeBodyInjected & NativeBodyFrameworkPro
 /** What a title registration injects. */
 export interface NativeTitleInjected {
   readonly records: NativeTabRecords
+  /**
+   * The middle-click controller the chip publishes its close to (see
+   * `tab-middle-click.ts`): the host's strip has no button-1 handling, so the
+   * plugin restores the gesture from the one element of a native tab it
+   * renders itself.
+   */
+  readonly middleClick: NativeTabMiddleClick
 }
 
 /**
@@ -337,14 +355,26 @@ export interface NativeTitleInjected {
  * in-place file switch, the side chat on the thread's first prompt). Without
  * this registration the chip would keep the title captured when the tab
  * opened.
+ *
+ * The chip is also where the plugin takes back the middle-click close the
+ * host's strip does not implement: it stamps its native tab id (the marker
+ * the document-level press handler resolves ownership AND identity from) and
+ * publishes `actions.close()` for it, so a middle press anywhere on the tab
+ * closes exactly this tab, in exactly its session.
  */
 export function NativeTabTitle(props: NativeTitleInjected & NativeBodyFrameworkProps): ReactNode {
-  const { records, useTabInfo } = props
+  const { records, middleClick, useTabInfo } = props
   const nativeTab = useTabInfo().tab
-  return useSyncExternalStore(
+  const title = useSyncExternalStore(
     listener => records.subscribe(listener),
     () => records.get(nativeTab.id)?.tab.title ?? nativeTab.title,
   )
+  const close = nativeTab.actions?.close
+  useEffect(() => {
+    if (close === undefined) return undefined
+    return middleClick.register(nativeTab.id, close)
+  }, [middleClick, nativeTab.id, close])
+  return createElement('span', nativeTabMarker(nativeTab.id), title)
 }
 
 /** The component pair one descriptor contributes to the native surface. */

--- a/src/client/native/tab-middle-click.ts
+++ b/src/client/native/tab-middle-click.ts
@@ -1,0 +1,200 @@
+/**
+ * Middle-click close over the plugin's tabs inside DSH's native right Sidebar.
+ *
+ * DSH's own strip closes a tab only through its × button or the right-click
+ * menu: the kit's tab element handles pointerdown (drag tracking), click
+ * (activate), keydown (arrow focus) and contextmenu, and never button 1. The
+ * plugin cannot hang a handler on that element — it contributes a tab's BODY
+ * and its TITLE, never the chip around them — so this module listens on the
+ * document in the CAPTURE phase instead, and closes through the tab's own
+ * `actions.close()`: the very call the host's × button ends in
+ * (`navigator.closeIn(sessionId, tabId)`), so the close is session-exact and
+ * needs no ownership probe beyond the marker the plugin's own title chip
+ * stamps. A chip without that marker is a host tab (the built-in guide, the
+ * document preview) and is left completely alone — and so is everything
+ * outside a strip chip's box and a floating panel's header: middle-clicking a
+ * terminal or a web page inside a tab keeps whatever the platform gave it.
+ *
+ * Semantics match the plugin's own strip (TabBar.tsx) and the platforms it
+ * copies: the press is recorded on middle-button pointerdown OVER a plugin
+ * tab, and the close settles on the first middle-button release over that
+ * same tab — releasing elsewhere, or drifting past the drag slop, cancels
+ * (VS Code microsoft/vscode#101028, Chrome crbug/40679924). The press is
+ * `preventDefault`ed to disarm Chrome's middle-click autoscroll and
+ * `stopPropagation`ed so the kit's drag tracking never sees the middle
+ * button; both are scoped to presses on a chip this plugin rendered, so a
+ * host tab keeps its native behaviour untouched.
+ */
+
+/** The marker a plugin tab's title chip stamps: ownership + native tab id. */
+export const NATIVE_TAB_MARKER = 'data-dsh-better-sidebar-native-tab'
+
+/** The docking kit's attribute on one strip chip (the whole clickable tab). */
+const DOCK_TAB_ATTRIBUTE = 'data-dockkit-tab'
+
+/** The kit's attribute on a floating panel's header (its title row). */
+const FLOAT_HEADER_ATTRIBUTE = 'data-dockkit-float-grip'
+
+/**
+ * Where a release may land: the strip tab, or a floating panel's HEADER —
+ * never the panel at large, whose body hosts terminals and web content where
+ * the middle button means paste / open-in-background.
+ */
+const HIT_NODE_SELECTOR = `[${DOCK_TAB_ATTRIBUTE}], [${FLOAT_HEADER_ATTRIBUTE}]`
+
+/**
+ * The kit's own close controls. The kit renders one exactly where the tab may
+ * close (`canCloseTab`), so requiring one keeps the gesture inside the host's
+ * rule instead of inventing a second opinion about closability.
+ */
+const CLOSE_CONTROL_SELECTOR = '[data-dockkit-tab-close], [data-dockkit-float-close]'
+
+/**
+ * How far (CSS pixels) a middle press may drift before it counts as a drag.
+ * A drag can end anywhere and the kit moves the tab with it, so closing then
+ * would punish a gesture the user aimed at moving the tab.
+ */
+const DRAG_SLOP = 4
+
+/** The attributes one title chip stamps to claim its tab. */
+export function nativeTabMarker(tabId: string): Record<string, string> {
+  return { [NATIVE_TAB_MARKER]: tabId }
+}
+
+/** Middle-click close over the plugin's native tabs. */
+export interface NativeTabMiddleClick {
+  /**
+   * Publish one live tab's close action; called by that tab's title chip.
+   * @param tabId - the native tab id the chip is rendered for.
+   * @param close - the action ending the tab in its own session.
+   * @returns a disposer unpublishing the action (the chip's effect cleanup).
+   */
+  register(tabId: string, close: () => void): () => void
+  /** Stop listening; the chips this controller served are gone. */
+  dispose(): void
+}
+
+/** One outstanding middle press. */
+interface Press {
+  readonly id: string
+  /** Where the release must land (see {@link hitOf}). */
+  readonly node: Element
+  readonly x: number
+  readonly y: number
+}
+
+/** One plugin tab a press resolved to. */
+interface Hit {
+  readonly id: string
+  readonly node: Element
+}
+
+/**
+ * Resolve an event target to a plugin tab: the chip itself, or — for the
+ * parts of a strip tab the chip does not cover — the enclosing kit tab that
+ * contains one. The chip's marker is the ownership test: a tab without one
+ * belongs to the host and resolves to undefined.
+ *
+ * The node the release must land in is the kit's strip tab (so the tab's
+ * padding and the gap before the × count) or a floating panel's header — not
+ * the panel, whose body hosts terminals and web content where the middle
+ * button means paste. A node that carries no close control is one the host
+ * itself refuses to close, and is left alone.
+ * @param target - the event target.
+ * @returns the tab id and the node a release must land in, or undefined.
+ */
+function hitOf(target: EventTarget | null): Hit | undefined {
+  const element = target as Element | null
+  if (element === null || typeof element.closest !== 'function') return undefined
+  // The kit's own box for this tab: the strip chip, or the floating header.
+  // A press anywhere else (a pane body, the page) has no such box.
+  const container = element.closest(HIT_NODE_SELECTOR)
+  const chip = element.closest(`[${NATIVE_TAB_MARKER}]`)
+    ?? container?.querySelector(`[${NATIVE_TAB_MARKER}]`)
+    ?? null
+  if (chip === null) return undefined
+  const id = chip.getAttribute(NATIVE_TAB_MARKER)
+  if (id === null || id === '') return undefined
+  const node = chip.closest(HIT_NODE_SELECTOR) ?? chip
+  if (node !== chip && node.querySelector(CLOSE_CONTROL_SELECTOR) === null) return undefined
+  return { id, node }
+}
+
+/**
+ * Create the middle-click controller for one client activation.
+ *
+ * Listeners are attached at creation and removed by {@link NativeTabMiddleClick.dispose};
+ * the returned controller is one per activation (never a module singleton),
+ * so a disposed plugin leaves no document-level listener behind.
+ * @returns the controller the native title chips publish their closes to.
+ */
+export function createNativeTabMiddleClick(): NativeTabMiddleClick {
+  const handlers = new Map<string, () => void>()
+  let press: Press | undefined
+  const clear = (): void => { press = undefined }
+
+  const onDown = (event: Event): void => {
+    const down = event as MouseEvent
+    // Any other button starts a different gesture, so an outstanding middle
+    // press can never settle.
+    if (down.button !== 1) { clear(); return }
+    const hit = hitOf(down.target)
+    if (hit === undefined || !handlers.has(hit.id)) { clear(); return }
+    down.preventDefault()
+    down.stopPropagation()
+    press = { id: hit.id, node: hit.node, x: down.clientX, y: down.clientY }
+  }
+
+  const onUp = (event: Event): void => {
+    const up = event as MouseEvent
+    if (up.button !== 1) return
+    const held = press
+    clear()
+    if (held === undefined) return
+    // Release-position semantics: the close only settles over the pressed
+    // tab (and the tab must still be in the document — it may have been
+    // closed under the press).
+    if (!held.node.isConnected || !held.node.contains(up.target as Node)) return
+    if (Math.abs(up.clientX - held.x) > DRAG_SLOP || Math.abs(up.clientY - held.y) > DRAG_SLOP) return
+    handlers.get(held.id)?.()
+  }
+
+  const listening: Array<[EventTarget, string, EventListener]> = []
+  const listen = (target: EventTarget, type: string, listener: EventListener): void => {
+    target.addEventListener(type, listener, true)
+    listening.push([target, type, listener])
+  }
+  let disposed = false
+  if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    // Pointer events carry the press that the kit's own handler would
+    // otherwise turn into a tab drag; the mouse pair is the fallback for
+    // engines without PointerEvent (and for the jsdom lane).
+    if (typeof (window as { PointerEvent?: unknown }).PointerEvent === 'function') {
+      listen(document, 'pointerdown', onDown)
+      listen(document, 'pointerup', onUp)
+      listen(document, 'pointercancel', clear)
+    }
+    listen(document, 'mousedown', onDown)
+    listen(document, 'mouseup', onUp)
+    listen(window, 'blur', clear)
+  }
+
+  return {
+    register(tabId, close) {
+      handlers.set(tabId, close)
+      return () => {
+        // A chip that re-renders for the same tab must not unpublish a newer
+        // action it no longer owns.
+        if (handlers.get(tabId) === close) handlers.delete(tabId)
+      }
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      handlers.clear()
+      clear()
+      for (const [target, type, listener] of listening) target.removeEventListener(type, listener, true)
+      listening.length = 0
+    },
+  }
+}

--- a/tests/e2e/mount.e2e.ts
+++ b/tests/e2e/mount.e2e.ts
@@ -454,6 +454,23 @@ test('plugin mounts into the DSH shell and survives a built-in tab sweep', async
   await page.waitForTimeout(1_500)
   await assertNoCrash()
 
+  // Middle-click close over the native strip. DSH's own strip has no button-1
+  // handling at all (its tab element handles pointerdown for drag, click for
+  // activation, keydown for focus and contextmenu for the menu), so the
+  // plugin restores the gesture from the one element of a native tab it
+  // renders itself — the title chip — and closes through the tab's own
+  // `actions.close()`. This asserts the whole chain against the real host:
+  // marker chip → document-level capture listener → the host's store.
+  const fileTab = pane.locator('[data-dockkit-tab]').filter({ hasText: SEEDED_FILE })
+  await expect(fileTab, `the opened "${SEEDED_FILE}" tab must own one strip chip`).toHaveCount(1, { timeout: 10_000 })
+  await expect(
+    fileTab.locator('[data-dsh-better-sidebar-native-tab]'),
+    'the plugin must stamp its tab id on the chip (the ownership marker)',
+  ).toHaveCount(1, { timeout: 10_000 })
+  await fileTab.click({ button: 'middle' })
+  await expect(fileTab, 'a middle click must close the tab in the host store').toHaveCount(0, { timeout: 10_000 })
+  await assertNoCrash()
+
   // The mermaid chunk (client-mermaid.js) only loads when a previewed markdown
   // file contains a mermaid fence. Open the seeded diagram file from the
   // explorer and require the full round-trip: chunk fetch + sanitized SVG

--- a/tests/native-tab-middle-click.spec.tsx
+++ b/tests/native-tab-middle-click.spec.tsx
@@ -1,0 +1,333 @@
+/**
+ * Middle-click close over the plugin's tabs in DSH's native right Sidebar.
+ *
+ * The host's strip has no button-1 handling at all (its tab element handles
+ * pointerdown for drag, click for activation, keydown for arrow focus and
+ * contextmenu for the menu), so the plugin restores the gesture from the one
+ * element of a native tab it renders itself — the title chip — and closes
+ * through the tab's own `actions.close()`. These specs pin the three things
+ * that make that safe:
+ *
+ * - OWNERSHIP: only chips carrying the plugin's marker resolve to a tab, so a
+ *   host tab (the built-in guide / document preview) keeps its native
+ *   behaviour, autoscroll and all;
+ * - SEMANTICS: press over a plugin tab, release over the same tab, drift
+ *   inside the drag slop — the release-position rule the plugin's own strip
+ *   (TabBar.tsx) follows;
+ * - CONSENT OF THE HOST'S GESTURES: the press is consumed (preventDefault +
+ *   stopPropagation) so the kit's drag tracking never sees the middle button,
+ *   and the left button / right button / wheel paths are untouched.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { act } from 'react-dom/test-utils'
+
+import { renderRoot, setupReactAct } from './test-utils.ts'
+setupReactAct()
+
+import { createNativeTabRecords, NativeTabTitle, type NativeTabInfo } from '../src/client/native/tab-adapter.tsx'
+import {
+  createNativeTabMiddleClick,
+  NATIVE_TAB_MARKER,
+  nativeTabMarker,
+  type NativeTabMiddleClick,
+} from '../src/client/native/tab-middle-click.ts'
+
+const controllers: NativeTabMiddleClick[] = []
+const unmounts: Array<() => void> = []
+
+afterEach(() => {
+  for (const controller of controllers.splice(0)) controller.dispose()
+  for (const unmount of unmounts.splice(0)) unmount()
+  document.body.innerHTML = ''
+})
+
+/** One middle-button event on `target`. */
+function middle(target: EventTarget, type: 'mousedown' | 'mouseup', at = { x: 10, y: 10 }): MouseEvent {
+  const event = new MouseEvent(type, {
+    button: 1,
+    bubbles: true,
+    cancelable: true,
+    clientX: at.x,
+    clientY: at.y,
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+/**
+ * The host's own markup, shrunk to what the gesture reads: two strip tabs (one
+ * the plugin owns — marker chip + a close control, exactly the shape
+ * `canCloseTab` decides), a floating panel with a header and a body, and a
+ * plugin tab the host itself refuses to close (no close control).
+ */
+function mountTabs(): {
+  controller: NativeTabMiddleClick
+  close: ReturnType<typeof vi.fn>
+  floatClose: ReturnType<typeof vi.fn>
+  refusedClose: ReturnType<typeof vi.fn>
+  chip: HTMLElement
+  tab: HTMLElement
+  hostTab: HTMLElement
+  floatHeader: HTMLElement
+  floatBody: HTMLElement
+  refusedTab: HTMLElement
+} {
+  const controller = createNativeTabMiddleClick()
+  controllers.push(controller)
+  const close = vi.fn()
+  const floatClose = vi.fn()
+  const refusedClose = vi.fn()
+  controller.register('tab-1', close)
+  controller.register('float-1', floatClose)
+  controller.register('tab-3', refusedClose)
+  const wrapper = document.createElement('div')
+  wrapper.innerHTML = `
+    <div data-dockkit-tab="tab-1">
+      <span class="title"></span>
+      <button class="x" data-dockkit-tab-close="tab-1">x</button>
+    </div>
+    <div data-dockkit-tab="tab-2"><span class="title">guide</span></div>
+    <div data-dockkit-float="float-1">
+      <header data-dockkit-float-grip="float-1">
+        <span class="ftitle"></span>
+        <button data-dockkit-float-close="float-1">x</button>
+      </header>
+      <div class="fbody"><span class="term">terminal</span></div>
+    </div>
+    <div data-dockkit-tab="tab-3"><span class="title"></span></div>
+  `
+  document.body.append(wrapper)
+  const [tab, hostTab, refusedTab] = [...wrapper.querySelectorAll<HTMLElement>('[data-dockkit-tab]')]
+  const chip = document.createElement('span')
+  chip.setAttribute(NATIVE_TAB_MARKER, 'tab-1')
+  chip.textContent = 'a.ts'
+  tab!.querySelector<HTMLElement>('.title')!.append(chip)
+  const floatHeader = wrapper.querySelector<HTMLElement>('[data-dockkit-float-grip]')!
+  const floatChip = document.createElement('span')
+  floatChip.setAttribute(NATIVE_TAB_MARKER, 'float-1')
+  floatChip.textContent = 'b.ts'
+  floatHeader.querySelector<HTMLElement>('.ftitle')!.append(floatChip)
+  const refusedChip = document.createElement('span')
+  refusedChip.setAttribute(NATIVE_TAB_MARKER, 'tab-3')
+  refusedChip.textContent = 'c.ts'
+  refusedTab!.querySelector<HTMLElement>('.title')!.append(refusedChip)
+  return {
+    controller,
+    close,
+    floatClose,
+    refusedClose,
+    chip,
+    tab: tab!,
+    hostTab: hostTab!,
+    floatHeader,
+    floatBody: wrapper.querySelector<HTMLElement>('.fbody')!,
+    refusedTab: refusedTab!,
+  }
+}
+
+describe('createNativeTabMiddleClick', () => {
+  it('closes on a middle press and release over the same tab, anywhere on it', () => {
+    const { close, chip, tab } = mountTabs()
+    const down = middle(chip, 'mousedown')
+    // The press is consumed: autoscroll disarmed, and the kit's drag tracking
+    // (which listens on the bubbling path this capture listener precedes)
+    // never sees the middle button.
+    expect(down.defaultPrevented).toBe(true)
+    const seenByKit = vi.fn()
+    document.body.addEventListener('mousedown', seenByKit)
+    middle(chip, 'mousedown')
+    expect(seenByKit).not.toHaveBeenCalled()
+    document.body.removeEventListener('mousedown', seenByKit)
+    // The whole tab is the hit area, not just the chip.
+    middle(tab.querySelector('.x')!, 'mouseup')
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels when the release lands outside the pressed tab', () => {
+    const { close, chip, tab, hostTab } = mountTabs()
+    // Another tab, the page, and the pressed tab's own container are all
+    // "elsewhere": only a release inside the pressed tab settles the close.
+    middle(chip, 'mousedown')
+    middle(hostTab, 'mouseup')
+    middle(chip, 'mousedown')
+    middle(document.body, 'mouseup')
+    middle(chip, 'mousedown')
+    middle(tab.parentElement!, 'mouseup')
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('cancels when the press drifts past the drag slop', () => {
+    const { close, chip, tab } = mountTabs()
+    middle(chip, 'mousedown', { x: 10, y: 10 })
+    // A middle drag moves the tab; the release must not also close it.
+    middle(tab, 'mouseup', { x: 40, y: 12 })
+    expect(close).not.toHaveBeenCalled()
+    middle(chip, 'mousedown', { x: 10, y: 10 })
+    middle(tab, 'mouseup', { x: 13, y: 12 })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles one close per press', () => {
+    const { close, chip } = mountTabs()
+    middle(chip, 'mousedown')
+    middle(chip, 'mouseup')
+    middle(chip, 'mouseup')
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a host tab entirely alone', () => {
+    const { close, hostTab } = mountTabs()
+    const down = middle(hostTab, 'mousedown')
+    expect(down.defaultPrevented).toBe(false)
+    middle(hostTab, 'mouseup')
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('closes a floating panel from its header only, never from its body', () => {
+    const { floatClose, floatHeader, floatBody } = mountTabs()
+    const chip = floatHeader.querySelector<HTMLElement>(`[${NATIVE_TAB_MARKER}="float-1"]`)!
+    // The body hosts the terminal / web content: a middle press there means
+    // paste or open-in-background and must stay untouched.
+    const inBody = middle(floatBody.querySelector('.term')!, 'mousedown')
+    expect(inBody.defaultPrevented).toBe(false)
+    middle(floatHeader, 'mouseup')
+    expect(floatClose).not.toHaveBeenCalled()
+    // The header is the hit area, chip or padding alike.
+    middle(floatHeader, 'mousedown')
+    middle(chip, 'mouseup')
+    expect(floatClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a plugin tab the host refuses to close', () => {
+    const { refusedClose, refusedTab } = mountTabs()
+    const chip = refusedTab.querySelector<HTMLElement>(`[${NATIVE_TAB_MARKER}="tab-3"]`)!
+    const down = middle(chip, 'mousedown')
+    // No close control in the tab means `canCloseTab` said no: the press keeps
+    // its default behaviour and nothing closes.
+    expect(down.defaultPrevented).toBe(false)
+    middle(refusedTab, 'mouseup')
+    expect(refusedClose).not.toHaveBeenCalled()
+  })
+
+  it('ignores the left button on a plugin tab', () => {
+    const { close, chip } = mountTabs()
+    const down = new MouseEvent('mousedown', { button: 0, bubbles: true, cancelable: true })
+    chip.dispatchEvent(down)
+    expect(down.defaultPrevented).toBe(false)
+    chip.dispatchEvent(new MouseEvent('mouseup', { button: 0, bubbles: true, cancelable: true }))
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('keeps the newest action for a tab and honours its cleanup', () => {
+    const { close, chip, controller } = mountTabs()
+    const newest = vi.fn()
+    const offStale = controller.register('tab-1', vi.fn())
+    const offNewest = controller.register('tab-1', newest)
+    // A stale chip's cleanup must not unpublish the newer action.
+    offStale()
+    middle(chip, 'mousedown')
+    middle(chip, 'mouseup')
+    expect(newest).toHaveBeenCalledTimes(1)
+    expect(close).not.toHaveBeenCalled()
+    // The live chip unmounts: nothing is published, so nothing closes.
+    offNewest()
+    middle(chip, 'mousedown')
+    middle(chip, 'mouseup')
+    expect(newest).toHaveBeenCalledTimes(1)
+  })
+
+  it('unbinds every listener on dispose', () => {
+    const { close, chip, controller } = mountTabs()
+    controller.dispose()
+    const down = middle(chip, 'mousedown')
+    middle(chip, 'mouseup')
+    expect(down.defaultPrevented).toBe(false)
+    expect(close).not.toHaveBeenCalled()
+  })
+})
+
+describe('NativeTabTitle', () => {
+  const scope = { sessionId: 's1', cwd: '/work' }
+
+  /** One native tab's info, as the host's `useTabInfo` hands it over. */
+  const infoFor = (input: { id: string; title: string; close?: () => void }): (() => NativeTabInfo) => () => ({
+    tab: {
+      id: input.id,
+      kind: 'editor',
+      title: input.title,
+      contentId: `addr://s1/work/work/${input.title}`,
+      visible: true,
+      navigation: { address: `addr://s1/work/work/${input.title}`, params: undefined, revision: 1 },
+      signal: new AbortController().signal,
+      ...(input.close === undefined ? {} : { actions: { close: input.close } }),
+    },
+  })
+
+  /** Render one chip inside a kit tab element, the way the host nests it. */
+  const mountChip = (input: { id: string; title: string; close?: () => void }): { tab: HTMLElement; container: HTMLElement } => {
+    const records = createNativeTabRecords()
+    records.ensure({ id: input.id, kind: 'editor', title: input.title, params: undefined, scope })
+    const middleClick = createNativeTabMiddleClick()
+    controllers.push(middleClick)
+    const root = renderRoot(createElement(NativeTabTitle, { records, middleClick, useTabInfo: infoFor(input) }))
+    unmounts.push(root.unmount)
+    const tab = document.createElement('div')
+    tab.setAttribute('data-dockkit-tab', input.id)
+    // The kit's own close control: its presence IS `canCloseTab`.
+    const closeControl = document.createElement('button')
+    closeControl.setAttribute('data-dockkit-tab-close', input.id)
+    tab.append(closeControl)
+    document.body.append(tab)
+    tab.append(root.container)
+    return { tab, container: root.container }
+  }
+
+  it('stamps its tab and routes the middle click into the tab’s own close action', () => {
+    const close = vi.fn()
+    const { tab, container } = mountChip({ id: 'tab-1', title: 'a.ts', close })
+    const chip = container.querySelector<HTMLElement>(`[${NATIVE_TAB_MARKER}="tab-1"]`)
+    expect(chip).not.toBeNull()
+    expect(chip!.textContent).toBe('a.ts')
+
+    // Middle press on the tab's padding, release over the chip: one close,
+    // through the action the runtime bound to this tab's session.
+    middle(tab, 'mousedown')
+    middle(chip!, 'mouseup')
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders without publishing a close when the runtime omits the actions face', () => {
+    const { container } = mountChip({ id: 'tab-2', title: 'b.ts' })
+    const chip = container.querySelector<HTMLElement>(`[${NATIVE_TAB_MARKER}="tab-2"]`)
+    expect(chip!.textContent).toBe('b.ts')
+    // No published action means the press stays untouched (autoscroll and
+    // the kit's own gestures keep their default behaviour).
+    expect(middle(chip!, 'mousedown').defaultPrevented).toBe(false)
+    middle(chip!, 'mouseup')
+  })
+
+  it('keeps the chip on the record’s live title', () => {
+    const records = createNativeTabRecords()
+    records.ensure({ id: 'tab-3', kind: 'terminal', title: 'Terminal', params: undefined, scope })
+    const middleClick = createNativeTabMiddleClick()
+    controllers.push(middleClick)
+    const root = renderRoot(createElement(NativeTabTitle, {
+      records,
+      middleClick,
+      useTabInfo: infoFor({ id: 'tab-3', title: 'Terminal', close: () => {} }),
+    }))
+    unmounts.push(root.unmount)
+    expect(root.container.textContent).toBe('Terminal')
+    // The record's own subscription re-renders the chip under act().
+    act(() => { records.update('tab-3', { title: 'zsh' }) })
+    expect(root.container.textContent).toBe('zsh')
+  })
+})
+
+describe('nativeTabMarker', () => {
+  it('stamps the tab id under the exported attribute', () => {
+    expect(nativeTabMarker('tab-9')).toEqual({ [NATIVE_TAB_MARKER]: 'tab-9' })
+  })
+})


### PR DESCRIPTION
## 问题

v0.19.0（右列承载面迁移到 DSH 原生右侧栏）之后，**右侧栏 tab 的中键关闭失效**；插件底部工作台的中键关闭仍然有效。

这不是插件回归，而是**宿主的 tab 条从未实现该手势**：

- 右侧栏由 `@deepseek-ai/dsh-client-ui-sidebar-right` + `@deepseek-ai/dsh-client-ui-dockkit` 渲染；dockkit 的 tab 元素只挂四个处理器：`onPointerDown`（`button!==2` → 拖拽跟踪）、`onClick`（激活）、`onKeyDown`（方向键 / Home / End / Enter / Space）、`onContextMenu`（右键菜单）；
- 全包只出现 React DOM 自身的 `auxclick` 字样，**没有任何 `button===1` 分支**，也没有键盘关闭绑定；
- 关闭入口只有两个：× 按钮（`data-dockkit-tab-close`）与右键菜单项（`data-dockkit-menu-close`）。

证据强度：运行中的 `dsh web` 服务的 `/assets/index-*.js` 与本地 `@deepseek-ai/dsh@0.1.5-rc.1` 安装包 **sha256 完全一致**（`e8719e727fee91f681ee1d885c6d204f2309c8a3bee9742825ce526ebe06ef73`），即分析的正是运行时代码。

## 方案

插件只渲染原生 tab 的**正文**与**标题 chip**，拿不到宿主的 chip 外壳，因此从 chip 补回手势：

1. `NativeTabTitle` 给 chip 打标记 `data-dsh-better-sidebar-native-tab="<native tab id>"`（归属 + 身份），并发布该 tab 自己的 `tab.actions.close()` —— 即宿主 × 按钮最终调用的 `navigator.closeIn(sessionId, tabId)`，**会话精确**，无需探测 `closeIn`，也不必对「能否关闭」另立一套判断；
2. `src/client/native/tab-middle-click.ts` 在**捕获阶段**监听 `pointerdown`/`mousedown`（配合 `pointerup`/`mouseup`）：按下落在插件 tab 上时 `preventDefault()`（关掉 Chrome 中键自动滚动）并 `stopPropagation()`（宿主的拖拽跟踪挂在 pointerdown 上，否则中键会变成拖 tab）；
3. **释放落在同一个 tab 内**才关闭（含 × 与标题两侧空白）；换位置释放、或漂移 > 4px（视为中键拖拽）→ 取消。与 `TabBar.tsx`、VS Code、Chrome 的语义一致；
4. **热区**：条带 tab 元素，或**浮动面板的表头**；绝不含面板正文（终端/网页里中键是粘贴/后台打开）；宿主自己不渲染关闭控件（`canCloseTab` 为假）的 tab 直接跳过；
5. 宿主 tab（内置指南、文档预览）没有标记 → 完全不碰：不 `preventDefault`、不 `stopPropagation`；
6. 控制器每次客户端激活新建（非模块单例），随 `registerNativeSurface` 的 disposer 一起 `dispose()`，不在文档上留悬挂监听。

## 验证

- **单测** `tests/native-tab-middle-click.spec.tsx`（14 例）：归属、释放语义、漂移取消、单次结算、宿主 tab 不受影响、左键不受影响、浮动表头 vs 正文、宿主拒绝关闭时跳过、动作发布/撤回、`dispose` 解绑、`NativeTabTitle` 集成与标题跟随记录。
- **真机**（`dsh 0.1.5-rc.1` + 真实 `dsh web` + 真实 Chromium）：从插件文件树打开种子文件后对该 tab 发真实中键点击 → 宿主 store 里 tab 消失、`pageErrors=[]`。
- `tsc --noEmit` / `eslint .` 干净；全量单测 123 文件 / 1226 例通过（`agent-pty`、`smoke` 两个 pty 文件在本机沙箱内失败，干净 `main` 上同样失败，与本改动无关）。
- mount lane 新增断言：真实宿主里中键关闭真实 tab。整条 lane 在本机沙箱跑不完（服务器开终端 tab 时以 `libc++abi: Napi::Error` 崩溃，干净 `main` 同样崩），完整 lane 交给 CI。

## 风险与边界

- 依赖宿主的两个 data 属性（`data-dockkit-tab` / `data-dockkit-float-grip`）与关闭控件标记；上游若改结构，退化行为是「仅 chip 本身可关」，不会误伤宿主 tab。
- 宿主自己的手势完全不变：左键激活、拖拽排序、右键菜单、方向键焦点。
- 标题槽未渲染的类型没有标记 → 中键无动作（当前插件每个 tab 类型都注册了 title）。

## 文档

- 指南 §0 行为差异表新增「tab 条手势」一行；
- README / README_EN 快捷键表补「DSH 原生右侧栏与底部工作台通用」；
- 设计记录 `docs/plans/2026-09-10-native-tab-middle-click.md`。
