### PR TITLE
fix(native): land a browser tab's URL seed in `path`, not only `meta.url`

### DIFF
--- a/src/client/native/index.ts
+++ b/src/client/native/index.ts
@@ -53,6 +53,15 @@ const EDITOR_KIND = 'editor'
 /** The built-in page kind this plugin takes over. */
 const FILES_KIND = 'files'
 
+/**
+ * The descriptor whose tab navigates to a URL. Its open seed arrives as
+ * `navigation.params.url`, while the view reads — and the session state
+ * persists — `tab.path`, so the descriptor needs the mapping declared below;
+ * without it the seed stops at `meta.url` and the tab opens with an empty
+ * address bar.
+ */
+const BROWSER_KIND = 'browser'
+
 /** The plugin's implementation id for a descriptor (unique across kinds). */
 function nativeId(descriptorId: string): string {
   return `dsh-better-sidebar:${descriptorId}`
@@ -61,6 +70,20 @@ function nativeId(descriptorId: string): string {
 /** The descriptor's title text, evaluated fresh for the current locale. */
 function titleOf(descriptor: TabDescriptor): string {
   return typeof descriptor.title === 'function' ? descriptor.title() : descriptor.title
+}
+
+/**
+ * The URL a browser tab's record carries in its `meta`, when it has one.
+ * `meta.url` is where a native open stores the seed (`tab-adapter` keeps a
+ * navigation's `url` there), so reading it back is what makes an already-open
+ * or persisted tab render instead of showing an empty browser.
+ * @param meta - the native record's custom state.
+ * @returns the URL, or `undefined` when the record carries none.
+ */
+function urlOfMeta(meta: unknown): string | undefined {
+  if (typeof meta !== 'object' || meta === null) return undefined
+  const url = (meta as { url?: unknown }).url
+  return typeof url === 'string' && url !== '' ? url : undefined
 }
 
 /**
@@ -147,6 +170,18 @@ export function registerNativeSurface(deps: NativeSurfaceDeps): () => void {
       const address = parseFileAddress(info.tab.contentId)
       return address !== undefined && address.scope === 'session' ? address.sessionId : undefined
     }
+    /**
+     * The browser tab's open seed, mapped to the field its view reads: the
+     * seed arrives as `params.url` (how `openTab({ type, url })` and the
+     * agent/`sidebar_open` flow address it), and `BrowserView` mounts from
+     * `tab.path`. Declaring `path` also keeps a reload working, because the
+     * record's `path` is the field the session state persists.
+     */
+    const browserParamsOf = (info: NativeTabInfo): NativeTabParams | undefined => {
+      const params = info.tab.navigation.params
+      const url = params?.url ?? urlOfMeta(params?.meta)
+      return url === undefined ? undefined : { path: url }
+    }
 
     /** Register the body + chip-title slots for one native implementation id. */
     const registerSlots = (
@@ -204,7 +239,9 @@ export function registerNativeSurface(deps: NativeSurfaceDeps): () => void {
       const slots = registerSlots(
         id,
         { ctx, store, service, records, descriptorId: descriptor.id },
-        isEditor ? { paramsOf: fileParamsOf, sessionIdOf: fileSessionIdOf } : {},
+        isEditor
+          ? { paramsOf: fileParamsOf, sessionIdOf: fileSessionIdOf }
+          : descriptor.id === BROWSER_KIND ? { paramsOf: browserParamsOf } : {},
       )
       return () => {
         for (const dispose of slots.reverse()) dispose()

--- a/tests/native-surface.spec.ts
+++ b/tests/native-surface.spec.ts
@@ -255,6 +255,79 @@ describe('registerNativeSurface lifecycle (service-driven registration)', () => 
   })
 })
 
+describe('browser tab open seed reaches the view', () => {
+  it('maps a native open\'s `params.url` onto the tab `path` the view reads', () => {
+    // Regression: an open performed with `openTab({ type: 'browser', url })`
+    // (the chat link takeover, and the model-facing `sidebar_open` tool) rides
+    // the native record as `navigation.params.url`, while `BrowserView` mounts
+    // from `tab.path`. Without the descriptor's `paramsOf` the seed stopped at
+    // `meta.url` and the tab opened with an EMPTY address bar and no iframe —
+    // the tab was simply titled with the hostname and showed nothing. Verified
+    // against a real profile: filling the address bar by hand loaded the page,
+    // the open itself did not.
+    const store = createSidebarStore()
+    store.setSession('s1')
+    const service = createBetterSidebarService(store)
+    service.registerTab({ id: 'browser', title: 'Browser', component: () => null })
+    const records = createNativeTabRecords()
+
+    // Capture the props the slot injector hands the body, so the assertion
+    // runs the SAME `paramsOf` the surface registered. The seed lives on the
+    // registration's `inject` thunk (evaluated per session), not on the
+    // options object itself.
+    const injects = new Map<string, (sessionId: string) => Record<string, unknown>>()
+    const registry = { current: undefined as undefined | { register: (definition: { id: string; kind: string; title: (address: string) => string }) => () => void } }
+    let runInjected: (() => void) | undefined
+    const ctx = {
+      inject: (_deps: readonly string[], callback: (injected: { get: () => unknown }) => void) => {
+        runInjected = () => { callback({ get: () => registry.current }) }
+        return { dispose: () => { runInjected = undefined } }
+      },
+      get: () => registry.current,
+      slots: {
+        inject: (_key: string, callback: () => () => void) => callback(),
+        register: (options: { name: string; key?: string; inject?: (sessionId: string) => Record<string, unknown> }) => {
+          if (options.name === 'sidebar.right.pane.tab' && options.inject !== undefined) {
+            injects.set(options.key ?? options.name, options.inject)
+          }
+          return () => {}
+        },
+      },
+    }
+    registerNativeSurface({ ctx: ctx as never, store, service, records })
+    registry.current = { register: () => () => {} }
+    runInjected?.()
+
+    // The body's injector is what computes the seed; replay it with a record
+    // shaped exactly like one the native surface produces for a URL open.
+    const injected = injects.get('dsh-better-sidebar:browser')?.('s1') as
+      { paramsOf?: (info: unknown) => { path?: string } | undefined } | undefined
+    expect(injected?.paramsOf, 'the browser descriptor must declare a paramsOf').toBeDefined()
+    const info = {
+      tab: {
+        id: 'native-b1',
+        kind: 'browser',
+        title: 'example.com',
+        contentId: 'sidebar://browser',
+        visible: true,
+        navigation: { address: 'sidebar://browser', params: { url: 'https://example.com/x' }, revision: 0 },
+        signal: new AbortController().signal,
+      },
+    }
+    expect(injected!.paramsOf!(info)).toEqual({ path: 'https://example.com/x' })
+    // A record seeded before this mapping existed keeps its URL in `meta.url`;
+    // it must still render rather than come back empty.
+    const legacy = {
+      tab: { ...info.tab, navigation: { address: 'sidebar://browser', params: { meta: { url: 'https://legacy.test/y' } }, revision: 0 } },
+    }
+    expect(injected!.paramsOf!(legacy)).toEqual({ path: 'https://legacy.test/y' })
+    // A tab with neither seed yields nothing, so a fresh browser tab still
+    // opens on its empty "enter a URL" state.
+    const bare = { tab: { ...info.tab, navigation: { address: 'sidebar://browser', params: undefined, revision: 0 } } }
+    expect(injected!.paramsOf!(bare)).toBeUndefined()
+  })
+})
+
 describe('NativeTabBody full-height host wrapper', () => {
   it('renders the descriptor component inside the [data-dsh-native-tab-host] wrapper', () => {
     // DSH's native tab body host (`.paneBody`) is a BLOCK scroller with a


### PR DESCRIPTION
# fix(native): land a browser tab's URL seed in `path`, not only `meta.url`

## Symptom

Opening a URL into the sidebar — by clicking an external link in the chat, or
through the model-facing `sidebar_open` tool — creates a sidebar tab that is
titled with the target hostname but shows **nothing**: the address bar is
empty and no iframe mounts.

Filling the same URL into that tab's own address bar loads the page
immediately, so the browser view and the link takeover are both fine — the
open plumbing is what loses the URL.

Reproduced on a real profile: `dsh-better-sidebar@0.19.0` + DSH `0.1.5-rc.1`,
plain web UI, native right Sidebar.

## Cause

An open performed with `openTab({ type: 'browser', url })` carries the seed as
`navigation.params.url`, and `src/client/native/tab-adapter.tsx` stores a
navigation's `url` into the record's **`meta.url`**:

```ts
if (params?.url !== undefined) {
  patch.meta = { ...meta, url: params.url }
}
```

`BrowserView` mounts from a different field, `tab.path`:

```ts
const [url, setUrl] = useState<string | undefined>(tab.path)
```

Only a file open had a mapping between the two worlds — `registerDescriptor`
passes `paramsOf: fileParamsOf` for the editor, which turns a file address
into `{ path }`. A browser open had none, so the seed stopped at `meta.url`
and never reached the field the view (and the persisted session state) reads.

## Fix

Give the `browser` descriptor the same kind of `paramsOf` mapping the editor
already has:

```ts
const browserParamsOf = (info: NativeTabInfo): NativeTabParams | undefined => {
  const params = info.tab.navigation.params
  const url = params?.url ?? urlOfMeta(params?.meta)
  return url === undefined ? undefined : { path: url }
}
```

The `meta.url` fallback covers a tab that was opened (or persisted) before this
change: its seed is already sitting in `meta`, and it should start rendering
instead of staying empty.

## Test

`tests/native-surface.spec.ts` gains a regression test that drives the **real**
`registerNativeSurface` registration, replays the body's `inject` thunk, and
asserts the mapping for three records:

- a URL open (`params.url`) → `{ path }`,
- a legacy record whose seed is only `meta.url` → `{ path }`,
- a bare tab with neither → `undefined` (a fresh browser tab still opens on its
  empty "enter a URL" state).

The test fails on `main` with `the browser descriptor must declare a paramsOf`,
and passes with the fix.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm vitest run tests/native-surface.spec.ts` — 14/14
- `pnpm test` — 1313 passed, 1 failure in `tests/fs-operations.spec.ts`
  (upload-symlink teardown) that is **pre-existing**: measured identical in a
  worktree at the parent commit `0a2f1ac`.
- End-to-end on a real profile with the patched bundle: clicking an external
  https link now yields a sidebar tab titled `example.com` with the address bar
  at `https://example.com/...` and the iframe mounted, and **no new browser
  tab**; `sidebar_open` behaves the same for a loopback URL.
