### PR TITLE
fix(test): 等待 needle 不再出现在 skip 用例自己起的 shell 命令里（main 转绿）

### DIFF
--- a/tests/agent-pty.spec.ts
+++ b/tests/agent-pty.spec.ts
@@ -22,17 +22,37 @@ function testShell(): string {
   return process.platform === 'win32' ? 'powershell.exe' : '/bin/sh'
 }
 
+/**
+ * Wait for a freshly spawned shell to have produced ANY output.
+ *
+ * The alternative — waiting for a string the prepared command prints — ties
+ * the test to shell wording, and waiting for a string the command CONTAINS is
+ * worse: an interactive shell echoes what is written to it (PowerShell does,
+ * POSIX /bin/sh does not), so the needle would already be in the transcript
+ * before the point the test means to exercise. The suites that only need "the
+ * shell is up" therefore wait for output of any kind.
+ * @param registry - the registry under test.
+ * @param uuid - the terminal to watch.
+ * @returns nothing; the caller asserts straight after.
+ */
+async function waitForShellReady(registry: AgentPtyRegistry, uuid: string): Promise<void> {
+  await waitForTranscript(registry, uuid, '', 0, true)
+}
+
 /** Wait for a terminal's transcript to contain a substring (or timeout). */
 async function waitForTranscript(
   registry: AgentPtyRegistry,
   uuid: string,
   needle: string,
   timeoutMs = 15_000,
+  anyOutput = false,
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     const handle = registry.get(uuid)
-    if (handle !== undefined && handle.transcript.includes(needle)) return handle.transcript
+    if (handle !== undefined) {
+      if (anyOutput ? handle.transcript.length > 0 : handle.transcript.includes(needle)) return handle.transcript
+    }
     await new Promise(resolve => setTimeout(resolve, 50))
   }
   const handle = registry.get(uuid)
@@ -405,8 +425,15 @@ describe('AgentPtyRegistry', { timeout: 30_000 }, () => {
   it('waitFor returns skipped when the user skips from the sidebar', async () => {
     const registry = new AgentPtyRegistry(testShell())
     try {
-      const uuid = registry.create('s1', 'skip-test', 'echo skip-ready', process.cwd(), 80, 24)
-      await waitForTranscript(registry, uuid, 'skip-ready')
+      // A BARE shell, and the wait needle appears nowhere in its preparation:
+      // an interactive shell echoes what is written to it, so a command that
+      // spelled the needle would already have put it in the transcript before
+      // this point — waitFor's fast path would resolve the wait and there
+      // would be nothing left to skip. POSIX /bin/sh does not echo a command
+      // written to a non-tty and hid this for a long time; PowerShell does,
+      // which is why it only ever failed on Windows.
+      const uuid = registry.create('s1', 'skip-test', '', process.cwd(), 80, 24)
+      await waitForShellReady(registry, uuid)
       // waitFor registers its record synchronously (before the first poll
       // await), so the skip can fire immediately after the call.
       const waitPromise = registry.waitFor(uuid, 'NEVER_APPEARS_XYZ', 30_000)
@@ -424,8 +451,10 @@ describe('AgentPtyRegistry', { timeout: 30_000 }, () => {
   it('snapshot exposes waiting while a wait is active and clears after it ends', async () => {
     const registry = new AgentPtyRegistry(testShell())
     try {
-      const uuid = registry.create('s1', 'wait-snap', 'echo snap-ready', process.cwd(), 80, 24)
-      await waitForTranscript(registry, uuid, 'snap-ready')
+      // Same echo hazard as the skip case above: a bare shell puts no needle
+      // in the transcript on its own.
+      const uuid = registry.create('s1', 'wait-snap', '', process.cwd(), 80, 24)
+      await waitForShellReady(registry, uuid)
       const waitPromise = registry.waitFor(uuid, 'LATER_MARK_9', 30_000)
       // Registration happens synchronously before waitFor's first await.
       expect(registry.list('s1')[0]?.waiting?.needle).toBe('LATER_MARK_9')
@@ -467,8 +496,10 @@ describe('AgentPtyRegistry', { timeout: 30_000 }, () => {
   it('fires change listeners when a wait starts and ends', async () => {
     const registry = new AgentPtyRegistry(testShell())
     try {
-      const uuid = registry.create('s1', 'watched-wait', 'echo notify-ready', process.cwd(), 80, 24)
-      await waitForTranscript(registry, uuid, 'notify-ready')
+      // Same echo hazard as the skip case above: a bare shell puts no needle
+      // in the transcript on its own.
+      const uuid = registry.create('s1', 'watched-wait', '', process.cwd(), 80, 24)
+      await waitForShellReady(registry, uuid)
       let changes = 0
       const unsubscribe = registry.subscribe(() => { changes += 1 })
       const waitPromise = registry.waitFor(uuid, 'NEVER_NOTIFY_1', 30_000)


### PR DESCRIPTION
## 问题

合并 #626 后 `main` 的 `ci-windows` 变红（run 34579312780）：`tests/agent-pty.spec.ts:413` 断言 `skipWait` 返回 1，实际得到 0。

根因在**测试自己的准备动作**，不在注册表：

- 交互式 shell 会**回显**写入的命令；
- 三个 skip 类用例打开的终端所执行的命令里**含等待 needle**（`NEVER_APPEARS_XYZ` 等）；
- 于是 `waitFor` 运行前 needle 已经在 transcript 里，`waitFor` 的**快路径**立即解析，`skipWait` 自然找不到可跳过的等待。

POSIX `/bin/sh` 对非 tty 写入不回显，所以这个隐患与测试套件同龄、只是**只在 Windows 上暴露**（PowerShell 会回显）；也正因为它依赖 shell 行为，之前五连绿也没抓到。

## 修法

三个用例（skip / waiting 快照 / 等待通知）改为开 **bare shell**，并用新增的 `waitForShellReady` 等「shell 起来了」（transcript 有任意输出），不再等某个打印出来的标记——两半隐患一起消除：命令里没有 needle，也不依赖某个 shell 启动时打印什么词。断言本身一字未改（它们考的是注册表的等待记账，只需一个活着的终端）。

## 验证

- `tests/agent-pty.spec.ts` 33 passed（三个用例现在毫秒级完成，不再空等 transcript 轮询）；
- 全量 `pnpm test` **127 files / 1343 passed / 9 skipped**；`pnpm typecheck` / `pnpm lint` 绿。