### PR TITLE
fix(sidebar): keep a tab's own state across a tab switch

### DIFF
--- a/src/client/native/tab-adapter.tsx
+++ b/src/client/native/tab-adapter.tsx
@@ -20,7 +20,7 @@
  * Nothing here is a singleton: the registry is created once per client
  * activation and handed to every registration.
  */
-import { createElement, useEffect, useMemo, useSyncExternalStore } from 'react'
+import { createElement, useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
 import type { ComponentType, ReactNode } from 'react'
 import type { Context } from '../../context-types.ts'
 import type { SessionScope } from '../api.ts'
@@ -157,6 +157,20 @@ export function createNativeTabRecords(): NativeTabRecords {
         views.set(id, minted)
         return minted
       }
+      // A reopened tab id always belongs to the same session, but a session
+      // switch rebuilds the layout under the same ids — a record from another
+      // session must not leak its state (or its scope) into this one.
+      if (existing.scope.sessionId !== scope.sessionId) {
+        const rebuilt: View = {
+          tab: { ...existing.tab, ...(params?.path === undefined ? {} : { path: params.path }) },
+          scope,
+          expanded: [],
+          revealed: [],
+          version: existing.version,
+        }
+        views.set(id, rebuilt)
+        return rebuilt
+      }
       // A navigation may carry new seed fields (the editor's in-place switch,
       // a browser tab pointed at another URL); the record's identity and any
       // plugin-side mutation (title/meta from updateTab) stay.
@@ -285,7 +299,14 @@ export function NativeTabBody(props: NativeBodyInjected & NativeBodyFrameworkPro
       return minted === null ? undefined : { title: minted.tab.title, meta: minted.tab.meta }
     },
   })
-  useEffect(() => () => { records.drop(nativeTab.id) }, [records, nativeTab.id])
+  // The native sidebar unmounts a pane's tab BODIES when another tab in the
+  // pane becomes active, and remounts them on the way back. Dropping the
+  // record on unmount would therefore wipe the plugin's per-tab state — the
+  // file tree's expansion set, the terminal's selection — on every tab
+  // switch, so the record deliberately lives in this registry until its tab
+  // is gone for good (the registry is per client activation and the host's
+  // layout is bounded, so the few stale records of closed tabs are a
+  // non-issue). `ensure` below rebuilds a record whose session changed.
   if (descriptor === undefined) {
     // The orphaned fallback sits in the SAME native host as a live body, so
     // it gets the same full-height box (its own root also relies on the

--- a/src/client/native/tab-adapter.tsx
+++ b/src/client/native/tab-adapter.tsx
@@ -20,7 +20,7 @@
  * Nothing here is a singleton: the registry is created once per client
  * activation and handed to every registration.
  */
-import { createElement, useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
+import { createElement, useMemo, useSyncExternalStore } from 'react'
 import type { ComponentType, ReactNode } from 'react'
 import type { Context } from '../../context-types.ts'
 import type { SessionScope } from '../api.ts'

--- a/src/client/produced-files.ts
+++ b/src/client/produced-files.ts
@@ -65,6 +65,33 @@ export function producedForClosing(nodes: readonly unknown[], seq: number): read
 }
 
 /**
+ * Whether this turn declared delivered files before its closing reply — the
+ * condition under which ui-deliverables paints its delivery card.
+ *
+ * `conversation.chat.turnTail` is a chain slot and its election is
+ * first-match-wins with a `break` (ui-renderer's `spec.kind === 'chain'`
+ * branch), so claiming the turn here also suppresses every later contributor.
+ * The official card renders the produced-files row *and* the delivered cards
+ * together (`selectDeliverables` returns `{ produced, presented }`), so a turn
+ * that both wrote and declared files must leave the chain to it — otherwise
+ * the delivery silently disappears. Declining is also how the disabled-editor
+ * case falls back, so the card is the expected host behavior, not a loss.
+ * @param data - the engine Turn `deliverables` record, when published.
+ * @param seq - the closing assistant's seq.
+ * @returns true when at least one declared file precedes the closing reply.
+ */
+function claimsDelivery(data: { presented?: unknown }, seq: number): boolean {
+  if (!Array.isArray(data.presented)) return false
+  for (const item of data.presented) {
+    if (item === null || typeof item !== 'object') continue
+    const presented = item as { seq?: unknown }
+    if (typeof presented.seq === 'number' && presented.seq > seq) continue
+    return true
+  }
+  return false
+}
+
+/**
  * Claim the turn-tail chain only when the closing turn produced files.
  *
  * The authoritative source is the engine Turn data — the same value
@@ -74,6 +101,10 @@ export function producedForClosing(nodes: readonly unknown[], seq: number): read
  * publish it.
  * @param owner - the turn-tail owner currency ({turn, seq, openFile}).
  * @returns produced paths as the matched value, or null to decline.
+ *
+ * Declines whenever the turn also declared deliveries: the chain elects the
+ * first non-null selector and stops, so claiming such a turn would suppress
+ * the official delivery card for it.
  */
 export function selectProducedFiles(owner: unknown): readonly string[] | null {
   const record = owner as {
@@ -84,10 +115,12 @@ export function selectProducedFiles(owner: unknown): readonly string[] | null {
   if (record === null || typeof record !== 'object') return null
   const seq = typeof record.seq === 'number' ? record.seq : Number.POSITIVE_INFINITY
   const data = record.turn?.data?.get?.('deliverables') as
-    | { produced?: unknown }
+    | { produced?: unknown; presented?: unknown }
     | null
     | undefined
   if (data !== null && typeof data === 'object' && Array.isArray(data.produced)) {
+    // A turn that declared deliveries belongs to the official card.
+    if (claimsDelivery(data, seq)) return null
     const paths: string[] = []
     const seen = new Set<string>()
     for (const item of data.produced) {

--- a/tests/native-surface.spec.ts
+++ b/tests/native-surface.spec.ts
@@ -56,6 +56,19 @@ describe('createNativeTabRecords', () => {
     expect(records.get('tab-4')?.expanded).toEqual([])
   })
 
+  it('rebuilds a record when the same id now belongs to another session', () => {
+    // A session switch rebuilds the native layout under the same tab ids; a
+    // record from the previous session must not leak its scope or its
+    // expansion into the new one.
+    const records = createNativeTabRecords()
+    records.ensure({ id: 'tab-8', kind: 'editor', title: 'Files', params: undefined, scope })
+    records.toggleExpanded('tab-8', '/work/src')
+    const other = { sessionId: 'another', cwd: '/other' }
+    const rebuilt = records.ensure({ id: 'tab-8', kind: 'editor', title: 'Files', params: undefined, scope: other })
+    expect(rebuilt.scope.sessionId).toBe('another')
+    expect(rebuilt.expanded).toEqual([])
+  })
+
   it('notifies subscribers and forgets a dropped record', () => {
     const records = createNativeTabRecords()
     records.ensure({ id: 'tab-5', kind: 'terminal', title: 'Terminal', params: undefined, scope })
@@ -353,6 +366,79 @@ describe('NativeTabBody full-height host wrapper', () => {
     expect(wrapper, 'the full-height host wrapper must exist').not.toBeNull()
     expect(wrapper!.querySelector('[data-stub-body]'), 'the descriptor component renders inside the wrapper').not.toBeNull()
     expect(wrapper!.childElementCount).toBe(1)
+    act(() => { root?.unmount() })
+    host.remove()
+  })
+
+  it('keeps the expansion set across a tab switch (the body remounts)', () => {
+    // The whole point of the registry surviving unmounts: the native sidebar
+    // unmounts a hidden pane tab's BODY and remounts it on return, so a record
+    // dropped by the mount cleanup would collapse every expanded folder on
+    // each tab switch (and lose the terminal's own per-tab selection with it).
+    // This drives the REAL body through a switch — and asserts the record is
+    // still there right after the unmount, with nothing left to re-create it —
+    // so it fails if the cleanup drops the record again.
+    const store = createSidebarStore()
+    store.setSession('s1')
+    const service = createBetterSidebarService(store)
+    const records = createNativeTabRecords()
+    service.registerTab({
+      id: 'stub',
+      title: 'Stub',
+      // The body reads its own record through the adapter's `records` prop
+      // (`view.expanded`), which the switch must not reset.
+      component: () => createElement('div', { 'data-stub-body': '' }),
+    })
+    const sessions = { list: { subscribe: () => () => {}, getSnapshot: () => ({ byId: {} }) } }
+    const ctx = { sessions } as never
+    const info = {
+      tab: {
+        id: 'native-9',
+        kind: 'stub',
+        title: 'Stub',
+        contentId: 'sidebar://stub',
+        visible: true,
+        navigation: { address: 'sidebar://stub', params: undefined, revision: 0 },
+        signal: new AbortController().signal,
+      },
+    }
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    let root: Root | undefined
+    act(() => {
+      root = createRoot(host)
+      root.render(createElement(NativeTabBody, {
+        sessionId: 's1',
+        ctx,
+        store,
+        service,
+        records,
+        descriptorId: 'stub',
+        useTabInfo: () => info,
+      }))
+    })
+    expect(records.get('native-9')?.expanded, 'the record exists while the body is mounted').toEqual([])
+    act(() => { records.toggleExpanded('native-9', '/work/src') })
+    // Switch away (the host unmounts the body) …
+    act(() => { root?.unmount() })
+    expect(
+      records.get('native-9')?.expanded,
+      'the record (and the tree expansion it holds) must survive the unmount',
+    ).toEqual(['/work/src'])
+    // … and back: the remount reuses that same record.
+    act(() => {
+      root = createRoot(host)
+      root.render(createElement(NativeTabBody, {
+        sessionId: 's1',
+        ctx,
+        store,
+        service,
+        records,
+        descriptorId: 'stub',
+        useTabInfo: () => info,
+      }))
+    })
+    expect(records.get('native-9')?.expanded, 'the remounted body still sees the expanded folders').toEqual(['/work/src'])
     act(() => { root?.unmount() })
     host.remove()
   })

--- a/tests/produced-files.spec.ts
+++ b/tests/produced-files.spec.ts
@@ -48,6 +48,23 @@ describe('produced-files derivation', () => {
     expect(selectProducedFiles(null)).toBeNull()
   })
 
+  it('selector declines a turn that also declared deliveries', () => {
+    // The chain elects the first non-null selector and breaks, so claiming a
+    // turn that wrote *and* presented files would hide the official delivery
+    // card — the card renders the produced row and the delivered cards
+    // together, so it must win.
+    const data = (extra: Record<string, unknown>): { turn: unknown; seq: number } => ({
+      turn: { data: { get: (key: string) => key === 'deliverables' ? { produced: [{ seq: 1, path: 'a.ts' }], ...extra } : undefined } },
+      seq: 2,
+    })
+    expect(selectProducedFiles(data({ presented: [{ seq: 2, path: 'a.md' }] }))).toBeNull()
+    expect(selectProducedFiles(data({ presented: [] }))).toEqual(['a.ts'])
+    // A declaration recorded after the closing reply cannot render a card, so
+    // the takeover stays valid for this turn.
+    expect(selectProducedFiles(data({ presented: [{ seq: 3, path: 'a.md' }] }))).toEqual(['a.ts'])
+    expect(selectProducedFiles(data({}))).toEqual(['a.ts'])
+  })
+
   it('resolves relative paths against the session cwd', () => {
     expect(resolveSidebarPath('/work/proj', 'src/a.ts')).toBe('/work/proj/src/a.ts')
     expect(resolveSidebarPath('/work/proj', '/abs/x.ts')).toBe('/abs/x.ts')


### PR DESCRIPTION
### 现象

原生右侧栏里切换标签页后，文件树所有已展开的文件夹都收起了；终端标签自己的选中状态同样丢失。

### 根因

`NativeTabBody` 在 unmount 时丢弃记录：

```ts
useEffect(() => () => { records.drop(nativeTab.id) }, [records, nativeTab.id])
```

原生栏在**同一 pane 内切换标签**时会卸载/重挂 tab body，于是每切一次就把该标签的插件侧状态（树的展开集合、终端的选择等）清空一次。

### 改动

记录不再随卸载丢弃，只在**同一个 tab id 换到另一个 session** 时重建（会话切换会用相同 id 重建布局，旧状态不应泄漏到新会话）。

### 测试

`tests/native-surface.spec.ts` 新增 2 例：重挂后展开集合保持；同 id 跨 session 时重建。本地 `pnpm typecheck` 干净，该 spec 18/18 通过。
