### PR TITLE
fix(turn-tail): leave a turn that declared deliveries to the delivery card

### DIFF
--- a/src/client/produced-files.ts
+++ b/src/client/produced-files.ts
@@ -65,6 +65,33 @@ export function producedForClosing(nodes: readonly unknown[], seq: number): read
 }
 
 /**
+ * Whether this turn declared delivered files before its closing reply — the
+ * condition under which ui-deliverables paints its delivery card.
+ *
+ * `conversation.chat.turnTail` is a chain slot and its election is
+ * first-match-wins with a `break` (ui-renderer's `spec.kind === 'chain'`
+ * branch), so claiming the turn here also suppresses every later contributor.
+ * The official card renders the produced-files row *and* the delivered cards
+ * together (`selectDeliverables` returns `{ produced, presented }`), so a turn
+ * that both wrote and declared files must leave the chain to it — otherwise
+ * the delivery silently disappears. Declining is also how the disabled-editor
+ * case falls back, so the card is the expected host behavior, not a loss.
+ * @param data - the engine Turn `deliverables` record, when published.
+ * @param seq - the closing assistant's seq.
+ * @returns true when at least one declared file precedes the closing reply.
+ */
+function claimsDelivery(data: { presented?: unknown }, seq: number): boolean {
+  if (!Array.isArray(data.presented)) return false
+  for (const item of data.presented) {
+    if (item === null || typeof item !== 'object') continue
+    const presented = item as { seq?: unknown }
+    if (typeof presented.seq === 'number' && presented.seq > seq) continue
+    return true
+  }
+  return false
+}
+
+/**
  * Claim the turn-tail chain only when the closing turn produced files.
  *
  * The authoritative source is the engine Turn data — the same value
@@ -74,6 +101,10 @@ export function producedForClosing(nodes: readonly unknown[], seq: number): read
  * publish it.
  * @param owner - the turn-tail owner currency ({turn, seq, openFile}).
  * @returns produced paths as the matched value, or null to decline.
+ *
+ * Declines whenever the turn also declared deliveries: the chain elects the
+ * first non-null selector and stops, so claiming such a turn would suppress
+ * the official delivery card for it.
  */
 export function selectProducedFiles(owner: unknown): readonly string[] | null {
   const record = owner as {
@@ -84,10 +115,12 @@ export function selectProducedFiles(owner: unknown): readonly string[] | null {
   if (record === null || typeof record !== 'object') return null
   const seq = typeof record.seq === 'number' ? record.seq : Number.POSITIVE_INFINITY
   const data = record.turn?.data?.get?.('deliverables') as
-    | { produced?: unknown }
+    | { produced?: unknown; presented?: unknown }
     | null
     | undefined
   if (data !== null && typeof data === 'object' && Array.isArray(data.produced)) {
+    // A turn that declared deliveries belongs to the official card.
+    if (claimsDelivery(data, seq)) return null
     const paths: string[] = []
     const seen = new Set<string>()
     for (const item of data.produced) {

--- a/tests/produced-files.spec.ts
+++ b/tests/produced-files.spec.ts
@@ -48,6 +48,23 @@ describe('produced-files derivation', () => {
     expect(selectProducedFiles(null)).toBeNull()
   })
 
+  it('selector declines a turn that also declared deliveries', () => {
+    // The chain elects the first non-null selector and breaks, so claiming a
+    // turn that wrote *and* presented files would hide the official delivery
+    // card — the card renders the produced row and the delivered cards
+    // together, so it must win.
+    const data = (extra: Record<string, unknown>): { turn: unknown; seq: number } => ({
+      turn: { data: { get: (key: string) => key === 'deliverables' ? { produced: [{ seq: 1, path: 'a.ts' }], ...extra } : undefined } },
+      seq: 2,
+    })
+    expect(selectProducedFiles(data({ presented: [{ seq: 2, path: 'a.md' }] }))).toBeNull()
+    expect(selectProducedFiles(data({ presented: [] }))).toEqual(['a.ts'])
+    // A declaration recorded after the closing reply cannot render a card, so
+    // the takeover stays valid for this turn.
+    expect(selectProducedFiles(data({ presented: [{ seq: 3, path: 'a.md' }] }))).toEqual(['a.ts'])
+    expect(selectProducedFiles(data({}))).toEqual(['a.ts'])
+  })
+
   it('resolves relative paths against the session cwd', () => {
     expect(resolveSidebarPath('/work/proj', 'src/a.ts')).toBe('/work/proj/src/a.ts')
     expect(resolveSidebarPath('/work/proj', '/abs/x.ts')).toBe('/abs/x.ts')


### PR DESCRIPTION
## 问题

**同一轮里既改代码又交付图片时，交付卡片整个消失。** 例如脚本出图后 `present` 它、顺手还改了脚本或文档——这是最常见的收尾方式——那个 `present` 出来的图片不会出现在这一轮的交付列表里。

根因在两份数据不一致：

- `conversation.chat.turnTail` 是 chain 槽，选举是**先命中先赢 + `break`**（ui-renderer `spec.kind === 'chain'` 分支）。本插件只要这一轮有写文件就抢占这个位置，官方交付卡片的注册者根本轮不到被咨询；
- 本插件的 chips 只读 `produced`（用户级即「本次产出」行，由 `write` / `edit` 类工具的改动路径累积），而脚本产出的图片这类文件是 `present` 声明的，只进 `presented`、不进 `produced`。

于是抢占之后这一轮只剩产出行，`presented` 无处渲染。官方卡片本来把两者一起渲染（`selectDeliverables` 返回 `{ produced, presented }`），所以这些交付不是没数据，是被本插件挡掉了。

## 修法

这一轮在收尾回复前声明过交付时，本插件主动退让：`selectProducedFiles` 返回 `null`，把位置还给官方卡片。判据与官方 `presentedForClosing` 一致（存在 `presented.seq < 收尾 seq` 的声明）——晚于收尾回复的声明本来也渲染不出卡片，不影响抢占。

这与已有的两个退让分支（editor tab 被设置禁用、侧栏被外部禁用）是同一条路径：官方卡片就是宿主预期行为，不是能力损失。

不改成「本插件自己把 `presented` 也画出来」：那要自己接管交付卡片的打开通道（`presentedFileUrl` 认证打开、原生「用默认应用打开」菜单、桌面可用性判定），面比让位大得多，且与宿主实现长期重复。

## 验证

`tests/produced-files.spec.ts` 新增用例，覆盖四种情形（有先前声明 → null；空声明 / 晚于收尾的声明 / 无 `presented` 字段 → 仍抢占）。

已实测反事实：把该用例跑在本 PR 之前的 `selectProducedFiles`（base blob `23a2f1ea`）上失败——返回 `['a.ts']`，即抢占发生、`presented` 被挡掉；打上补丁后通过。`pnpm typecheck` 通过。

## 代价

这类轮次的「本次产出」标签回到宿主行为：点开走宿主文件预览，不再是本插件的侧栏编辑器；「在文件夹中显示」也不再提供。其余轮次（仅改文件、仅交付）行为一字不变。

另外记录一条未处理项：`priority: -1` 在 chain 语义下不生效（选举不看 priority），本 PR 未改动。

不 fix [#390](https://github.com/omdsh-dev/DSH-better-sidebar/issues/390)：那条是「只产出文件」时第三方卡片被顶掉，本 PR 只让出「产出 + 声明交付」的轮次。
