### PR TITLE
fix(native): 原生 tab 记录按会话持有，并在 tab 切换间存活（#636 + #661）

### DIFF
--- a/docs/plans/2026-09-12-native-tab-record-ownership-fix.md
+++ b/docs/plans/2026-09-12-native-tab-record-ownership-fix.md
@@ -49,11 +49,11 @@
 
 - **回归守护（确定性）**：`tests/native-surface.spec.ts` 修复后 **25 passed**；把 `src/client/native/tab-adapter.tsx` + `surface.ts` 回退到 `origin/main` 后 **5 条红**，其中组件级那条的断言正是用户症状——`the entered session keeps a record of its own: expected false to be true`，另有 `the entering body does not inherit the leaving one's tree state`、`the live record survives the other body's teardown`。组件级用例刻意照抄宿主形状：外层 `div` 以 sessionId 作 key、内层 body 以同一 tab id 渲染，一次 `act` 完成「进入会话 render + 离开会话 unmount」。
 - **门槛**：`pnpm typecheck` / `pnpm lint` 干净。`pnpm test` = 127 files / **1319 passed** / 9 skipped / 33 failed——**这 33 条失败全部在 `tests/agent-pty.spec.ts` 与 `tests/smoke.spec.ts`，报 `posix_spawnp failed`（本机沙箱不允许 node-pty 起进程）**；把本次改动 stash 掉跑同样两个文件仍是同样 33 条红，与本次改动无关。
-- **未做**：真机 3080 部署验证（本地 profile 仍是 0.19.0 产物），留给 review / 发版流程。
+- **真机（用户执行）**：把 web profile 以 `link:` 指向本分支后，用户在本机 3080（Windows 浏览器经 LAN 隧道 `http://127.0.0.2:3080`）实测——**切换对话后文件浏览器照常响应，原先必现的「切进去失灵、切回来原来好的也一起失灵」未再出现**。该次链接只改了 profile 的依赖声明（`dsh-better-sidebar: link:/Users/y/workspace/dsh-better-sidebar`；pnpm 顺带移除了旧 npm 副本自带的 164 个依赖），其余插件与 `dsh.profile.bundles` 清单不变；实测完已按用户要求换回 npm `latest`（0.19.1，不含本修复）。
 
 ## 未覆盖（诚实记录）
 
-- 单测锁定的是宿主契约的**形状**（每会话计数 + 会话级 seat 按 sessionId 换 key，读的是 `0.1.5-rc.1` / `rc.2` 两个版本的产物，行为一致），**没有**在真实浏览器里端到端点过一次；真机复现步骤（两个新会话各开「文件」→ 确认两边 `data-dockkit-tab` 同号 → 连续切两次 → 点文件夹无反应 → 折叠/展开右侧栏即自愈）已写入 PR 描述。
+- 单测锁定的是宿主契约的**形状**（每会话计数 + 会话级 seat 按 sessionId 换 key，读的是 `0.1.5-rc.1` / `rc.2` 两个版本的产物，行为一致）。**浏览器里的端到端复现由用户先于本次修复完成**（复现步骤：两个新会话各开「文件」→ 确认两边 `data-dockkit-tab` 同号 → 连续切两次 → 点文件夹无反应 → 折叠/展开右侧栏即自愈），本次修复后的真机确认亦由用户执行；插件作者侧（我）没有独立跑过那条浏览器复现，确定性证据是上面的单测红/绿。
 - 记录表仍按 tab id 解析 `update/close/has`，语义是「当前存在的那条记录」；同上，宿主挂载模型是单会话面板，故无歧义。
 - 「离开会话记录被用过（version > 0）时那一次切换会自愈」是既有行为，本次不动：修复后不再有记录被误删，该分支不再产生失效，只是展开状态在会话间本就应当各自独立。
 

--- a/docs/plans/2026-09-12-native-tab-record-ownership-fix.md
+++ b/docs/plans/2026-09-12-native-tab-record-ownership-fix.md
@@ -1,0 +1,64 @@
+# 原生 tab 记录归属：切换对话后文件浏览器不再失效
+
+日期：2026-09-12　分支：`fix/native-tab-record-ownership`
+
+## 背景
+
+用户报告（真机复现，稳定）：**切换对话后，之前打开过的侧栏文件浏览器点文件夹 / 文件都没反应**，把该 tab 关掉重开才恢复；更关键的一步是——**切回原来那个会话，原本正常的文件浏览器也一起失效了**。合并模式（`editorExplorer: true`，用户本机设置）下，文件夹点击不展开、文件点击不原地切换；Network 面板里**一个请求都不发**（不是 403 / 路径围栏那类问题）。
+
+## 根因
+
+两方契约叠加出的一个「跨会话同 id 误删」：
+
+| 侧 | 事实 | 出处 |
+|---|---|---|
+| DSH 宿主 | 原生 tab id 由**每会话各自**的计数器铸造（`counting(0)`），前缀 `tab` → 每个会话里第一个 tab 都叫 `tab1`、第二个 `tab2`…… | `dsh-client-ui-sidebar-right/lib/client.js`（`createSurface()` → `counting(0)`）+ dockkit `planOpenContent` 的 `mint("tab")` |
+| DSH 宿主 | 右侧栏的会话级 seat 以 **sessionId 作 React key**（`StrictSessionEntry` 以 `}, binding.key)` 收尾）→ 切换对话 = **同一次 commit** 里「进入会话的子树 render + 离开会话的子树 unmount」 | `dsh-client-ui-renderer/lib/client.js` |
+| 本插件 | 合成记录表 `views` 只按**原生 tab id** 存；tab 体 unmount 时 `records.drop(id)` **不校验归属**；`versionOf(缺失) = 0` | `src/client/native/tab-adapter.tsx` |
+
+于是每次切换：
+
+1. 进入会话的 tab 体在 **render 阶段** `ensure('tabN')` —— 同号 → 直接**接管**离开会话那条记录；
+2. 同一次 commit 的 passive 清理里，离开会话的 tab 体执行 `drop('tabN')` → **把进入会话正在用的记录删掉**；
+3. 记录没了、而它当初是 v0（`versionOf` 0 → 0 快照不变）→ `useSyncExternalStore` 不重渲染 → `ensure` 不会重新铸记录；
+4. 此后所有经过注册表的点击都是**静默 no-op**：
+   - 文件夹：`onToggleDir` → `records.toggleExpanded(id, path)` → `views.get(id)` 为 undefined → 直接 return（不会发 `fs.tree`）；
+   - 文件（合并模式）：`EditorHost.openFile` → `updateTab(tab.id, …)` → `surface.update` 因 `records.has(tabId) === false` 返回 false → 回落插件底部面板 `patchTab`（该 id 不存在，同引用返回、连 notify 都没有，不会发 `fs.read`）。
+
+**自我维持**：第一次之后，每次切换都是「进入方 render 时新铸一条 v0 → 离开方 unmount 又把它删掉」，所以此后**每次切换进入的会话都是死的**——这正是用户看到的「切回来原来好的也没反应」。若离开会话的记录刚好被用过（version > 0），`N → 0` 是快照变化，会触发一次重渲染并自愈（只是展开状态被清空），这解释了「偶尔看起来是好的」。
+
+## 决策
+
+| # | 决策 | 理由 |
+|---|---|---|
+| 1 | 记录携带 **owner token**（每个 tab 体实例一个，`useRef` 持有） | 同 id 的两条记录必须能区分归属，否则任何一方都可能读/删对方的 |
+| 2 | `ensure` 遇到**别人的记录不接管、直接重建**（留在 `views` 里的是新 owner 的记录） | 会话切换时进入方 render 早于离开方清理；接管就等于把自己绑在一条马上会被删的记录上。顺带修掉「进入会话静默继承上一会话展开状态」 |
+| 3 | `drop(id, owner)` 只删自己那条；另开 `remove(id)` 表示「不看归属地强制删」 | 语义分开：body 生命周期 vs 宿主关闭 tab |
+| 4 | `surface.close(sessionId, tabId)` 先按 `record.scope.sessionId === sessionId` 判定再删 | 同一 id 也命名着别的会话的活 tab，无条件删会复现同一类故障 |
+| 5 | **不**改成 `sessionId + tabId` 复合键 | `SidebarSurface` 的 `update/close/has/activate` 公开签名都以 tabId 为参数，复合键要连带改一圈接入 API；而宿主同一时刻只挂载在屏会话的面板，单键 + 归属校验已足够（记录在案：若宿主将来同时挂载多会话面板，需要把 session 带进这些签名） |
+
+## 改动清单（子系统级）
+
+| 子系统 | 文件 | 变更 |
+|---|---|---|
+| 记录表 | `src/client/native/tab-adapter.tsx` | `View.owner`（body token）；`ensure` 收 `owner` 且**不接管**别人的记录（重建，静默——它跑在 render 里）；`drop(id, owner)` 归属校验 + 新增 `remove(id)`；`NativeTabBody` 用 `useRef` 造 token 并传入 `ensure` / 卸载清理；接口 docblock 记下「原生 id 每会话重名 + 会话级 seat 按 sessionId 换 key」这条宿主契约 |
+| 写入面 | `src/client/native/surface.ts` | `close()` 只在记录属于该会话时删（改用 `remove`） |
+| 测试 | `tests/native-surface.spec.ts` | 既有 19 条适配 `owner` 参数；**净增 6 条**：注册表级 3 条（不接管他人记录 / 只删自己的 / `remove` 强制删）、组件级 3 条（离开会话卸载不得删进入会话的记录 + 切回仍可用；进入会话不继承上一会话树状态；连续三次切换每次都可用） |
+
+## 验证
+
+- **回归守护（确定性）**：`tests/native-surface.spec.ts` 修复后 **25 passed**；把 `src/client/native/tab-adapter.tsx` + `surface.ts` 回退到 `origin/main` 后 **5 条红**，其中组件级那条的断言正是用户症状——`the entered session keeps a record of its own: expected false to be true`，另有 `the entering body does not inherit the leaving one's tree state`、`the live record survives the other body's teardown`。组件级用例刻意照抄宿主形状：外层 `div` 以 sessionId 作 key、内层 body 以同一 tab id 渲染，一次 `act` 完成「进入会话 render + 离开会话 unmount」。
+- **门槛**：`pnpm typecheck` / `pnpm lint` 干净。`pnpm test` = 127 files / **1319 passed** / 9 skipped / 33 failed——**这 33 条失败全部在 `tests/agent-pty.spec.ts` 与 `tests/smoke.spec.ts`，报 `posix_spawnp failed`（本机沙箱不允许 node-pty 起进程）**；把本次改动 stash 掉跑同样两个文件仍是同样 33 条红，与本次改动无关。
+- **未做**：真机 3080 部署验证（本地 profile 仍是 0.19.0 产物），留给 review / 发版流程。
+
+## 未覆盖（诚实记录）
+
+- 单测锁定的是宿主契约的**形状**（每会话计数 + 会话级 seat 按 sessionId 换 key，读的是 `0.1.5-rc.1` / `rc.2` 两个版本的产物，行为一致），**没有**在真实浏览器里端到端点过一次；真机复现步骤（两个新会话各开「文件」→ 确认两边 `data-dockkit-tab` 同号 → 连续切两次 → 点文件夹无反应 → 折叠/展开右侧栏即自愈）已写入 PR 描述。
+- 记录表仍按 tab id 解析 `update/close/has`，语义是「当前存在的那条记录」；同上，宿主挂载模型是单会话面板，故无歧义。
+- 「离开会话记录被用过（version > 0）时那一次切换会自愈」是既有行为，本次不动：修复后不再有记录被误删，该分支不再产生失效，只是展开状态在会话间本就应当各自独立。
+
+## 不做
+
+- 不改 DSH 源码（仓库硬约束 §1）。
+- 不改插件自绘底部工作台的记录语义（它按会话隔离持久化，不共享本记录表）。
+- 不新增设置项、不动 `TabDescriptor` / `ctx.betterSidebar` 的任何公开签名。

--- a/src/client/native/surface.ts
+++ b/src/client/native/surface.ts
@@ -123,7 +123,10 @@ export function createNativeSurface(ctx: Context, records: NativeTabRecords): Na
     close(sessionId, tabId) {
       const record = records.get(tabId)
       if (record === undefined) return undefined
-      records.drop(tabId)
+      // Only a record THIS session owns may be forgotten: native tab ids are
+      // minted per session, so the same id names another session's live tab
+      // too (removing that one would leave its body mounted but inert).
+      if (record.scope.sessionId === sessionId) records.remove(tabId)
       const api = controller()
       if (api !== undefined) {
         if (sessionId === activeSessionId(ctx)) api.close(tabId)

--- a/src/client/native/tab-adapter.tsx
+++ b/src/client/native/tab-adapter.tsx
@@ -20,7 +20,7 @@
  * Nothing here is a singleton: the registry is created once per client
  * activation and handed to every registration.
  */
-import { createElement, useEffect, useMemo, useSyncExternalStore } from 'react'
+import { createElement, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import type { ComponentType, ReactNode } from 'react'
 import type { Context } from '../../context-types.ts'
 import type { SessionScope } from '../api.ts'
@@ -81,6 +81,14 @@ interface View {
   revealed: string[]
   /** Bumped on every mutation; the components subscribe to it. */
   version: number
+  /**
+   * The tab body that minted this record. DSH mints native tab ids from a
+   * PER-SESSION counter, so every session's first tabs are all called `tab1`,
+   * `tab2`, … — two sessions' bodies therefore ensure the SAME id as a matter
+   * of course. The token keeps one body from reading (or deleting) a record
+   * that another body owns.
+   */
+  owner: object
 }
 
 /** The plugin-side record registry for native tabs. */
@@ -89,7 +97,13 @@ export interface NativeTabRecords {
    * The synthetic record for a native tab, minted on first sight and kept
    * across navigations (a navigation refreshes the seed fields, never the
    * identity or a plugin-side title/meta mutation).
-   * @param input - the native record and the session it lives in.
+   *
+   * A record belonging to ANOTHER body is never adopted: the same native tab
+   * id exists in every session, and DSH keys the session-scoped seat by
+   * session id, so a conversation switch renders the ENTERING session's body
+   * before the LEAVING session's body is deleted. Adopting there would hand
+   * this body a record the leaving body is about to drop (see `drop`).
+   * @param input - the native record, the session it lives in, and its body.
    * @returns the current view state.
    */
   ensure(input: {
@@ -98,6 +112,8 @@ export interface NativeTabRecords {
     title: string
     params: NativeTabParams | undefined
     scope: SessionScope
+    /** The ensuring tab body's identity token (one per body instance). */
+    owner: object
     /**
      * The descriptor's own factory, called ONCE for a record that arrives
      * without seed fields (a native guide open, which knows nothing about the
@@ -112,8 +128,17 @@ export interface NativeTabRecords {
   has(id: string): boolean
   /** Merge a patch into the synthetic record (the `updateTab` path). */
   update(id: string, patch: { title?: string; path?: string; meta?: unknown }): void
-  /** Forget a record (the native tab closed). */
-  drop(id: string): void
+  /**
+   * Forget the record this body owns (its body unmounted). A record owned by
+   * a DIFFERENT body is left strictly alone — that is what keeps an entering
+   * session's explorer alive when the leaving session's body unmounts right
+   * after it rendered.
+   * @param id - the native tab id.
+   * @param owner - the asking body; only its own record is removed.
+   */
+  drop(id: string, owner: object): void
+  /** Forget a record regardless of its owner (the host closed the tab). */
+  remove(id: string): void
   /** Toggle one directory in a record's expansion set. */
   toggleExpanded(id: string, path: string): void
   /** Mint the next instance number of a kind (titles like "Terminal 2"). */
@@ -135,9 +160,11 @@ export function createNativeTabRecords(): NativeTabRecords {
     notify()
   }
   return {
-    ensure({ id, kind, title, params, scope, mint }) {
+    ensure({ id, kind, title, params, scope, owner, mint }) {
       const existing = views.get(id)
-      if (existing === undefined) {
+      // A record owned by another body is not adopted, it is replaced: see
+      // the `ensure` contract. Silent by design — this runs during render.
+      if (existing === undefined || existing.owner !== owner) {
         const seeded = params?.title === undefined && params?.meta === undefined ? mint?.() : undefined
         const meta = params?.meta ?? seeded?.meta
         const minted: View = {
@@ -153,6 +180,7 @@ export function createNativeTabRecords(): NativeTabRecords {
           expanded: [],
           revealed: [],
           version: 0,
+          owner,
         }
         views.set(id, minted)
         return minted
@@ -185,7 +213,13 @@ export function createNativeTabRecords(): NativeTabRecords {
       if (entry === undefined) return
       put(id, { ...entry, tab: { ...entry.tab, ...patch } })
     },
-    drop(id) {
+    drop(id, owner) {
+      const entry = views.get(id)
+      if (entry === undefined || entry.owner !== owner) return
+      views.delete(id)
+      notify()
+    },
+    remove(id) {
       if (views.delete(id)) notify()
     },
     toggleExpanded(id, path) {
@@ -261,6 +295,17 @@ export function NativeTabBody(props: NativeBodyInjected & NativeBodyFrameworkPro
   const { ctx, store, service, records, descriptorId, useTabInfo } = props
   const info = useTabInfo()
   const nativeTab = info.tab
+  // This body instance's identity token (stable across its renders). Native
+  // tab ids restart in every session, so the record MUST carry who owns it:
+  // on a conversation switch the entering session's body renders before the
+  // leaving session's body unmounts, and an ownership-blind drop there would
+  // delete the record this body is rendering from — leaving the explorer
+  // mounted but inert (every click routed through the registry silently
+  // no-ops, because the missing record's version stays 0 and nothing
+  // re-renders to re-mint it).
+  const ownerRef = useRef<object | null>(null)
+  if (ownerRef.current === null) ownerRef.current = {}
+  const owner = ownerRef.current
   const version = useRecordVersion(records, nativeTab.id)
   const sessionId = props.sessionIdOf?.(info) ?? props.sessionId
   const cwd = useSessionCwd(ctx, sessionId)
@@ -278,6 +323,7 @@ export function NativeTabBody(props: NativeBodyInjected & NativeBodyFrameworkPro
     title: nativeTab.title,
     params,
     scope,
+    owner,
     mint: () => {
       const state = store.getSnapshot().state
       if (descriptor?.createTab === undefined || state === undefined) return undefined
@@ -285,7 +331,7 @@ export function NativeTabBody(props: NativeBodyInjected & NativeBodyFrameworkPro
       return minted === null ? undefined : { title: minted.tab.title, meta: minted.tab.meta }
     },
   })
-  useEffect(() => () => { records.drop(nativeTab.id) }, [records, nativeTab.id])
+  useEffect(() => () => { records.drop(nativeTab.id, owner) }, [records, nativeTab.id, owner])
   if (descriptor === undefined) {
     // The orphaned fallback sits in the SAME native host as a live body, so
     // it gets the same full-height box (its own root also relies on the

--- a/tests/native-surface.spec.ts
+++ b/tests/native-surface.spec.ts
@@ -10,16 +10,23 @@ import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react-dom/test-utils'
 import { createNativeTabRecords, NativeTabBody, NativeTabTitle } from '../src/client/native/tab-adapter.tsx'
 import { registerNativeSurface } from '../src/client/native/index.ts'
-import { createBetterSidebarService, type SidebarSurface } from '../src/client/service.ts'
+import { createBetterSidebarService, type SidebarSurface, type TabComponentProps } from '../src/client/service.ts'
 import { createSidebarStore, type SidebarTab } from '../src/client/state.ts'
 
 const scope = { sessionId: 's1', cwd: '/work' }
+/**
+ * One tab body's identity token. Every body instance mints its own; the
+ * registry never adopts — nor drops — a record another token owns, because
+ * DSH mints native tab ids per session (every session's first tabs are all
+ * called `tab1`, `tab2`, …).
+ */
+const owner = {}
 
 describe('createNativeTabRecords', () => {
   it('mints a synthetic tab from the native record + params', () => {
     const records = createNativeTabRecords()
     const view = records.ensure({
-      id: 'tab-1', kind: 'browser', title: 'Browser', params: { url: 'https://a.test', meta: { k: 1 } }, scope,
+      id: 'tab-1', kind: 'browser', title: 'Browser', params: { url: 'https://a.test', meta: { k: 1 } }, scope, owner,
     })
     expect(view.tab).toMatchObject({ id: 'tab-1', type: 'browser', title: 'Browser', meta: { k: 1 } })
     expect(view.scope).toBe(scope)
@@ -29,25 +36,25 @@ describe('createNativeTabRecords', () => {
   it('calls the descriptor factory once for a record that arrives without seed fields', () => {
     const records = createNativeTabRecords()
     const mint = vi.fn(() => ({ title: 'Side chat', meta: { autoCreate: true } }))
-    const view = records.ensure({ id: 'tab-2', kind: 'sidechat', title: 'Side Chat', params: undefined, scope, mint })
+    const view = records.ensure({ id: 'tab-2', kind: 'sidechat', title: 'Side Chat', params: undefined, scope, owner, mint })
     expect(mint).toHaveBeenCalledTimes(1)
     expect(view.tab).toMatchObject({ title: 'Side chat', meta: { autoCreate: true } })
     // A second render of the same record does not re-mint.
-    records.ensure({ id: 'tab-2', kind: 'sidechat', title: 'Side Chat', params: undefined, scope, mint })
+    records.ensure({ id: 'tab-2', kind: 'sidechat', title: 'Side Chat', params: undefined, scope, owner, mint })
     expect(mint).toHaveBeenCalledTimes(1)
   })
 
   it('refreshes the seed fields on navigation but keeps the record identity', () => {
     const records = createNativeTabRecords()
-    records.ensure({ id: 'tab-3', kind: 'editor', title: 'a.ts', params: { path: '/work/a.ts' }, scope })
+    records.ensure({ id: 'tab-3', kind: 'editor', title: 'a.ts', params: { path: '/work/a.ts' }, scope, owner })
     records.update('tab-3', { title: 'renamed.ts' })
-    const view = records.ensure({ id: 'tab-3', kind: 'editor', title: 'b.ts', params: { path: '/work/b.ts' }, scope })
+    const view = records.ensure({ id: 'tab-3', kind: 'editor', title: 'b.ts', params: { path: '/work/b.ts' }, scope, owner })
     expect(view.tab).toMatchObject({ id: 'tab-3', path: '/work/b.ts', title: 'renamed.ts' })
   })
 
   it('tracks expansion per record and bumps its version', () => {
     const records = createNativeTabRecords()
-    records.ensure({ id: 'tab-4', kind: 'editor', title: 'Files', params: undefined, scope })
+    records.ensure({ id: 'tab-4', kind: 'editor', title: 'Files', params: undefined, scope, owner })
     const before = records.versionOf('tab-4')
     records.toggleExpanded('tab-4', '/work/src')
     expect(records.get('tab-4')?.expanded).toEqual(['/work/src'])
@@ -58,18 +65,58 @@ describe('createNativeTabRecords', () => {
 
   it('notifies subscribers and forgets a dropped record', () => {
     const records = createNativeTabRecords()
-    records.ensure({ id: 'tab-5', kind: 'terminal', title: 'Terminal', params: undefined, scope })
+    records.ensure({ id: 'tab-5', kind: 'terminal', title: 'Terminal', params: undefined, scope, owner })
     const listener = vi.fn()
     const off = records.subscribe(listener)
     records.update('tab-5', { title: 'zsh' })
     expect(listener).toHaveBeenCalledTimes(1)
     expect(records.get('tab-5')?.tab.title).toBe('zsh')
-    records.drop('tab-5')
+    records.drop('tab-5', owner)
     expect(records.has('tab-5')).toBe(false)
     off()
-    records.ensure({ id: 'tab-6', kind: 'terminal', title: 'Terminal', params: undefined, scope })
+    records.ensure({ id: 'tab-6', kind: 'terminal', title: 'Terminal', params: undefined, scope, owner })
     records.update('tab-6', { title: 'x' })
     expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('never adopts a record another body owns (the same native id lives in every session)', () => {
+    const records = createNativeTabRecords()
+    const bodyA = {}
+    const bodyB = {}
+    records.ensure({ id: 'tab2', kind: 'editor', title: 'Files', params: undefined, scope, owner: bodyA })
+    records.toggleExpanded('tab2', '/work/src')
+
+    // DSH renders the entering session's body BEFORE deleting the leaving
+    // session's, and both ensure the same id — the entering body must get its
+    // OWN record instead of adopting the one that is about to be dropped.
+    const view = records.ensure({ id: 'tab2', kind: 'editor', title: 'Files', params: undefined, scope, owner: bodyB })
+    expect(view.expanded, 'the entering body does not inherit the leaving one’s tree state').toEqual([])
+    expect(records.get('tab2')?.owner).toBe(bodyB)
+  })
+
+  it('drops only the asking body’s record', () => {
+    const records = createNativeTabRecords()
+    const bodyA = {}
+    const bodyB = {}
+    records.ensure({ id: 'tab2', kind: 'editor', title: 'Files', params: undefined, scope, owner: bodyA })
+    records.ensure({ id: 'tab2', kind: 'editor', title: 'Files', params: undefined, scope, owner: bodyB })
+
+    // The leaving body's unmount cleanup must not touch the live record.
+    records.drop('tab2', bodyA)
+    expect(records.has('tab2'), 'the live record survives the other body’s teardown').toBe(true)
+    records.toggleExpanded('tab2', '/work/src')
+    expect(records.get('tab2')?.expanded).toEqual(['/work/src'])
+
+    records.drop('tab2', bodyB)
+    expect(records.has('tab2')).toBe(false)
+  })
+
+  it('removes a record regardless of owner (the host closed the tab)', () => {
+    const records = createNativeTabRecords()
+    const bodyA = {}
+    records.ensure({ id: 'tab2', kind: 'editor', title: 'Files', params: undefined, scope, owner: bodyA })
+    records.remove('tab2')
+    expect(records.has('tab2')).toBe(false)
   })
 })
 
@@ -416,7 +463,7 @@ describe('NativeTabTitle (the chip glyph)', () => {
       icon: (size: number) => createElement('i', { 'data-stub-icon': size }),
       component: () => createElement('div'),
     })
-    records.ensure({ id: 'chip-1', kind: 'stub-tab', title: 'Stub', params: undefined, scope })
+    records.ensure({ id: 'chip-1', kind: 'stub-tab', title: 'Stub', params: undefined, scope, owner })
 
     const { host, unmount } = renderTitle(records, service, nativeInfo('chip-1', 'stub-tab', 'Stub'), 'stub-tab')
     const chip = host.querySelector('[aria-hidden="true"]')
@@ -442,6 +489,7 @@ describe('NativeTabTitle (the chip glyph)', () => {
       title: 'notes.md',
       params: { path: '/work/notes.md' },
       scope,
+      owner,
     })
 
     const { host, unmount } = renderTitle(records, service, nativeInfo('chip-2', 'editor', 'notes.md'), 'editor')
@@ -457,11 +505,138 @@ describe('NativeTabTitle (the chip glyph)', () => {
   it('falls back to the title alone when the type is gone (unregistered descriptor)', () => {
     const records = createNativeTabRecords()
     const service = createBetterSidebarService(createSidebarStore())
-    records.ensure({ id: 'chip-3', kind: 'ghost', title: 'Ghost', params: undefined, scope })
+    records.ensure({ id: 'chip-3', kind: 'ghost', title: 'Ghost', params: undefined, scope, owner })
 
     const { host, unmount } = renderTitle(records, service, nativeInfo('chip-3', 'ghost', 'Ghost'), 'ghost')
     expect(host.querySelector('[aria-hidden="true"]')).toBeNull()
     expect(host.textContent).toBe('Ghost')
     unmount()
+  })
+})
+
+describe('conversation switch keeps the entered session’s explorer alive', () => {
+  /**
+   * Mount tab bodies the way DSH does: the session-scoped seat is KEYED by
+   * session id (upstream `StrictSessionEntry` renders with `}, binding.key)`),
+   * so a conversation switch renders the entering session's body and deletes
+   * the leaving session's in ONE commit — the entering body's `ensure()` runs
+   * during render, the leaving body's cleanup (`drop`) in the passive phase
+   * after it. Native tab ids restart per session, so both bodies ensure the
+   * same id; before the ownership fix the entering body adopted the leaving
+   * body's record and then had it deleted, leaving the explorer mounted but
+   * inert (every click routed through the registry became a silent no-op).
+   */
+  const mountSwitchable = (): {
+    records: ReturnType<typeof createNativeTabRecords>
+    show: (sessionId: string) => void
+    clickFolder: () => void
+    expanded: () => string
+    unmount: () => void
+  } => {
+    const store = createSidebarStore()
+    store.setSession('session-A')
+    const service = createBetterSidebarService(store)
+    service.registerTab({
+      id: 'explorer',
+      title: 'Files',
+      component: (props: TabComponentProps) => createElement(
+        'div',
+        { 'data-body': props.tab.id },
+        createElement('button', { 'data-toggle': '', onClick: () => { props.onToggleDir?.('/work/dir') } }, 'toggle'),
+        createElement('span', { 'data-expanded': '' }, (props.expanded ?? []).join('|')),
+      ),
+    })
+    const records = createNativeTabRecords()
+    const sessions = { list: { subscribe: () => () => {}, getSnapshot: () => ({ byId: {} }) } }
+    const ctx = { sessions } as never
+    const info = {
+      tab: {
+        id: 'tab2',
+        kind: 'explorer',
+        title: 'Files',
+        contentId: 'sidebar://files',
+        visible: true,
+        navigation: { address: 'sidebar://files', params: undefined, revision: 0 },
+        signal: new AbortController().signal,
+      },
+    }
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const show = (sessionId: string): void => {
+      root.render(createElement(
+        // The session-scoped seat's key (upstream StrictSessionEntry).
+        'div',
+        { key: sessionId, 'data-session': sessionId },
+        createElement(NativeTabBody, {
+          key: 'tab2',
+          sessionId,
+          ctx,
+          store,
+          service,
+          records,
+          descriptorId: 'explorer',
+          useTabInfo: () => info,
+        }),
+      ))
+    }
+    return {
+      records,
+      show,
+      clickFolder: () => {
+        const button = host.querySelector<HTMLButtonElement>('[data-toggle]')
+        expect(button, 'the explorer body must be mounted').not.toBeNull()
+        act(() => { button!.click() })
+      },
+      expanded: () => host.querySelector('[data-expanded]')?.textContent ?? '<none>',
+      unmount: () => { act(() => { root.unmount() }); host.remove() },
+    }
+  }
+
+  it('the leaving session’s unmount must not delete the entering session’s record', () => {
+    const t = mountSwitchable()
+    act(() => { t.show('session-A') })
+    expect(t.records.has('tab2')).toBe(true)
+
+    // ONE commit: session-B renders (same native tab id) while A is deleted.
+    // A's record is untouched here (version 0) — the case that used to break
+    // for good: the entering body adopted it, A's cleanup deleted it, and the
+    // unchanged snapshot (0 → 0) meant nothing ever re-rendered to re-mint
+    // it, so the explorer stayed mounted but inert.
+    act(() => { t.show('session-B') })
+    expect(t.records.has('tab2'), 'the entered session keeps a record of its own').toBe(true)
+    t.clickFolder()
+    expect(t.expanded(), 'a folder click still responds').toBe('/work/dir')
+
+    // …and the switch is not one-way: going back keeps working too.
+    act(() => { t.show('session-A') })
+    expect(t.records.has('tab2')).toBe(true)
+    t.clickFolder()
+    expect(t.expanded(), 'the session switched back into still responds').toBe('/work/dir')
+    t.unmount()
+  })
+
+  it('the entering session does not inherit the leaving session’s tree state', () => {
+    const t = mountSwitchable()
+    act(() => { t.show('session-A') })
+    t.clickFolder()
+    expect(t.expanded()).toBe('/work/dir')
+
+    act(() => { t.show('session-B') })
+    expect(t.expanded(), 'B starts from its own state, not A’s').toBe('')
+    t.unmount()
+  })
+
+  it('every switch keeps working (no self-sustaining dead state)', () => {
+    const t = mountSwitchable()
+    act(() => { t.show('session-A') })
+    for (const sessionId of ['session-B', 'session-A', 'session-B']) {
+      act(() => { t.show(sessionId) })
+      expect(t.records.has('tab2'), `${sessionId} entered keeps a record`).toBe(true)
+      expect(t.expanded(), `${sessionId} starts with its own state`).toBe('')
+      t.clickFolder()
+      expect(t.expanded(), `${sessionId} responds to a folder click`).toBe('/work/dir')
+    }
+    t.unmount()
   })
 })


### PR DESCRIPTION
## 问题

Closes #636、Closes #661

同一处根因的两个症状：

**① #636（跨会话）**：切换对话后，之前打开过的侧栏「文件」浏览器点文件夹不展开、点文件不打开（合并模式下本应原地切换），Network 里一个请求都不发；再切回原来那个会话，原本正常的文件浏览器也一起失灵。关掉该 tab 重开、或折叠再展开右侧栏即恢复。

**② #661（同会话切 tab）**：同一会话内切换右侧栏 tab，会把该 tab 的插件侧状态清空——文件树已展开的目录全部收起、终端 tab 的选中状态丢失；merged（`editorExplorer=true`）下用「文件」窗口**就地打开**的文件，切走再切回会退回空白资源管理器、chip 标题也退回「文件」。

三个事实叠在一起：

| 侧 | 事实 | 出处 |
|---|---|---|
| DSH 宿主 | 原生 tab id 由**每会话各自**的计数器铸造（每个会话第一个 tab 都叫 `tab1`）→ **跨会话必然重名** | `dsh-client-ui-sidebar-right` 的 `createSurface()` → `counting(0)`；dockkit `planOpenContent` 的 `mint("tab")` |
| DSH 宿主 | ①右侧栏会话级 seat 以 **sessionId 作 React key**（`StrictSessionEntry` 以 `}, binding.key)` 收尾）→ 切换对话 = 同一次 commit 里「进入会话的 body render + 离开会话的 body unmount」；②**同一 pane 内只挂载当前 tab 的 body** → 切 tab = 卸载/重挂 body | `dsh-client-ui-renderer`、`dsh-client-ui-dockkit` |
| 本插件 | 合成记录表只按**原生 tab id** 存（`views`），且 tab 体卸载时无条件删记录；`versionOf(缺失) = 0` | `src/client/native/tab-adapter.tsx` |

于是：

- **#636**：进入会话的 body 在 render 阶段 `ensure('tabN')`，同号 → **接管**离开会话那条记录；同一次 commit 的 passive 清理里，离开会话的 body 把它删掉；记录 v0（`versionOf` 0 → 0，快照不变）→ 不重渲染 → `ensure` 不重建 → 此后所有经过注册表的点击都是**静默 no-op**（文件夹：`records.toggleExpanded` 直接 return；合并模式的文件：`surface.update` 因 `records.has === false` 返回 false）。而每次切换都在重复这个循环，所以「切回来原来好的也一起失灵」。
- **#661**：切走即卸载 body → 卸载清理删记录 → 该 tab 的插件态（树展开集、终端选中态、merged 就地打开写进记录的 path/title）全丢；切回来只能从原生 tab 重新铸造，而 merged 的 path 只存在于记录里、原生 tab 的地址不带它。

## 修复

把「身份」和「寿命」都放到正确的载体上：

| 维度 | 之前（本 PR 早期 commit） | 现在 |
|---|---|---|
| 身份 | 铸造它的 **body 实例 token**（`View.owner`） | 原生 tab 的**会话**：`ensure` 发现 `existing.scope.sessionId !== scope.sessionId` 时，按该 tab **自己的原生种子**重建（不再 `{...existing.tab}`，title/path/meta 不可能跨会话串） |
| 寿命 | 随 body 卸载 `drop(id, owner)` | 活到**宿主关闭该 tab** 为止（唯一出口 `surface.close` → `remove(id)`，保留 `record.scope.sessionId === sessionId` 校验） |
| API | `drop(id, owner)` + `remove(id)` | 只剩 `remove(id)`；`View.owner`、`NativeTabBody` 的 `useRef` token、卸载清理全部删除 |

为什么不再是 body token：body 会随 tab 切换卸载/重挂，拿它当身份与寿命，等于「每切一次 tab 就换一个 tab 身份」——这正是 #661。会话才是「同一个 id 是不是同一个 tab」的判别式（id 每会话重名，而宿主会话级 seat 本来就按 sessionId 换 key）。

为什么 map 仍是单键（tab id）：`SidebarSurface` 的 `update/close/has/activate` 公开签名都以 tabId 为参数，复合键要连带改一圈接入 API；宿主同一时刻只挂载在屏会话的面板，单键 + 会话判据已足够（记录在案：若宿主将来同时挂载多会话面板，需要把 session 带进这些签名）。

```ts
// tab-adapter.tsx
ensure(input) {
  const existing = views.get(id)
  if (existing === undefined) { views.set(id, mintRecord(…, version: 0)); return … }
  // 同一个 id 落到别的会话 = 另一个 tab：只按它自己的原生种子重建
  if (existing.scope.sessionId !== scope.sessionId) { views.set(id, mintRecord(…, version: existing.version)); return … }
  …导航补丁（path/diff/url），身份与插件侧改动手感不变
}
remove(id) { if (views.delete(id)) notify() }   // 唯一忘记记录的入口

// surface.ts
if (record.scope.sessionId === sessionId) records.remove(tabId)
```

## 测试

`tests/native-surface.spec.ts` **26 passed**：

- 注册表级：不接管别的会话的记录（且不继承其 path/title/树状态）；**同会话 body 重挂载保住树展开集 + 就地打开的 path/title**（新增，对应 #661）；`remove` 按宿主关闭语义删除。
- 组件级（照抄宿主形状：外层 `div` 以 sessionId 作 key、内层 body 用**同一个**原生 tab id，一次 `act` 完成「进入会话 render + 离开会话 unmount」）：离开会话卸载不得删进入会话的记录且切回仍可用；进入会话不继承上一会话树状态；连续三次切换每次都可用。本轮给该 harness 加了 `hide()/path()` 两个观察面，用来覆盖「同一会话切 tab（body 重挂载）」。
- **红/绿证据**：把 `tab-adapter.tsx` 回退到本 PR 早期实现 → **2 条红**，其中组件级那条即 #661 症状：`the expansion set survives the body remount: expected '' to deeply equal '/work/dir'`。（#636 基线的红/绿见本 PR 早期 commit 的描述：回退到 `origin/main` 时 5 条红。）

## 验证

- `pnpm typecheck` / `pnpm lint` 干净；`pnpm build` 产物含新逻辑。
- `pnpm test`：1319 passed / 9 skipped / 33 failed——33 条全在 `tests/agent-pty.spec.ts`、`tests/smoke.spec.ts`（`posix_spawnp failed`，沙箱不允许 node-pty 起进程）与 `tests/market-manifest.spec.ts`（worktree 内 pnpm 不可用）；回退本次改动跑同样文件仍同样红，与本次改动无关。
- **真机**（`dsh web` + 报告者 profile 的副本，scratch home，不动线上实例）：merged 模式「就地打开 md → 切走 → 切回」——本 PR 早期实现 `CTRL-RESULT chip=0 heading=0`（tab 退回「文件」、正文丢失）→ 现在 **`chip=1 heading=1`**（chip 仍是 `ccc-readme.md`，正文仍在）。
- 与 #631 的关系：它以「unmount 不丢记录 + 同 id 换会话重建」修同一根因；本方案吸收了该思路，并把重建改成**只按该 tab 的原生种子**（#631 的重建分支保留了 `{...existing.tab}`，会把上一会话的 title/path/meta 带过来）。落地后 #631 可关。

## 未覆盖（诚实记录）

- 宿主自己的 × 关闭 tab 不经过插件 `closeTab` 时，记录会留到页面关闭。按 tab id 计数、同一 pane 内 tab 数有界，且被关闭的 id 不会被复用（宿主按会话计数器只增），故不构成状态错用；用 `tab.signal` 驱动的清理留给后续。
- 浏览器里的端到端复现仍由报告者侧完成；作者侧的确定性证据是上面的单测红/绿与 scratch-profile 真机脚本。
- `update/close/has` 仍按 tab id 解析，语义是「当前存在的那条记录」；宿主挂载模型是单会话面板，故无歧义。

## 设计文档

[docs/plans/2026-09-12-native-tab-record-ownership-fix.md](docs/plans/2026-09-12-native-tab-record-ownership-fix.md)（宿主契约、决策表、红/绿证据、本次判据/寿命修正的 follow-up 段、未覆盖项）
