### PR TITLE
feat(viewer): zoom and pan the image preview

### DIFF
--- a/docs/plans/2026-08-19-editor-preview-refresh.md
+++ b/docs/plans/2026-08-19-editor-preview-refresh.md
@@ -19,7 +19,10 @@
 ## 范围外（记录，不实现）
 
 - LLM 改文件后自动刷新（磁盘指纹对比 + silent 不闪屏）——分形有先例，另行立项；
-- image/pdf/binary viewer 的手动刷新（toolbar 为空，无入口；内容静态，低优先级）。
+- image/pdf/binary viewer 的手动刷新（内容静态，低优先级）。
+  **2026-09-13 更新**：image viewer 现在有自己的 toolbar（缩放读数 + − / 重置 / +，滚轮按光标缩放、
+  拖拽平移、双击 fit ↔ 2×，见 `src/client/ImageView.tsx`），所以「toolbar 为空」不再成立；
+  刷新入口仍未加（内容静态，重开 tab 即可）。
 
 ## 验证
 

--- a/src/client/ImageView.tsx
+++ b/src/client/ImageView.tsx
@@ -1,0 +1,340 @@
+/**
+ * Image preview with wheel zoom and drag panning.
+ *
+ * The picture starts at FIT — stretched to the stage's content box and
+ * `object-fit: contain`ed inside it, which is the box the viewer also measures
+ * its panning against — and every gesture only ever scales it UP from there:
+ * the wheel zooms around the cursor, a pointer drag pans, a double click
+ * toggles fit ↔ 2×, and the toolbar carries the zoom readout plus −/reset/+
+ * commands. Zooming out below fit would only shrink the picture inside a box
+ * it already fits, so `1` is the floor — the one baseline the layout defines.
+ *
+ * Panning is bounded by that same box: at zoom `z` the picture is `box × z`
+ * wide against a `box`-wide window, so the slack is `box × (z - 1) / 2` and
+ * the picture can never be dragged away from its own edge (which is what a
+ * naive bound — the picture's untransformed layout box — would allow at low
+ * zoom levels).
+ *
+ * Why the transforms are written to the DOM instead of through state: a wheel
+ * gesture fires dozens of times per second, and a React render per tick would
+ * re-run this viewer's whole subtree for a transform that only the browser
+ * needs to hear about. `zoomRef` is the source of truth; the `zoom` state
+ * exists solely for the toolbar readout, so it changes at most once per
+ * gesture step.
+ *
+ * The pinch gesture and the wheel share one path: a trackpad pinch arrives as
+ * a wheel event with `ctrlKey` set, so it is handled by the same handler and
+ * `preventDefault()`ed — which also keeps the browser's page zoom out of it.
+ * The native (non-passive) listener is required for that `preventDefault`, as
+ * React's synthetic wheel listener is passive (same reason as the mermaid zoom
+ * modal, whose gesture maths this viewer follows).
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { t } from './locales.ts'
+import css from './sidebar.module.css'
+
+/** Largest zoom the gestures may reach (the readout shows e.g. `1600%`). */
+const MAX_ZOOM = 16
+/** One wheel notch / button click step. */
+const ZOOM_STEP = 1.1
+/** What a double click zooms to from fit. */
+const DOUBLE_CLICK_ZOOM = 2
+
+/** Clamp `value` into `[min, max]` (inverted ranges collapse to `min`). */
+export function clampZoom(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * New zoom + translation for a zoom step anchored at one stage point.
+ *
+ * The stage centers its child with flexbox, so the picture's center sits at
+ * the stage's center and the transform only has to keep the anchor point
+ * stationary while the scale changes: the offset between the anchor and the
+ * center shrinks (or grows) by exactly the scale ratio. `translate` is applied
+ * BEFORE `scale` in the transform list, so the translation itself is in
+ * unscaled stage pixels — which is what the anchor maths assumes.
+ *
+ * @param current - The zoom/translation in effect before the step.
+ * @param ratio - Scale multiplier (`newZoom / current.zoom`).
+ * @param anchor - The point to keep fixed, in stage coordinates.
+ * @param stageWidth - The stage's width in CSS pixels.
+ * @param stageHeight - The stage's height in CSS pixels.
+ * @returns The new zoom and translation (both in stage pixels).
+ */
+export function zoomedTransform(
+  current: { zoom: number; tx: number; ty: number },
+  ratio: number,
+  anchor: { x: number; y: number },
+  stageWidth: number,
+  stageHeight: number,
+): { zoom: number; tx: number; ty: number } {
+  const zoom = current.zoom * ratio
+  const grow = zoom / current.zoom
+  const cx = stageWidth / 2
+  const cy = stageHeight / 2
+  return {
+    zoom,
+    tx: anchor.x - cx - (anchor.x - cx - current.tx) * grow,
+    ty: anchor.y - cy - (anchor.y - cy - current.ty) * grow,
+  }
+}
+
+/** The pan offsets that keep `zoom`ed content inside its stage. */
+export function clampPan(
+  zoom: number,
+  tx: number,
+  ty: number,
+  imageWidth: number,
+  imageHeight: number,
+  stageWidth: number,
+  stageHeight: number,
+): { tx: number; ty: number } {
+  const span = (scaled: number, box: number): number => Math.max(0, (scaled - box) / 2)
+  const limitX = span(imageWidth * zoom, stageWidth)
+  const limitY = span(imageHeight * zoom, stageHeight)
+  // `+ 0` folds the -0 that `Math.max(-limit, ...)` can produce: the offsets
+  // are written into a transform string, and `translate(-0px)` is only noise.
+  return {
+    tx: Math.min(limitX, Math.max(-limitX, tx)) + 0,
+    ty: Math.min(limitY, Math.max(-limitY, ty)) + 0,
+  }
+}
+
+/**
+ * The box a fitted picture fills: the stage's own content box.
+ *
+ * NOT the image's `offsetWidth`: the picture is stretched to 100% of this box
+ * and then scaled by the transform, so its layout size stays fixed while its
+ * painted size grows. Panning has to be bounded by what is on screen —
+ * `content × zoom` against `content` — which is exactly what this gives.
+ */
+function stageContentBox(stage: HTMLElement): { width: number; height: number } {
+  let padX = 0
+  let padY = 0
+  const view = stage.ownerDocument.defaultView
+  if (view !== null) {
+    const style = view.getComputedStyle(stage)
+    const px = (value: string): number => {
+      const parsed = Number.parseFloat(value)
+      return Number.isFinite(parsed) ? parsed : 0
+    }
+    padX = px(style.paddingLeft) + px(style.paddingRight)
+    padY = px(style.paddingTop) + px(style.paddingBottom)
+  }
+  return { width: Math.max(0, stage.offsetWidth - padX), height: Math.max(0, stage.offsetHeight - padY) }
+}
+
+/**
+ * A stretched image draws at its intrinsic size and lets the transform scale
+ * it down; `object-fit: contain` (the CSS default here) letterboxes the image
+ * inside that box instead, so the painted picture and its hit area disagree
+ * and the cursor-anchored zoom drifts. `stretch` (below) is what makes the
+ * box and the fit box the same thing.
+ */
+const STRETCH_STYLE = { width: '100%', height: '100%', objectFit: 'contain' } as const
+
+export function ImageView(props: { mediaUrl?: string; title: string }) {
+  const { mediaUrl: url, title } = props
+  const stageRef = useRef<HTMLDivElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+  const zoomRef = useRef({ zoom: 1, tx: 0, ty: 0 })
+  const dragRef = useRef<{ pointerId: number; startX: number; startY: number } | null>(null)
+  const [zoom, setZoom] = useState(1)
+
+  /** Push `zoomRef` onto the image and remember the readout's zoom. */
+  const apply = useCallback((): void => {
+    const img = imgRef.current
+    if (img === null) return
+    const current = zoomRef.current
+    current.zoom = clampZoom(current.zoom, 1, MAX_ZOOM)
+    const stage = stageRef.current
+    if (stage !== null) {
+      const box = stageContentBox(stage)
+      const fixed = clampPan(current.zoom, current.tx, current.ty, box.width, box.height, box.width, box.height)
+      current.tx = fixed.tx
+      current.ty = fixed.ty
+    }
+    img.style.transform = `translate(${current.tx}px, ${current.ty}px) scale(${current.zoom})`
+    if (img.dataset.imageZoom !== String(current.zoom)) img.dataset.imageZoom = String(current.zoom)
+    setZoom(previous => (previous === current.zoom ? previous : current.zoom))
+  }, [])
+
+  /** Zoom by `ratio`, keeping `anchor` (stage coordinates) stationary. */
+  const zoomBy = useCallback((ratio: number, anchor?: { x: number; y: number }): void => {
+    const stage = stageRef.current
+    if (stage === null) return
+    const current = zoomRef.current
+    const next = clampZoom(current.zoom * ratio, 1, MAX_ZOOM)
+    if (next === current.zoom) return
+    // The stage's content box, not getBoundingClientRect(): it is the box the
+    // offsets are clamped against (see `apply`) and it stays meaningful where
+    // a rect is unavailable or degenerate. The picture's centre sits at the
+    // stage's centre because the stage is a flex centring container.
+    const box = stageContentBox(stage)
+    const point = anchor ?? { x: box.width / 2, y: box.height / 2 }
+    zoomRef.current = zoomedTransform(current, next / current.zoom, point, box.width, box.height)
+    apply()
+  }, [apply])
+
+  /** Back to fit: no scale, no offset. */
+  const reset = useCallback((): void => {
+    zoomRef.current = { zoom: 1, tx: 0, ty: 0 }
+    apply()
+  }, [apply])
+
+  // Wheel + drag. Both run on the stage node rather than through React
+  // handlers: the wheel listener must be non-passive to preventDefault, and
+  // pointer capture on the stage keeps a drag alive outside the pane.
+  useEffect(() => {
+    const stage = stageRef.current
+    const img = imgRef.current
+    if (stage === null || img === null) return
+
+    const onWheel = (event: WheelEvent): void => {
+      if (event.deltaY === 0) return
+      event.preventDefault()
+      // Client coordinates are viewport-relative; the anchor must be stage-
+      // relative, hence the offset by the stage's own top-left corner.
+      const rect = stage.getBoundingClientRect()
+      zoomBy(event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP, {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      })
+    }
+    const onPointerDown = (event: PointerEvent): void => {
+      if (event.button !== 0) return
+      event.preventDefault()
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX - zoomRef.current.tx,
+        startY: event.clientY - zoomRef.current.ty,
+      }
+      // Capture keeps the drag alive when the pointer leaves the pane. It can
+      // be refused (a synthetic event with no active pointer, an embedder
+      // without the API), and a refused capture must not cost us the drag —
+      // the move handler below works on the stage either way.
+      try { stage.setPointerCapture(event.pointerId) } catch { /* drag still works */ }
+      stage.dataset.imageDragging = ''
+    }
+    const onPointerMove = (event: PointerEvent): void => {
+      const drag = dragRef.current
+      if (drag === null || drag.pointerId !== event.pointerId) return
+      zoomRef.current.tx = event.clientX - drag.startX
+      zoomRef.current.ty = event.clientY - drag.startY
+      apply()
+    }
+    const endDrag = (event: PointerEvent): void => {
+      const drag = dragRef.current
+      if (drag === null || drag.pointerId !== event.pointerId) return
+      // The last move may have carried the picture past its clamp (or the
+      // zoom may have changed under the pointer); settle it against the
+      // current limits before the drag goes away. Dropping the ref first
+      // makes this the final word — no further move can follow this release.
+      dragRef.current = null
+      apply()
+      delete stage.dataset.imageDragging
+      try { if (stage.hasPointerCapture(drag.pointerId)) stage.releasePointerCapture(drag.pointerId) } catch { /* already gone */ }
+    }
+    const onDoubleClick = (event: MouseEvent): void => {
+      if (zoomRef.current.zoom > 1) {
+        reset()
+        return
+      }
+      const rect = stage.getBoundingClientRect()
+      zoomBy(DOUBLE_CLICK_ZOOM, { x: event.clientX - rect.left, y: event.clientY - rect.top })
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === '+' || event.key === '=') zoomBy(1.2)
+      else if (event.key === '-' || event.key === '_') zoomBy(1 / 1.2)
+      else if (event.key === '0') reset()
+    }
+    // A pane resize changes the room the offsets were clamped against; without
+    // this the picture can sit outside the visible box after the drag that
+    // widened the sidebar, or stay off-center after it narrowed.
+    const onResize = (): void => { apply() }
+
+    stage.addEventListener('wheel', onWheel, { passive: false })
+    stage.addEventListener('pointerdown', onPointerDown)
+    stage.addEventListener('pointermove', onPointerMove)
+    stage.addEventListener('pointerup', endDrag)
+    stage.addEventListener('pointercancel', endDrag)
+    stage.addEventListener('dblclick', onDoubleClick)
+    stage.addEventListener('keydown', onKeyDown)
+    window.addEventListener('resize', onResize)
+    return () => {
+      stage.removeEventListener('wheel', onWheel)
+      stage.removeEventListener('pointerdown', onPointerDown)
+      stage.removeEventListener('pointermove', onPointerMove)
+      stage.removeEventListener('pointerup', endDrag)
+      stage.removeEventListener('pointercancel', endDrag)
+      stage.removeEventListener('dblclick', onDoubleClick)
+      stage.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [apply, reset, zoomBy])
+
+  // A different picture starts from fit again: the previous offsets were
+  // clamped against the previous image's size.
+  useEffect(() => {
+    zoomRef.current = { zoom: 1, tx: 0, ty: 0 }
+    apply()
+  }, [url, apply])
+
+  const percent = useMemo(() => `${Math.round(zoom * 100)}%`, [zoom])
+
+  return (
+    <div className={css.editorImageView}>
+      <div className={css.editorImageToolbar}>
+        <button
+          type="button"
+          className={css.editorImageButton}
+          title={t('mermaidZoomOut')}
+          aria-label={t('mermaidZoomOut')}
+          onClick={() => zoomBy(1 / ZOOM_STEP)}
+        >
+          −
+        </button>
+        <span className={css.editorImageZoom} data-image-zoom-readout>{percent}</span>
+        <button
+          type="button"
+          className={css.editorImageButton}
+          title={t('mermaidZoomIn')}
+          aria-label={t('mermaidZoomIn')}
+          onClick={() => zoomBy(ZOOM_STEP)}
+        >
+          +
+        </button>
+        <button
+          type="button"
+          className={css.editorImageButton}
+          title={t('mermaidZoomReset')}
+          aria-label={t('mermaidZoomReset')}
+          onClick={reset}
+        >
+          ⟲
+        </button>
+      </div>
+      <div
+        className={css.editorImageStage}
+        ref={stageRef}
+        tabIndex={0}
+        role="group"
+        aria-label={title}
+        data-image-stage=""
+      >
+        <img
+          className={css.editorImage}
+          ref={imgRef}
+          data-image=""
+          src={url}
+          alt={title}
+          draggable={false}
+          onLoad={apply}
+          style={STRETCH_STYLE}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/client/builtins/viewers.tsx
+++ b/src/client/builtins/viewers.tsx
@@ -24,6 +24,7 @@
  */
 import { IconCodeOutline16, IconDownloadOutline16 } from '@deepseek-ai/dsh-client-ui-primitives'
 import { lazyChunkComponent } from '../lazy-chunk.tsx'
+import { ImageView } from '../ImageView.tsx'
 import { PdfView } from '../PdfView.tsx'
 import { BinaryDownload } from '../binary-download.tsx'
 import {
@@ -35,7 +36,6 @@ import {
 import type { ComponentType } from 'react'
 import type { FileViewerDescriptor, FileViewerProps } from '../service.ts'
 import { t } from '../locales.ts'
-import css from '../sidebar.module.css'
 
 /**
  * Lazy wrapper over the chunk-resident viewer component. The `pick`
@@ -54,11 +54,7 @@ export function builtinViewers(): readonly FileViewerDescriptor[] {
       icon: (size: number) => <IconImageOutline16 size={size} />,
       exts: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif'],
       fetchStrategy: 'mediaUrl',
-      component: ({ mediaUrl: url, title }) => (
-        <div className={css.editorImageWrap}>
-          <img className={css.editorImage} src={url} alt={title} />
-        </div>
-      ),
+      component: ({ mediaUrl: url, title }) => <ImageView mediaUrl={url} title={title} />,
     },
     {
       id: 'pdf',

--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -1576,20 +1576,92 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   color: var(--dsw-alias-label-primary);
 }
 
-.editorImageWrap {
+.editorImageView {
   flex: 1;
   min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.editorImageToolbar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 8px;
+  /* Opaque on purpose: the toolbar floats over the picture, and a translucent
+     chip over a photograph is unreadable at exactly the zoom levels a reader
+     reaches for it. */
+  background: var(--dsw-alias-bg-layer-2);
+}
+
+.editorImageButton {
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dsw-alias-label-primary);
+  font: var(--dsw-font-xs-strong-13);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.editorImageButton:hover {
+  background: var(--dsw-alias-interactive-bg-hover);
+}
+
+.editorImageZoom {
+  min-width: 42px;
+  text-align: center;
+  font: var(--dsw-font-xs-strong-13);
+  color: var(--dsw-alias-label-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.editorImageStage {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: auto;
   padding: 12px;
+  cursor: grab;
+  /* The stage owns the touch gesture stream: a drag pans the picture instead
+     of scrolling (or bouncing) the pane. */
+  touch-action: none;
+}
+
+.editorImageStage:focus-visible {
+  outline: 2px solid var(--dsw-alias-border-l2);
+  outline-offset: -2px;
+}
+
+.editorImageStage[data-image-dragging] {
+  cursor: grabbing;
 }
 
 .editorImage {
-  max-width: 100%;
-  max-height: 100%;
+  display: block;
+  max-width: none;
+  max-height: none;
   object-fit: contain;
+  /* A stretched box + object-fit: contain is what keeps the painted picture
+     aligned with the transform: offsetWidth/offsetHeight then describe the
+     picture's box exactly (see ImageView.tsx). */
+  transform-origin: center center;
+  will-change: transform;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .editorMd {

--- a/tests/e2e/image-zoom.e2e.ts
+++ b/tests/e2e/image-zoom.e2e.ts
@@ -1,0 +1,228 @@
+/**
+ * Real-browser verification of the image viewer's zoom/pan surface.
+ *
+ * The lane this runs in is booted by `scripts/e2e-mount.sh` against the
+ * npm-packed plugin (the same install path a user takes), so this spec proves
+ * the gestures on the artifact that ships — not on the source tree. It opens a
+ * seeded PNG through the plugin's own explorer and drives the three gestures
+ * the viewer promises: the wheel zooms around the cursor, a pointer drag pans,
+ * and a double click returns to fit.
+ *
+ * The zoom is read off the picture's LIVE transform matrix rather than the
+ * readout chip, because the matrix is what the browser actually paints: a
+ * scale that never reached the DOM would still update a React state.
+ *
+ * This is the only lane where `offsetWidth`/`getBoundingClientRect` are real,
+ * which is why the pan bound (`content box × zoom` against the content box) is
+ * asserted here rather than in the jsdom spec.
+ */
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { deflateSync } from 'node:zlib'
+import { createHostApi, gotoPage, hostRpc, sendFirstMessage } from './host'
+
+const WORKSPACE_PATH = process.env.DSH_E2E_WORKSPACE ?? join(process.env.TMPDIR ?? '/tmp', 'dsh-e2e-workspace')
+const SEEDED_PNG = 'zz-zoom-check.png'
+
+/** A 96x64 PNG (the pane is much larger, so FIT is a real scale-up). */
+function checkerPng(): Buffer {
+  const width = 96
+  const height = 64
+  const raw = Buffer.alloc((width * 3 + 1) * height)
+  let at = 0
+  for (let y = 0; y < height; y += 1) {
+    raw[at] = 0
+    at += 1
+    for (let x = 0; x < width; x += 1) {
+      const on = (Math.floor(x / 8) + Math.floor(y / 8)) % 2 === 0
+      raw[at] = on ? 240 : 30
+      raw[at + 1] = on ? 90 : 40
+      raw[at + 2] = on ? 60 : 70
+      at += 3
+    }
+  }
+  const chunk = (tag: string, data: Buffer): Buffer => {
+    const head = Buffer.alloc(8)
+    head.writeUInt32BE(data.length, 0)
+    head.write(tag, 4, 'ascii')
+    const body = Buffer.concat([head.subarray(4), data])
+    const crc = Buffer.alloc(4)
+    crc.writeUInt32BE(crc32(body), 0)
+    return Buffer.concat([head, data, crc])
+  }
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(width, 0)
+  ihdr.writeUInt32BE(height, 4)
+  ihdr[8] = 8
+  ihdr[9] = 2
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', deflateSync(raw, { level: 9 })),
+    chunk('IEND', Buffer.alloc(0)),
+  ])
+}
+
+/** CRC-32 (the PNG chunk checksum) without pulling in a dependency. */
+function crc32(bytes: Buffer): number {
+  let crc = 0xffffffff
+  for (const byte of bytes) {
+    crc ^= byte
+    for (let bit = 0; bit < 8; bit += 1) crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+const CHROME = '[data-sidebar-right-panel]'
+const STAGE = '[data-image-stage]'
+const IMG = '[data-image]'
+const READOUT = '[data-image-zoom-readout]'
+
+/** The RPC request context (carries the launch token's auth cookie). */
+let api: APIRequestContext
+
+test.beforeAll(async () => {
+  api = await createHostApi()
+  // Seed a real workspace + session through the same calls the UI makes: the
+  // native right Sidebar only renders its guide (and with it the plugin's
+  // files entry) for a live session, and the picture must be visible to the
+  // explorer this test drives.
+  writeFileSync(join(WORKSPACE_PATH, SEEDED_PNG), checkerPng())
+  const workspace = await hostRpc<{ workspace: { workspaceId: string } }>(api, 'workspace.create', { path: WORKSPACE_PATH })
+  await hostRpc(api, 'session.create', { workspaceId: workspace.value.workspace.workspaceId })
+})
+
+test.afterAll(async () => {
+  await api?.dispose()
+})
+
+test('the image viewer zooms around the cursor, pans by drag and resets to fit', async ({ page }) => {
+  await gotoPage(page)
+  await expect(page.locator('#root > *'), 'the shell must render').not.toHaveCount(0, { timeout: 90_000 })
+  await expect(page.locator('[data-dsh-better-sidebar]'), 'the plugin must mount').toBeAttached({ timeout: 90_000 })
+
+  // A keyless boot stacks onboarding takeovers over the shell (welcome
+  // notice, then the provider dialog), and they mask the composer — dismiss
+  // them BEFORE typing, the same order the mount smoke uses.
+  try {
+    await expect
+      .poll(() => page.getByRole('button', { name: /^(Continue|Configure later)$/ }).count(), { timeout: 60_000 })
+      .toBeGreaterThan(0)
+  } catch {
+    console.warn('[e2e] no onboarding takeover appeared; proceeding without dismissal')
+  }
+  for (let round = 0; round < 8; round++) {
+    let dismissed = false
+    for (const name of ['Continue', 'Configure later']) {
+      const button = page.getByRole('button', { name, exact: true }).first()
+      if ((await button.count()) === 0) continue
+      try {
+        await button.click({ timeout: 4_000 })
+        dismissed = true
+        await page.waitForTimeout(1_000)
+      } catch {
+        // Masked by the takeover stacked above it; the next round tries the
+        // other button first.
+      }
+    }
+    if (!dismissed) break
+  }
+
+  // A live conversation is what the native sidebar renders into.
+  await sendFirstMessage(page)
+
+  await page.locator('[data-sidebar-right-expand]').first().click()
+
+  const pane = page.locator(CHROME)
+  await expect(pane.locator('[data-sidebar-right-guide]'), 'the native sidebar must show its guide').toBeVisible({ timeout: 30_000 })
+  await expect(
+    page.locator('[data-sidebar-right-guide-entry="files"]'),
+    'the plugin must be offered as a native tab type before it can be opened',
+  ).toHaveCount(1, { timeout: 30_000 })
+  await page.locator('[data-sidebar-right-guide-entry="files"]').first().click()
+  const row = pane.locator(`[role="button"][title$="${SEEDED_PNG}"]:visible`)
+  await expect(row, `the seeded "${SEEDED_PNG}" must appear in the plugin's explorer`).toHaveCount(1, { timeout: 30_000 })
+  await row.click({ position: { x: 8, y: 8 } })
+
+  const stage = pane.locator(STAGE).first()
+  await expect(stage, 'the image viewer must render its zoom stage').toBeVisible({ timeout: 30_000 })
+  const img = stage.locator(IMG)
+  await expect(img, 'the picture must be present inside the stage').toBeVisible()
+
+  /** The live scale/translation the browser is painting. */
+  const matrix = async (): Promise<{ scale: number; x: number; y: number }> =>
+    img.evaluate((node: HTMLElement | SVGElement) => {
+      const computed = getComputedStyle(node).transform
+      const parts = computed.startsWith('matrix(')
+        ? computed.slice('matrix('.length, -1).split(',').map(Number)
+        : [1, 0, 0, 1, 0, 0]
+      return { scale: parts[0] ?? 1, x: parts[4] ?? 0, y: parts[5] ?? 0 }
+    })
+
+  const atFit = await matrix()
+  expect(atFit.scale, 'the viewer opens at fit, unscaled').toBeCloseTo(1, 3)
+  expect(
+    await img.evaluate((node: HTMLElement | SVGElement) => node instanceof HTMLImageElement && node.offsetWidth > 0 && node.offsetHeight > 0),
+    'the picture has a real box',
+  ).toBe(true)
+
+  // Wheel zoom, anchored on a point off the stage's centre so the anchored
+  // maths is actually exercised: the picture must grow AND move.
+  const box = await stage.boundingBox()
+  expect(box, 'the stage must have a box').not.toBeNull()
+  const anchor = { x: box!.width * 0.25, y: box!.height * 0.25 }
+  await page.mouse.move(box!.x + anchor.x, box!.y + anchor.y)
+  await page.mouse.wheel(0, -240)
+  await expect
+    .poll(async () => (await matrix()).scale, { message: 'the wheel must zoom the picture in', timeout: 10_000 })
+    .toBeGreaterThan(1.05)
+  const zoomed = await matrix()
+  expect(zoomed.x, 'an off-centre anchor must also translate the picture').not.toBeCloseTo(0, 2)
+
+  // The pane must NOT scroll while the wheel zooms: the stage swallows it.
+  const scrolled = await stage.evaluate((node) => node.scrollTop + node.scrollLeft)
+  expect(scrolled, 'the wheel is consumed by the viewer, not by a scroller').toBe(0)
+
+  // Drag panning: a pointer drag moves the picture further, bounded by the
+  // fit box, and the cursor feedback marks the gesture.
+  const before = await matrix()
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2)
+  await page.mouse.down()
+  await expect(stage, 'a drag in flight is marked for the grabbing cursor').toHaveAttribute('data-image-dragging', '')
+  await page.mouse.move(box!.x + box!.width / 2 - 60, box!.y + box!.height / 2 - 40, { steps: 6 })
+  await page.mouse.up()
+  await expect(stage, 'the drag marker clears on release').not.toHaveAttribute('data-image-dragging', '')
+  const dragged = await matrix()
+  expect(
+    Math.hypot(dragged.x - before.x, dragged.y - before.y),
+    'the drag must move the picture',
+  ).toBeGreaterThan(5)
+  // Bounded: the picture's scaled box never leaves more slack than it has.
+  const bounded = await img.evaluate((node: HTMLElement | SVGElement) => {
+    if (!(node instanceof HTMLImageElement)) throw new Error('the viewer must render an <img>')
+    const parts = getComputedStyle(node).transform.slice('matrix('.length, -1).split(',').map(Number)
+    const scale = parts[0] ?? 1
+    const stageBox = node.parentElement as HTMLElement
+    const style = getComputedStyle(stageBox)
+    const px = (value: string): number => Number.parseFloat(value) || 0
+    const contentWidth = stageBox.offsetWidth - px(style.paddingLeft) - px(style.paddingRight)
+    const contentHeight = stageBox.offsetHeight - px(style.paddingTop) - px(style.paddingBottom)
+    return {
+      x: parts[4] ?? 0,
+      y: parts[5] ?? 0,
+      limitX: Math.max(0, (contentWidth * scale - contentWidth) / 2) + 1,
+      limitY: Math.max(0, (contentHeight * scale - contentHeight) / 2) + 1,
+    }
+  })
+  expect(Math.abs(bounded.x), 'panning stays inside the picture’s own overflow (x)').toBeLessThanOrEqual(bounded.limitX)
+  expect(Math.abs(bounded.y), 'panning stays inside the picture’s own overflow (y)').toBeLessThanOrEqual(bounded.limitY)
+
+  // Double click toggles fit ↔ 2×.
+  await stage.dblclick({ position: { x: box!.width / 2, y: box!.height / 2 } })
+  await expect
+    .poll(async () => (await matrix()).scale, { message: 'a double click on a zoomed picture returns to fit' })
+    .toBeCloseTo(1, 2)
+  // The readout chip lives in the viewer's toolbar, next to (not inside) the stage.
+  expect(await pane.locator(READOUT).textContent()).toBe('100%')
+})

--- a/tests/image-view.spec.tsx
+++ b/tests/image-view.spec.tsx
@@ -1,0 +1,253 @@
+/**
+ * The image viewer's zoom/pan surface.
+ *
+ * jsdom has no layout engine, so the tests stub exactly the four numbers the
+ * viewer reads off the DOM (`offsetWidth`/`offsetHeight` on the image and the
+ * stage) and drive the rest through real events: a non-passive `wheel` on the
+ * stage, pointer events for the drag, and the toolbar's buttons. That keeps
+ * the assertions on observable behaviour — the inline transform, the readout,
+ * and whether the wheel's default was prevented — rather than on internals.
+ *
+ * The pure maths (`zoomedTransform` / `clampPan` / `clampZoom`) is covered
+ * directly as well, so a regression names the helper that broke, not just the
+ * component.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { ImageView, clampPan, clampZoom, zoomedTransform } from '../src/client/ImageView.tsx'
+
+import { setupReactAct } from './test-utils.ts'
+setupReactAct()
+
+interface Mounted {
+  host: HTMLDivElement
+  stage: HTMLDivElement
+  img: HTMLImageElement
+  readout: HTMLElement
+  unmount: () => void
+}
+
+interface MountedView extends Mounted {
+  zoom: () => number
+  offsets: () => { x: number; y: number }
+  transform: () => string
+}
+
+/**
+ * Mount the viewer with a stubbed layout: the picture is `image` CSS pixels,
+ * the stage is `stage` CSS pixels. Returns the nodes plus a `zoom` reader.
+ */
+function mount(image = { width: 400, height: 300 }, stage = { width: 400, height: 300 }): MountedView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  let root: Root | undefined
+  act(() => {
+    root = createRoot(host)
+    root.render(createElement(ImageView, { mediaUrl: '/sidebar/file?path=x.png', title: 'x.png' }))
+  })
+  const stageEl = host.querySelector('[role="group"]') as HTMLDivElement
+  const img = host.querySelector('img') as HTMLImageElement
+  const readout = host.querySelector('[data-image-zoom-readout]') as HTMLElement
+  for (const [node, size] of [[img, image], [stageEl, stage]] as const) {
+    Object.defineProperty(node, 'offsetWidth', { value: size.width, configurable: true })
+    Object.defineProperty(node, 'offsetHeight', { value: size.height, configurable: true })
+    // The wheel/double-click anchors are stage-relative, which the viewer
+    // derives from the stage's rect origin (jsdom reports a zeroed rect).
+    node.getBoundingClientRect = () => ({
+      x: 0, y: 0, left: 0, top: 0, right: size.width, bottom: size.height,
+      width: size.width, height: size.height, toJSON: () => ({}),
+    }) as DOMRect
+  }
+  // The image is "loaded": apply() is what writes the first transform.
+  act(() => { img.dispatchEvent(new Event('load')) })
+  /** The numeric translate offsets, so float noise does not fail a strictly
+   *  correct transform (1.1 * 400 - 200 / 2 = 120.00000000000003). */
+  const offsets = (): { x: number; y: number } => {
+    const match = /translate\((-?[\d.]+)px, (-?[\d.]+)px\)/.exec(img.style.transform)
+    if (match === null) throw new Error(`no translate in ${img.style.transform}`)
+    return { x: Number(match[1]), y: Number(match[2]) }
+  }
+  return {
+    host,
+    stage: stageEl,
+    img,
+    readout,
+    zoom: () => Number(img.dataset.imageZoom ?? 'NaN'),
+    offsets,
+    transform: () => img.style.transform,
+    unmount: () => {
+      act(() => { root?.unmount() })
+      host.remove()
+    },
+  }
+}
+
+/** One wheel notch: `deltaY < 0` zooms in, at `at` in stage coordinates. */
+function wheel(stage: HTMLElement, deltaY: number, at?: { x: number; y: number }): boolean {
+  const event = new WheelEvent('wheel', {
+    deltaY,
+    clientX: at?.x ?? 0,
+    clientY: at?.y ?? 0,
+    bubbles: true,
+    cancelable: true,
+  })
+  act(() => { stage.dispatchEvent(event) })
+  return event.defaultPrevented
+}
+
+function drag(stage: HTMLElement, from: { x: number; y: number }, to: { x: number; y: number }): void {
+  act(() => {
+    stage.dispatchEvent(new PointerEvent('pointerdown', { pointerId: 1, button: 0, clientX: from.x, clientY: from.y, bubbles: true }))
+    stage.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, clientX: to.x, clientY: to.y, bubbles: true }))
+    stage.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, clientX: to.x, clientY: to.y, bubbles: true }))
+  })
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('the pure zoom maths', () => {
+  it('clamps zoom into [min, max] and rejects non-finite input', () => {
+    // (value, min, max) — a non-finite value falls back to the floor, so a
+    // broken rect or a divide-by-zero can never leave the picture invisible.
+    expect(clampZoom(0.1, 1, 16)).toBe(1)
+    expect(clampZoom(99, 1, 16)).toBe(16)
+    expect(clampZoom(2.5, 1, 16)).toBe(2.5)
+    expect(clampZoom(Number.NaN, 1, 16)).toBe(1)
+    // Infinity is not finite either, so it takes the same floor: a degenerate
+    // ratio leaves the picture at fit rather than at the ceiling.
+    expect(clampZoom(Number.POSITIVE_INFINITY, 1, 16)).toBe(1)
+  })
+
+  it('keeps the anchored point stationary across a scale step', () => {
+    // Anchor (150, 100) in a 200x200 stage whose centre is (100, 100): the
+    // offset from the centre must shrink by exactly the scale ratio.
+    const next = zoomedTransform({ zoom: 1, tx: 0, ty: 0 }, 2, { x: 150, y: 100 }, 200, 200)
+    expect(next.zoom).toBe(2)
+    expect(next.tx).toBe(-50)
+    expect(next.ty).toBe(0)
+    // The anchored point in content coordinates is unchanged: it sits at
+    // centre + (anchor - centre - tx) / zoom before and after.
+    const before = (150 - 100 - 0) / 1
+    const after = (150 - 100 - next.tx) / next.zoom
+    expect(after).toBe(before)
+  })
+
+  it('allows no panning while the picture fits, and bounds it by the overflow once it does not', () => {
+    // 400x300 in a 400x300 stage: exactly fit, no slack in either axis.
+    expect(clampPan(1, 40, -40, 400, 300, 400, 300)).toEqual({ tx: 0, ty: 0 })
+    // 400x300 at zoom 2 = 800x600 in a 400x300 stage: 200px / 150px of slack.
+    expect(clampPan(2, 999, -999, 400, 300, 400, 300)).toEqual({ tx: 200, ty: -150 })
+    expect(clampPan(2, 50, -50, 400, 300, 400, 300)).toEqual({ tx: 50, ty: -50 })
+    // One axis larger than the stage, the other smaller: only the larger pans.
+    expect(clampPan(2, 999, 999, 400, 100, 400, 300)).toEqual({ tx: 200, ty: 0 })
+  })
+})
+
+describe('ImageView', () => {
+  it('starts at fit and zooms in around the cursor on wheel-up, preventing the default', () => {
+    const view = mount()
+    expect(view.zoom()).toBe(1)
+    expect(view.readout.textContent).toBe('100%')
+    expect(view.transform()).toContain('scale(1)')
+
+    const prevented = wheel(view.stage, -100, { x: 250, y: 150 })
+    expect(prevented, 'the pane must not scroll while the wheel zooms the picture').toBe(true)
+    expect(view.zoom()).toBeCloseTo(1.1, 5)
+    expect(view.readout.textContent).toBe('110%')
+    // Anchor (250,150) in a 400x300 stage: centre (200,150), so the anchor sits
+    // 50px right of centre and must stay there across the 1.1 step.
+    expect(view.offsets().x).toBeCloseTo(-5, 6)
+    expect(view.offsets().y).toBeCloseTo(0, 6)
+    expect(view.transform()).toContain('scale(1.1)')
+    view.unmount()
+  })
+
+  it('never zooms below fit, and stops at the ceiling', () => {
+    const view = mount()
+    for (let i = 0; i < 12; i += 1) wheel(view.stage, 120, { x: 200, y: 150 })
+    expect(view.zoom(), 'zoom-out floor is the fit scale').toBe(1)
+    expect(view.readout.textContent).toBe('100%')
+
+    for (let i = 0; i < 80; i += 1) wheel(view.stage, -120, { x: 200, y: 150 })
+    expect(view.zoom()).toBe(16)
+    expect(view.readout.textContent).toBe('1600%')
+    view.unmount()
+  })
+
+  it('pans with a pointer drag, clamped so the picture cannot leave the stage', () => {
+    const view = mount()
+    wheel(view.stage, -100, { x: 100, y: 100 })
+    expect(view.stage.dataset.imageDragging, 'no drag in flight').toBeUndefined()
+
+    drag(view.stage, { x: 200, y: 150 }, { x: 10_000, y: 10_000 })
+    // The fit box is 400x300 and the zoom is 1.1, so the visible slack is
+    // (400*1.1 - 400)/2 = 20 horizontally and (300*1.1 - 300)/2 = 15
+    // vertically. A picture cannot be dragged past its own edge — the old
+    // bound (its 400x300 layout box in a 200x200 stage) let it.
+    expect(view.offsets().x).toBeCloseTo(20, 6)
+    expect(view.offsets().y).toBeCloseTo(15, 6)
+    expect(view.stage.dataset.imageDragging, 'the drag marker is cleared on pointerup').toBeUndefined()
+
+    // Zooming all the way out lands on fit, where the picture exactly fills its
+    // box: there is no slack left in either axis.
+    for (let i = 0; i < 12; i += 1) wheel(view.stage, 120, { x: 200, y: 150 })
+    expect(view.zoom()).toBe(1)
+    drag(view.stage, { x: 200, y: 150 }, { x: 900, y: 900 })
+    expect(view.offsets()).toEqual({ x: 0, y: 0 })
+    expect(view.transform()).toContain('scale(1)')
+    view.unmount()
+  })
+
+  it('toggles fit ↔ 2× on a double click', () => {
+    const view = mount()
+    act(() => {
+      view.stage.dispatchEvent(new MouseEvent('dblclick', { clientX: 200, clientY: 150, bubbles: true }))
+    })
+    expect(view.zoom()).toBe(2)
+    act(() => {
+      view.stage.dispatchEvent(new MouseEvent('dblclick', { clientX: 200, clientY: 150, bubbles: true }))
+    })
+    expect(view.zoom()).toBe(1)
+    expect(view.offsets()).toEqual({ x: 0, y: 0 })
+    expect(view.transform()).toContain('scale(1)')
+    view.unmount()
+  })
+
+  it('answers the toolbar buttons and the keyboard', () => {
+    const view = mount()
+    const buttons = Array.from(view.host.querySelectorAll('button'))
+    expect(buttons, 'zoom out, zoom in, reset').toHaveLength(3)
+    const [zoomOut, zoomIn, reset] = buttons as [HTMLButtonElement, HTMLButtonElement, HTMLButtonElement]
+    act(() => { zoomIn.click() })
+    expect(view.readout.textContent).toBe('110%')
+    act(() => { zoomIn.click() })
+    expect(view.readout.textContent).toBe('121%')
+    act(() => { zoomOut.click() })
+    expect(view.readout.textContent).toBe('110%')
+
+    act(() => { view.stage.dispatchEvent(new KeyboardEvent('keydown', { key: '0', bubbles: true })) })
+    expect(view.readout.textContent).toBe('100%')
+    act(() => { view.stage.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true })) })
+    expect(view.zoom()).toBeCloseTo(1.2, 5)
+    act(() => { view.stage.dispatchEvent(new KeyboardEvent('keydown', { key: '-', bubbles: true })) })
+    expect(view.zoom()).toBeCloseTo(1, 5)
+    act(() => { reset.click() })
+    expect(view.offsets()).toEqual({ x: 0, y: 0 })
+    expect(view.transform()).toContain('scale(1)')
+    view.unmount()
+  })
+
+  it('renders the picture inside the stage, with the pane able to shrink', () => {
+    const view = mount()
+    expect(view.img.getAttribute('src')).toBe('/sidebar/file?path=x.png')
+    expect(view.img.getAttribute('alt')).toBe('x.png')
+    expect(view.img.draggable).toBe(false)
+    expect(view.img.parentElement).toBe(view.stage)
+    view.unmount()
+  })
+})


### PR DESCRIPTION
The image viewer was a static `<img>` in a scroll box: a picture larger than the pane could only be read by scrolling, and a small one could not be inspected at all.

It now starts at fit and scales up from there:

- **wheel** zooms around the cursor (a trackpad pinch arrives as a wheel event with `ctrlKey`, so it rides the same path);
- **pointer drag** pans, bounded by the fit box (`box × zoom` against `box`) so the picture can never be dragged free of its own edge;
- **double click** toggles fit ↔ 2×;
- a small **toolbar** carries the zoom readout with − / reset / +, and the pane's keyboard focus answers `+` / `-` / `0`.

The transform is written to the image node rather than through React state: a wheel gesture fires dozens of times a second and only the browser needs to hear about it, so the ref holds the truth and the component's state exists solely for the readout.

One intentional rendering change: the picture no longer overflows into a scrollbar — it is scaled to the pane, which is what makes a gesture-driven zoom meaningful.

### Tests

- `tests/image-view.spec.tsx` — jsdom: the pure zoom/pan maths plus the wheel, drag, double-click, button and keyboard paths.
- `tests/e2e/image-zoom.e2e.ts` — a real browser against the npm-packed plugin: opens a seeded PNG through the plugin's explorer, then drives the gestures and reads the **live transform matrix** back (the pan bound is asserted here, where `getBoundingClientRect` is real).

Both lanes green locally: `pnpm test:mount` 8/8 (the new spec plus the existing sweep), `pnpm test` 1325 passed with only the pre-existing environment failures (no node-pty / unset git identity in `smoke` / `pty-deps` / `agent-pty`).