### PR TITLE
fix(editor): 「添加到对话」浮层透字——底色改用不透明令牌

### DIFF
--- a/src/client/sidebar.module.css
+++ b/src/client/sidebar.module.css
@@ -1784,8 +1784,11 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 /* The floating "add to conversation" button anchored above a text
    selection in the preview/code viewers. Portalled to document.body and
    position:fixed, so the editor's overflow clips cannot crop it; flat
-   chrome like the rest of the sidebar (hairline border, layer-2 fill,
-   hover fill — no shadow). */
+   chrome like the rest of the sidebar (hairline border, no shadow).
+   Fills come from the menu/overlay pair, not the layer/hover pair: this
+   button floats over text with no panel behind it, while skins make the
+   layer tokens translucent (~0.45) and interactive-bg-hover a bare
+   0.06-0.08 tint, neither of which is readable over the text beneath. */
 .selectionPopup {
   position: fixed;
   z-index: 60;
@@ -1796,7 +1799,7 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
   padding: 0 10px;
   border: 1px solid var(--dsw-alias-border-l1);
   border-radius: 6px;
-  background: var(--dsw-alias-bg-layer-2);
+  background: var(--dsw-specific-menu);
   color: var(--dsw-alias-label-primary);
   font: var(--dsw-font-xxxs-strong-11);
   white-space: nowrap;
@@ -1804,7 +1807,7 @@ body[data-dsh-sidebar-dragging] .bottomPanel {
 }
 
 .selectionPopup:hover {
-  background: var(--dsw-alias-interactive-bg-hover);
+  background: var(--dsw-alias-interactive-bg-hover-solid);
 }
 
 .editorPdf {


### PR DESCRIPTION
Fixes #649

浮层底色取自 layer / hover 两个令牌，两者都不保证不透明：

- **静止**：`--dsw-alias-bg-layer-2` 在玻璃类皮肤下是 rgba 0.45 左右；浮层 `createPortal` 到 `document.body`，吃不到皮肤对 `[data-dsh-better-sidebar]` 锚点内的修正，底下的正文就透上来（默认主题下令牌是实色，所以只有装了皮肤的机器能看到）。
- **悬停**：`--dsw-alias-interactive-bg-hover` 本身就是 alpha 0.06–0.08 的叠加色，语义是"叠在已有不透明底之上"（宿主 Menu item 即此用法）。浮层没有容器底衬，悬停即近乎全透明——**这条与皮肤无关，默认主题一样触发**。

默认深色主题、未装任何皮肤实测：

| 状态 | 计算背景色 |
| --- | --- |
| 静止 | `rgb(44,44,46)` |
| 悬停 | `rgba(255,255,255,0.08)` |
| 移开 | `rgb(44,44,46)` |

修法：静止改用 `--dsw-specific-menu`（宿主菜单同款），悬停改用 `--dsw-alias-interactive-bg-hover-solid`。默认暗色下两者都是 `#353638`，与原 `#2c2c2e` 观感接近；玻璃皮肤下 `--dsw-specific-menu` 的覆盖值为 0.88–1.0。

验证：`tests/theme.spec.ts` 12 项通过；`pnpm test` 1340 通过（`fs-operations` 3 项因本机沙箱禁止创建符号链接失败，与本次改动无关）。
