### PR TITLE
fix(state): contain a throwing store listener instead of blanking the sidebar

### DIFF
--- a/docs/external-plugin-guide.md
+++ b/docs/external-plugin-guide.md
@@ -657,7 +657,10 @@ interface BetterSidebarService {
   /** 当前快照：激活 sessionId + 其状态（面板几何/打开的 tabs/展开集）+ prefs。
    *  session 未激活时 state/sessionId 为 undefined。 */
   getSnapshot(): SidebarSnapshot
-  /** 订阅快照变化（会话切换/状态变更/prefs 写入）；返回 disposer */
+  /** 订阅快照变化（会话切换/状态变更/prefs 写入）；返回 disposer。
+   *  listener 抛出的异常被逐个隔离并 `console.error`，既不中断其余监听器
+   *  （含 React 自己的渲染订阅），也不会把整条侧栏换成错误条——所以
+   *  listener 里读宿主 state 的字段仍请自己判空，别指望异常能当哨兵。 */
   subscribeState(listener: () => void): () => void
   /** 更新一个已打开 tab 的显示字段（title/path/meta）；tab 不存在时 no-op */
   updateTab(tabId: string, patch: { title?: string; path?: string; meta?: unknown }): void

--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -1235,8 +1235,31 @@ export class SidebarStore {
     this.persistTimers.set(sessionId, timer)
   }
 
+  /**
+   * Fan one store change out to every subscribed listener. A throwing
+   * listener is CONTAINED instead of aborting the loop.
+   *
+   * `service.subscribeState` hands this store's own `subscribe` to consumer
+   * plugins, and `notify()` runs inline in whatever call site mutated the
+   * store — `setSession` from the Sidebar's mount effect, `reduce` from a
+   * click handler. An exception escaping here therefore surfaces as a
+   * render/commit-phase error, and the shell's ROOT RenderBoundary swaps the
+   * ENTIRE sidebar for its error strip: one plugin misreading a field this
+   * store no longer carries (0.19.0 dropped the right column's `splits`
+   * tree) takes the panel down for every other plugin and for the user.
+   *
+   * Isolating per listener also keeps the remaining listeners running —
+   * React's own useSyncExternalStore callback shares this loop, so a crash
+   * in one subscriber no longer costs the healthy ones their re-render.
+   */
   private notify(): void {
-    for (const listener of [...this.listeners]) listener()
+    for (const listener of [...this.listeners]) {
+      try {
+        listener()
+      } catch (error) {
+        console.error('[dsh-better-sidebar] store listener error:', error)
+      }
+    }
   }
 }
 

--- a/tests/sidebar-crash.spec.tsx
+++ b/tests/sidebar-crash.spec.tsx
@@ -1,5 +1,6 @@
 /**
- * Sidebar crash tests — the two failure modes behind issue #31.
+ * Sidebar crash tests — the failure modes behind issue #31 plus the store's
+ * listener containment.
  *
  * 1. Layout-push leak: the layout-push effect writes
  *    `--dsh-sidebar-height` on document.documentElement (the right column
@@ -13,6 +14,14 @@
  *    take down the whole sidebar. The per-tab boundary shows a strip inside
  *    that tab's pane while the toggle cluster, the other tabs, and the panel
  *    itself stay alive; the retry button recovers a transient crash.
+ *
+ * 3. Store listener containment: `service.subscribeState` is the store's own
+ *    `subscribe`, so a consumer plugin's listener runs inside `notify()` —
+ *    which runs inline in the mutating call site (the Sidebar's own mount
+ *    effect calls `store.setSession`). A throw escaping that loop lands in
+ *    the React commit phase, where the shell's ROOT RenderBoundary (index.tsx)
+ *    swaps the WHOLE sidebar for its error strip. One listener must not be
+ *    able to do that to the rest of the panel.
  *
  * Rendered with the REAL Sidebar shell + real store/service against a minimal
  * fake context (createRoot + act(), the repo's jsdom pattern).
@@ -185,5 +194,32 @@ describe('tab crash containment', () => {
     act(() => { retry!.click() })
     expect(container.textContent).toContain('recovered')
     expect(container.textContent).not.toContain('transient')
+  })
+})
+
+describe('store listener containment', () => {
+  it('a throwing consumer listener cannot take the shell down', () => {
+    const { container, service, store } = mountSidebar()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // A consumer plugin subscribes through the service's PUBLIC state seam
+    // (subscribeState IS the store's subscribe) and throws while reading a
+    // field this store no longer carries — the 0.19.0 shape that dropped the
+    // right column's `splits` tree, i.e. a real third-party plugin's failure
+    // mode rather than a synthetic one.
+    const unsubscribe = service.subscribeState(() => {
+      throw new Error('third-party listener boom')
+    })
+    // The mutation drives notify() from inside act(); before the isolation
+    // this call threw straight out of the store into the commit phase.
+    expect(() => { act(() => { store.reduce(toggleBottomPanel) }) }).not.toThrow()
+    // The shell is intact (the collapse control is still mounted) and the
+    // mutation landed for everyone else.
+    expect(container.textContent).not.toContain('dsh-better-sidebar:')
+    expect(container.querySelector(`[aria-label="${t('collapseBottomPanel')}"]`)).not.toBeNull()
+    expect(store.getSnapshot().state!.bottomOpen).toBe(true)
+    // The crash is reported rather than swallowed silently.
+    expect(errorSpy).toHaveBeenCalled()
+    unsubscribe()
+    errorSpy.mockRestore()
   })
 })

--- a/tests/state.spec.ts
+++ b/tests/state.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   activateTab, allLeaves, BOTTOM_DEFAULT, BOTTOM_MIN, closeTab, CONVERSATION_MIN, createSidebarStore,
   insertLeafAt, makeDefaultState, moveTab, moveTabToEdge, openDiffTab,
@@ -889,5 +889,65 @@ describe('URL reset escape hatch (issue #369)', () => {
     store.setSession('s1')
     const leaf = store.getSnapshot().state!.bottomSplits as { tabs: { type: string }[] }
     expect(leaf.tabs.map(tab => tab.type)).toEqual([])
+  })
+})
+
+/**
+ * listener isolation. `service.subscribeState` is this store's own
+ * `subscribe`, so a consumer plugin's listener throws INSIDE notify() — and
+ * notify() runs inline in the mutating call site (setSession from the
+ * Sidebar's mount effect, reduce from a click handler). An escaping throw
+ * therefore lands in the React commit phase, where the shell's ROOT
+ * RenderBoundary swaps the whole sidebar for its error strip.
+ */
+describe('store listener isolation', () => {
+  // Same browser-global stubs as the blocks above: setSession → loadState
+  // reads window.location.search and localStorage.
+  beforeEach(() => {
+    const g = globalThis as Record<string, unknown>
+    g.window = { clearTimeout: () => {}, setTimeout: () => 0, innerWidth: 1024, innerHeight: 800, location: { search: '' } }
+    g.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} }
+  })
+  afterEach(() => {
+    const g = globalThis as Record<string, unknown>
+    delete g.window
+    delete g.localStorage
+  })
+
+  it('contains a throwing listener and still delivers the change to the rest', () => {
+    const store = createSidebarStore()
+    const delivered: string[] = []
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    store.subscribe(() => {
+      delivered.push('throwing')
+      throw new Error('third-party listener boom')
+    })
+    store.subscribe(() => { delivered.push('healthy') })
+    // The mutation must not throw out of the store, and the throwing
+    // listener must not rob the healthy ones of their notification (React's
+    // own useSyncExternalStore callback shares this loop in the real shell).
+    expect(() => store.setSession('s1')).not.toThrow()
+    expect(delivered).toEqual(['throwing', 'healthy'])
+    // The mutation itself still landed.
+    expect(store.getSnapshot().sessionId).toBe('s1')
+    expect(store.getSnapshot().state).toBeDefined()
+    // The crash is reported, not swallowed silently.
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('keeps notifying every listener on later mutations (the loop recovers)', () => {
+    const store = createSidebarStore()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let healthyCalls = 0
+    store.subscribe(() => { throw new Error('boom') })
+    store.subscribe(() => { healthyCalls += 1 })
+    store.setSession('s1')
+    const afterFirst = healthyCalls
+    // A later mutation notifies again: the throwing listener was neither
+    // dropped from the set nor left the loop half-iterated.
+    store.reduce(toggleBottomPanel)
+    expect(healthyCalls).toBe(afterFirst + 1)
+    errorSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## 问题

`service.subscribeState` 就是 store 自己的 `subscribe`（`src/client/service.ts`），所以消费插件的 listener 是在 `SidebarStore.notify()` 里执行的；而 `notify()` 又是**在触发变更的调用点内联跑**的——`Sidebar` 挂载 effect 里的 `store.setSession`、点击处理里的 `store.reduce`。

于是 listener 抛出的异常会穿进 React 的提交阶段，被 `index.tsx` 的**根级 RenderBoundary** 接住：整条侧栏被换成错误条。

真机复现（DSH Desktop + 本插件 0.19.0 + 一个消费插件）：该插件的 listener 还在遍历右侧栏的 `splits` 树，而这个字段 0.19.0 已经删掉（右列改由 DSH 原生 Sidebar 托管，store 里只剩 `bottomSplits`），于是一路读到 `undefined.kind`：

```
TypeError: Cannot read properties of undefined (reading 'kind')
    at leafNodes            (消费插件 client)
    at observationTabOpen   (消费插件 client)
    at evaluate             (消费插件 client)
    at SidebarStore.notify  (本插件)
    at SidebarStore.setSession
    at Sidebar (Sidebar.tsx 挂载 effect)
```

结果：**一个插件读错字段，所有插件和用户一起丢掉整条侧栏**，且停在错误条上直到手动刷新。插件的字段漂移当然该由插件自己修（已另案处理），但宿主的通知循环不该把一个第三方 listener 的异常放大成整面墙的白屏级故障。

## 改动

`SidebarStore.notify()` 逐监听器 `try/catch` + `console.error`：

```ts
private notify(): void {
  for (const listener of [...this.listeners]) {
    try {
      listener()
    } catch (error) {
      console.error('[dsh-better-sidebar] store listener error:', error)
    }
  }
}
```

异常仍然**可见**（照旧打日志），只是不再中断循环。React 自己的 `useSyncExternalStore` 回调就在同一个循环里，所以其余订阅者照常收到通知并重渲染——修好之前，一个 listener 崩了会连带让健康的订阅者收不到这次变更。

顺带同步了 `docs/external-plugin-guide.md` §7 的 `subscribeState` 说明：异常被逐个隔离，别把它当哨兵用——listener 里读宿主 state 的字段仍请自己判空（本次事故的插件正是漏了这一步）。

## 测试

三个用例，都先证实**在改动前会失败**：

- `tests/state.spec.ts`：抛异常的 listener 被兜住，且后续 listener 仍收到通知；后续每次变更继续正常广播（循环没有被留在半迭代状态）。
- `tests/sidebar-crash.spec.tsx`：用真 store + 真 service + 真的 `Sidebar` 挂载，经 **`service.subscribeState` 这个公开接缝**注册一个抛异常的 listener，断言变更不抛、面板仍在（收起控件还在）、变更本身落地。

撤掉 `src` 改动后重跑的证据：

```
 ❯ tests/state.spec.ts (53 tests | 2 failed)
     × contains a throwing listener and still delivers the change to the rest
     × keeps notifying every listener on later mutations (the loop recovers)
 ❯ tests/sidebar-crash.spec.tsx (5 tests | 1 failed)
     × a throwing consumer listener cannot take the shell down
AssertionError: expected [Function] to not throw an error but 'Error: third-party listener boom' was thrown
```

## 验证

- `pnpm exec vitest run tests/state.spec.ts tests/sidebar-crash.spec.tsx` → 58 passed
- `pnpm typecheck` → 通过
- `pnpm lint` → 通过
- 真机：打上同款改动后，往宿主 store 注册一个必定抛异常的监听器，页面刷新后侧栏完整渲染、无错误条（对照：改动前同一操作必然出现错误条）

## 兼容性

对行为正常的 listener 零影响（顺序、时机、快照语义都不变）；唯一的语义变化是「一个 listener 的异常不再阻止其余 listener 执行」，这正是本 PR 的目的。没有插件可以合法依赖「我的异常能中断别人的通知」。
