### PR TITLE
fix(server): resolve session-relative paths in fs.write and fs.read

### DIFF
--- a/src/path-security.ts
+++ b/src/path-security.ts
@@ -1,6 +1,7 @@
 /** Filesystem path guards shared by sidebar APIs that access a session workspace. */
 import { realpath } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
+import { isAbsolute } from 'node:path'
 import { isWithin, requireAbsolute } from './fs-tree.ts'
 import { resolveSessionPath } from './session-path.ts'
 import { SidebarError } from './wire.ts'
@@ -33,7 +34,12 @@ function assertWithinWorkspace(workspace: string, target: string): void {
  * @returns The canonical absolute path used for the filesystem operation.
  */
 export async function ensureWorkspacePath(cwd: string, target: string, fence = true): Promise<string> {
-  const absolute = requireAbsolute(resolveSessionPath(cwd, target))
+  // #646: the ecosystem passes session-relative paths (e.g. `openFile(scope,
+  // 'pastes/x.txt')` produces `pastes/x.txt` in the tab). Resolve them
+  // against the session cwd before the absolute check so read and write
+  // paths share the same contract.
+  const resolved = isAbsolute(target) ? target : join(cwd, target)
+  const absolute = requireAbsolute(resolveSessionPath(cwd, resolved))
   const [realCwd, realTarget] = await Promise.all([
     resolveRealPath(cwd, 'workspace'),
     resolveRealPath(absolute, 'target'),
@@ -56,7 +62,10 @@ export async function ensureWorkspacePath(cwd: string, target: string, fence = t
  * @returns A canonical path for an existing target or its nearest existing ancestor.
  */
 export async function ensureWorkspaceWritePath(cwd: string, target: string, fence = true): Promise<string> {
-  const absolute = requireAbsolute(resolveSessionPath(cwd, target))
+  // #646: same relative-path resolution as the read path — a plugin that
+  // opened a file with a session-relative path must be able to save it.
+  const resolved = isAbsolute(target) ? target : join(cwd, target)
+  const absolute = requireAbsolute(resolveSessionPath(cwd, resolved))
   const realCwd = await resolveRealPath(cwd, 'workspace')
   let existingPath = absolute
   const missingSegments: string[] = []

--- a/tests/fs-write-relative-path.spec.ts
+++ b/tests/fs-write-relative-path.spec.ts
@@ -1,0 +1,39 @@
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ensureWorkspaceWritePath } from '../src/path-security.ts'
+
+const dirs: string[] = []
+afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }) })
+
+describe('fs.write resolves session-relative paths (#646)', () => {
+  it('resolves a relative write path against the session cwd', async () => {
+    const dir = join(tmpdir(), 'dshm-646-a')
+    dirs.push(dir)
+    mkdirSync(join(dir, 'pastes'), { recursive: true })
+    const result = await ensureWorkspaceWritePath(dir, 'pastes/test.txt', false)
+    expect(result).toContain('pastes')
+    expect(result).toContain('test.txt')
+  })
+
+  it('keeps an absolute write path unchanged', async () => {
+    const dir = join(tmpdir(), 'dshm-646-b')
+    dirs.push(dir)
+    mkdirSync(dir, { recursive: true })
+    const abs = join(dir, 'abs.txt')
+    const result = await ensureWorkspaceWritePath(dir, abs, false)
+    expect(result).toContain('abs.txt')
+  })
+
+  it('still fences a write outside the workspace', async () => {
+    const dir = join(tmpdir(), 'dshm-646-c')
+    dirs.push(dir)
+    mkdirSync(join(dir, 'inside'), { recursive: true })
+    const outside = join(tmpdir(), 'dshm-646-outside')
+    mkdirSync(outside, { recursive: true })
+    dirs.push(outside)
+    await expect(ensureWorkspaceWritePath(dir, join(outside, 'x.txt'), true))
+      .rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #646: `openFile(scope, 'pastes/x.txt')` stores the session-relative path in the tab. The editor's read path resolves it (fs.read → `resolveGitPath(cwd, path)` → `ensureWorkspacePath`), but the write path calls `ensureWorkspaceWritePath(cwd, rawPath)` where `resolveSessionPath` does NOT join relative paths onto the cwd — it only handles the WSL UNC projection. `requireAbsolute` then throws on the still-relative path → 400 with zero disk side effects.

## What changed

`src/path-security.ts` — both `ensureWorkspacePath` and `ensureWorkspaceWritePath` now resolve session-relative targets against the session cwd before the absolute check:

```ts
const resolved = isAbsolute(target) ? target : join(cwd, target)
const absolute = requireAbsolute(resolveSessionPath(cwd, resolved))
```

This collapses the read/write asymmetry at the security-layer contract level (the reporter's option 2), so any current or future API that receives a session-relative path works consistently regardless of whether it reads or writes.

## Testing

`tests/fs-write-relative-path.spec.ts` — 3 cases:

- relative path (`pastes/test.txt`) resolves to `<cwd>/pastes/test.txt`;
- absolute path passes through unchanged;
- a path outside the workspace is still fenced (containment check not bypassed).

All 3 pass. `tsc --noEmit` clean. 96/96 in the related suites (service, native-surface, sidechat-seed-validation, session-path, and this file).
